### PR TITLE
Avoid log4j2 getSource() method call

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/logging/IbisMaskingLayout.java
+++ b/core/src/main/java/nl/nn/adapterframework/logging/IbisMaskingLayout.java
@@ -118,8 +118,8 @@ public abstract class IbisMaskingLayout extends AbstractStringLayout {
 
 	/**
 	 * When converting from a (Log4jLogEvent) to a mutable LogEvent ensure to not invoke any getters but assign the fields directly.
-	 * @see https://issues.apache.org/jira/browse/LOG4J2-1179
-	 * @see https://issues.apache.org/jira/browse/LOG4J2-1382
+	 * @see "https://issues.apache.org/jira/browse/LOG4J2-1179"
+	 * @see "https://issues.apache.org/jira/browse/LOG4J2-1382"
 	 * 
 	 * Directly calling RewriteAppender.append(LogEvent) can do 44 million ops/sec, but when calling rewriteLogger.debug(msg) to invoke
 	 * a logger that calls this appender, all of a sudden throughput drops to 37 thousand ops/sec. That's 1000x slower.


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LOG4J2-1382, https://issues.apache.org/jira/browse/LOG4J2-1179 and https://www.mail-archive.com/log4j-dev@logging.apache.org/msg35500.html

When converting to a MutableLogEvent it copies over all LogEvent properties by invoking the getters. When no message source is present this triggers the invocation of StackLocatorUtil#calcLocation(String), which creates a snapshot of the stack and walks it in order to find the callers location information.