### PR TITLE
Add ability to start FF without resolving the ladybug module version

### DIFF
--- a/core/src/main/resources/SpringEnvironmentContext.xml
+++ b/core/src/main/resources/SpringEnvironmentContext.xml
@@ -9,6 +9,8 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	>
 
+	<context:property-placeholder />
+
 	<context:component-scan base-package="nl.nn.adapterframework,nl.nn.ibistesttool.web">
 		<context:include-filter type="annotation" expression="nl.nn.adapterframework.lifecycle.IbisInitializer"/>
 

--- a/ladybug/src/main/resources/springIbisTestTool.xml
+++ b/ladybug/src/main/resources/springIbisTestTool.xml
@@ -5,16 +5,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans classpath:xml/xsd/spring-beans-3.2.xsd"
 	>
 
-	<bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
-		<property name="locations">
-			<list>
-				<value>classpath:META-INF/maven/org.ibissource/ibis-adapterframework-ladybug/pom.properties</value>
-				<!-- Other properties like ibistesttool.* are provided by IAF (AppConstants is added as PropertySources to the Spring configuration) -->
-			</list>
-		</property>
-		<property name="ignoreResourceNotFound" value="true" />
-	</bean>
-
 	<bean
 		name="lowerCasePropertySourcePostProcessor"
 		class="nl.nn.adapterframework.configuration.LowerCasePropertySourcePostProcessor"
@@ -22,14 +12,6 @@
 	/>
 
 	<bean class="nl.nn.ibistesttool.DeploymentSpecificsBeanPostProcessor"/>
-
-	<bean name="configName" class="java.lang.String">
-		<constructor-arg value="Ibis Test Tool"/>
-	</bean>
-
-	<bean name="configVersion" class="java.lang.String">
-		<constructor-arg value="${version:#{''}}"/>
-	</bean>
 
 	<bean name="maxCheckpoints" class="java.lang.Integer">
 		<constructor-arg value="${ibistesttool.maxCheckpoints}"/>
@@ -48,8 +30,6 @@
 	</bean>
 
 	<bean name="testTool" class="nl.nn.testtool.TestTool" autowire="byName">
-		<property name="configName"><ref bean="configName"/></property>
-		<property name="configVersion"><ref bean="configVersion"/></property>
 		<property name="maxCheckpoints"><ref bean="maxCheckpoints"/></property>
 		<property name="maxMemoryUsage"><ref bean="maxMemoryUsage"/></property>
 		<property name="maxMessageLength"><ref bean="maxMessageLength"/></property>


### PR DESCRIPTION
Removes the `configName` and `configVersion` attributes which are only used when running the testtool standalone or directly via `../../testtool`