### PR TITLE
Avoid log4j2 getSource() method call (7.6)

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/logging/IbisMaskingLayout.java
+++ b/core/src/main/java/nl/nn/adapterframework/logging/IbisMaskingLayout.java
@@ -135,8 +135,8 @@ public abstract class IbisMaskingLayout extends AbstractStringLayout {
 			return builder.build();
 		}
 
+		//NB: this might trigger a source location lookup.
 		MutableLogEvent mutable = new MutableLogEvent();
-		event.setIncludeLocation(false); //force source location lookup to false
 		mutable.initFrom(event);
 		mutable.setMessage(message);
 		return mutable;


### PR DESCRIPTION
See #2331 for more info.