### PR TITLE
Enable to align XML in Json2XmlValidator

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/align/DomTreeAligner.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/DomTreeAligner.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Nationale-Nederlanden, 2020-2022 WeAreFrank!
+   Copyright 2017 Nationale-Nederlanden, 2020-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -66,27 +66,18 @@ public class DomTreeAligner extends Tree2Xml<Document,Node> {
 	}
 
 	@Override
-	public boolean hasChild(XSElementDeclaration elementDeclaration, Node node, String childName) throws SAXException {
-		// TODO this does not take overrideValues and defaultValues into account...
-		if (log.isTraceEnabled()) log.trace("hasChild() node ["+node+"] childName ["+childName+"]");
-		for (Node cur=node.getFirstChild();cur!=null;cur=cur.getNextSibling()) {
-			if (cur.getNodeType()==Node.ELEMENT_NODE && childName.equals(getNodeName(cur))) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	@Override
 	public Set<String> getAllNodeChildNames(XSElementDeclaration elementDeclaration, Node node) throws SAXException {
-		if (log.isTraceEnabled()) log.trace("getAllChildNames() node ["+node+"]");
+		if (log.isTraceEnabled()) log.trace("getAllNodeChildNames() node ["+node+"]");
 		Set<String> children = new HashSet<String>();
 		for (Node cur=node.getFirstChild();cur!=null;cur=cur.getNextSibling()) {
 			//if (log.isTraceEnabled()) log.trace("getAllChildNames() found node ["+getNodeName(cur)+"] type ["+cur.getNodeType()+"] ["+ToStringBuilder.reflectionToString(cur)+"]");
 			if (cur.getNodeType()==Node.ELEMENT_NODE) {
-				if (log.isTraceEnabled()) log.trace("getAllChildNames() node ["+node+"] added node ["+getNodeName(cur)+"] type ["+cur.getNodeType()+"]");
+				if (log.isTraceEnabled()) log.trace("getAllNodeChildNames() node ["+node+"] added node ["+getNodeName(cur)+"] type ["+cur.getNodeType()+"]");
 				children.add(getNodeName(cur));
 			}
+		}
+		if (children.isEmpty()) {
+			return null;
 		}
 		return children;
 	}
@@ -94,13 +85,16 @@ public class DomTreeAligner extends Tree2Xml<Document,Node> {
 	@Override
 	public Iterable<Node> getNodeChildrenByName(Node node, XSElementDeclaration childElementDeclaration) throws SAXException {
 		String name=childElementDeclaration.getName();
-		if (log.isTraceEnabled()) log.trace("getChildrenByName() node ["+node+"] name ["+name+"]");
+		if (log.isTraceEnabled()) log.trace("getNodeChildrenByName() node ["+node+"] name ["+name+"]");
 		List<Node> children = new LinkedList<Node>();
 		for (Node cur=node.getFirstChild();cur!=null;cur=cur.getNextSibling()) {
 			if (cur.getNodeType()==Node.ELEMENT_NODE && name.equals(getNodeName(cur))) {
-				if (log.isTraceEnabled()) log.trace("getChildrenByName() node ["+node+"] added node ["+getNodeName(cur)+"]");
+				if (log.isTraceEnabled()) log.trace("getNodeChildrenByName() node ["+node+"] added node ["+getNodeName(cur)+"]");
 				children.add(cur);
 			}
+		}
+		if (children.isEmpty()) {
+			return null;
 		}
 		return children;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/align/DomTreeAligner.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/DomTreeAligner.java
@@ -16,9 +16,9 @@
 package nl.nn.adapterframework.align;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +86,7 @@ public class DomTreeAligner extends Tree2Xml<Document,Node> {
 	public Iterable<Node> getNodeChildrenByName(Node node, XSElementDeclaration childElementDeclaration) throws SAXException {
 		String name=childElementDeclaration.getName();
 		if (log.isTraceEnabled()) log.trace("getNodeChildrenByName() node ["+node+"] name ["+name+"]");
-		List<Node> children = new LinkedList<Node>();
+		List<Node> children = new ArrayList<Node>();
 		for (Node cur=node.getFirstChild();cur!=null;cur=cur.getNextSibling()) {
 			if (cur.getNodeType()==Node.ELEMENT_NODE && name.equals(getNodeName(cur))) {
 				if (log.isTraceEnabled()) log.trace("getNodeChildrenByName() node ["+node+"] added node ["+getNodeName(cur)+"]");

--- a/core/src/main/java/nl/nn/adapterframework/pipes/Json2XmlValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/Json2XmlValidator.java
@@ -174,7 +174,7 @@ public class Json2XmlValidator extends XmlValidator implements HasPhysicalDestin
 
 				// Align XML if required
 				storeInputFormat(DocumentFormat.XML, input, session, responseMode);
-				if (isAlignXml() || getParameterList()!=null && !getParameterList().isEmpty()) {
+				if (isAlignXml() || (getParameterList()!=null && !getParameterList().isEmpty())) {
 					try {
 						return align(DocumentFormat.XML, messageToValidate, session, responseMode);
 					} catch (Exception e) {

--- a/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
+++ b/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
@@ -83,7 +83,7 @@ public class TestAlignXml {
 		String inputFile = "Abc/abc-x";
 		String expectedFailureReason = "Cannot find the declaration of element [x]";
 		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
-		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
+		String xmlString = TestFileUtils.getTestFile(BASEDIR + inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "extra elements not allowed", false, false);
 	}
 
@@ -94,7 +94,7 @@ public class TestAlignXml {
 		String inputFile = "Abc/abc-x";
 		String expectedFailureReason = null;
 		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
-		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
+		String xmlString = TestFileUtils.getTestFile(BASEDIR + inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "extra elements not allowed", false, true);
 	}
 
@@ -104,7 +104,7 @@ public class TestAlignXml {
 		String inputFile = "Abc/abc-wrongorder";
 		String expectedFailureReason = null;
 		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
-		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
+		String xmlString = TestFileUtils.getTestFile(BASEDIR + inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "root elements in wrong order", false, false);
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
+++ b/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
@@ -3,14 +3,12 @@ package nl.nn.adapterframework.align;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
+import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.util.XmlUtils;
 
 public class TestAlignXml {
@@ -62,31 +60,13 @@ public class TestAlignXml {
 		testXml(xmlIn, schemaUrl, expectedFailureReason, "");
 	}
 
-	protected String getTestFile(String file) throws IOException {
-		URL url = AlignTestBase.class.getResource(BASEDIR + file);
-		if (url == null) {
-			return null;
-		}
-		BufferedReader buf = new BufferedReader(new InputStreamReader(url.openStream()));
-		StringBuilder string = new StringBuilder();
-		String line = buf.readLine();
-		while (line != null) {
-			string.append(line);
-			line = buf.readLine();
-			if (line != null) {
-				string.append("\n");
-			}
-		}
-		return string.toString();
-	}
-
 	public void testFiles(String schemaFile, String namespace, String rootElement, String inputFile) throws Exception {
 		testFiles(schemaFile, namespace, rootElement, inputFile, null);
 	}
 
 	public void testFiles(String schemaFile, String namespace, String rootElement, String file, String expectedFailureReason) throws Exception {
-		URL schemaUrl = Utils.class.getResource(BASEDIR + schemaFile);
-		String xmlString = getTestFile(file + ".xml");
+		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
+		String xmlString = TestFileUtils.getTestFile(file + ".xml");
 		testStrings(xmlString, schemaUrl, namespace, rootElement, expectedFailureReason);
 	}
 
@@ -102,8 +82,8 @@ public class TestAlignXml {
 		String schemaFile = "Abc/abc.xsd";
 		String inputFile = "Abc/abc-x";
 		String expectedFailureReason = "Cannot find the declaration of element [x]";
-		URL schemaUrl = Utils.class.getResource(BASEDIR + schemaFile);
-		String xmlString = getTestFile(inputFile + ".xml");
+		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
+		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "extra elements not allowed", false, false);
 	}
 
@@ -113,8 +93,8 @@ public class TestAlignXml {
 		String schemaFile = "Abc/abc.xsd";
 		String inputFile = "Abc/abc-x";
 		String expectedFailureReason = null;
-		URL schemaUrl = Utils.class.getResource(BASEDIR + schemaFile);
-		String xmlString = getTestFile(inputFile + ".xml");
+		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
+		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "extra elements not allowed", false, true);
 	}
 
@@ -123,8 +103,8 @@ public class TestAlignXml {
 		String schemaFile = "Abc/abc.xsd";
 		String inputFile = "Abc/abc-wrongorder";
 		String expectedFailureReason = null;
-		URL schemaUrl = Utils.class.getResource(BASEDIR + schemaFile);
-		String xmlString = getTestFile(inputFile + ".xml");
+		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
+		String xmlString = TestFileUtils.getTestFile(inputFile + ".xml");
 		testXml(xmlString, schemaUrl, expectedFailureReason, "root elements in wrong order", false, false);
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
+++ b/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
@@ -66,7 +66,7 @@ public class TestAlignXml {
 
 	public void testFiles(String schemaFile, String namespace, String rootElement, String file, String expectedFailureReason) throws Exception {
 		URL schemaUrl = TestFileUtils.getTestFileURL(BASEDIR + schemaFile);
-		String xmlString = TestFileUtils.getTestFile(file + ".xml");
+		String xmlString = TestFileUtils.getTestFile(BASEDIR + file + ".xml");
 		testStrings(xmlString, schemaUrl, namespace, rootElement, expectedFailureReason);
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
+++ b/core/src/test/java/nl/nn/adapterframework/align/TestAlignXml.java
@@ -119,6 +119,16 @@ public class TestAlignXml {
 	}
 
 	@Test
+	public void testAbcWrongOrder() throws Exception {
+		String schemaFile = "Abc/abc.xsd";
+		String inputFile = "Abc/abc-wrongorder";
+		String expectedFailureReason = null;
+		URL schemaUrl = Utils.class.getResource(BASEDIR + schemaFile);
+		String xmlString = getTestFile(inputFile + ".xml");
+		testXml(xmlString, schemaUrl, expectedFailureReason, "root elements in wrong order", false, false);
+	}
+
+	@Test
 	public void testOK_hcda() throws Exception {
 		testFiles("HCDA/HandleCollectionDisbursementAccount3_v3.0.xsd", "", "HandleCollectionDisbursementAccount", "HCDA/HandleCollectionDisbursementAccount");
 	}

--- a/core/src/test/java/nl/nn/adapterframework/pipes/Json2XmlValidatorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/Json2XmlValidatorTest.java
@@ -253,8 +253,7 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 	}
 
 
-	@Test
-	public void testWithParameters() throws Exception {
+	public void testWithParameters(String input) throws Exception {
 		pipe.setName("RestGet");
 		pipe.setRoot("Root");
 		pipe.setOutputFormat(DocumentFormat.XML);
@@ -268,7 +267,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.configure();
 		pipe.start();
 
-		String input="";
 		String expected = TestFileUtils.getTestFile("/Validation/Parameters/out.xml");
 
 		session.put("b_key","b_value");
@@ -281,7 +279,17 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 	}
 
 	@Test
-	public void testWithParametersNestedElement() throws Exception {
+	public void testWithParamtersJson() throws Exception {
+		testWithParameters("");
+	}
+
+
+	@Test
+	public void testWithParamtersXml() throws Exception {
+		testWithParameters("<Root/>");
+	}
+
+	public void testWithParametersNestedElement(String input) throws Exception {
 		pipe.setName("Find with Nested Element");
 		pipe.setSchema("/Align/NestedValue/nestedValue.xsd");
 		pipe.setRoot("NestedValue");
@@ -294,7 +302,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.configure();
 		pipe.start();
 
-		String input="";
 		String expected = TestFileUtils.getTestFile("/Align/NestedValue/nestedValue.xml");
 
 		PipeRunResult prr = doPipe(pipe, input,session);
@@ -302,6 +309,16 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		String actualXml = Message.asString(prr.getResult());
 
 		assertXmlEquals("converted XML does not match", expected, actualXml, true);
+	}
+
+	@Test
+	public void testWithParametersNestedElementJson() throws Exception {
+		testWithParametersNestedElement("");
+	}
+
+	@Test
+	public void testWithParametersNestedElementXml() throws Exception {
+		testWithParametersNestedElement("<NestedValue/>");
 	}
 
 	@Test
@@ -351,8 +368,7 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 	}
 
 
-	@Test
-	public void testMultivaluedParameters() throws Exception {
+	public void testMultivaluedParameters(String input) throws Exception {
 		pipe.setName("testMultivaluedParameters");
 		pipe.setSchema("/Align/Options/options.xsd");
 		pipe.setRoot("Options");
@@ -377,7 +393,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.configure();
 		pipe.start();
 
-		String input    = "{ \"stringArray\" : [ \"xx\", \"yy\" ] }";
 		String expected = TestFileUtils.getTestFile("/Align/Options/allOptions.xml");
 
 		PipeRunResult prr = doPipe(pipe, input,session);
@@ -388,7 +403,17 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 	}
 
 	@Test
-	public void testMultivaluedParametersFindDocuments() throws Exception {
+	public void testMultivaluedParametersJson() throws Exception {
+		testMultivaluedParameters("{ \"stringArray\" : [ \"xx\", \"yy\" ] }");
+	}
+
+	@Test
+	@Ignore("Multivalued substitution parameters not yet working for XML alignment")
+	public void testMultivaluedParametersXml() throws Exception {
+		testMultivaluedParameters("<Options><stringArray><stringElem>xx</stringElem><stringElem>yy</stringElem></stringArray></Options>");
+	}
+
+	public void testMultivaluedParametersFindDocuments(String input) throws Exception {
 		pipe.setName("testMultivaluedParameters");
 		pipe.setSchema("/Align/FindDocuments/findDocuments.xsd");
 		pipe.setRoot("FindDocuments_Request");
@@ -407,7 +432,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 
 		session.put("agreementNumbers", agreementNumbers);
 
-		String input    = "{}";
 		String expected = TestFileUtils.getTestFile("/Align/FindDocuments/FindDocumentsRequest.xml");
 
 
@@ -416,6 +440,17 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		String actualXml = Message.asString(prr.getResult());
 
 		assertXmlEquals("converted XML does not match", expected, actualXml, true);
+	}
+
+	@Test
+	public void testMultivaluedParametersFindDocumentsJson() throws Exception {
+		testMultivaluedParametersFindDocuments("{}");
+	}
+
+	@Test
+	@Ignore("Multivalued substitution parameters not yet working for XML alignment")
+	public void testMultivaluedParametersFindDocumentsXml() throws Exception {
+		testMultivaluedParametersFindDocuments("<FindDocuments_Request/>");
 	}
 
 	@Test
@@ -450,8 +485,7 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		assertXmlEquals("converted XML does not match", expected, actualXml, true);
 	}
 
-	@Test
-	public void testSingleValueInArrayListParam() throws Exception {
+	public void testSingleValueInArrayListParam(String input) throws Exception {
 		pipe.setName("testMultivaluedParameters");
 		pipe.setSchema("/Align/Options/options.xsd");
 		pipe.setRoot("Options");
@@ -464,7 +498,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.configure();
 		pipe.start();
 
-		String input    = "{  }";
 		String expected = TestFileUtils.getTestFile("/Align/Options/singleValueInArray.xml");
 
 		PipeRunResult prr = doPipe(pipe, input,session);
@@ -475,7 +508,16 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 	}
 
 	@Test
-	public void testSingleValueInArrayStringParam() throws Exception {
+	public void testSingleValueInArrayListParamJson() throws Exception {
+		testSingleValueInArrayListParam("{}");
+	}
+	@Test
+	@Ignore("Multivalued substitution parameters not yet working for XML alignment")
+	public void testSingleValueInArrayListParamXml() throws Exception {
+		testSingleValueInArrayListParam("<Options/>");
+	}
+
+	public void testSingleValueInArrayStringParam(String input) throws Exception {
 		pipe.setName("testMultivaluedParameters");
 		pipe.setSchema("/Align/Options/options.xsd");
 		pipe.setRoot("Options");
@@ -486,7 +528,6 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.configure();
 		pipe.start();
 
-		String input    = "{  }";
 		String expected = TestFileUtils.getTestFile("/Align/Options/singleValueInArray.xml");
 
 
@@ -495,6 +536,16 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		String actualXml = Message.asString(prr.getResult());
 
 		assertXmlEquals("converted XML does not match", expected, actualXml, true);
+	}
+
+	@Test
+	public void testSingleValueInArrayStringParamJson() throws Exception {
+		testSingleValueInArrayStringParam("{}");
+	}
+	@Test
+	@Ignore("Multivalued substitution parameters not yet working for XML alignment")
+	public void testSingleValueInArrayStringParamXml() throws Exception {
+		testSingleValueInArrayStringParam("<Options/>");
 	}
 
 	public void testStoreRootElement(DocumentFormat outputFormat, String inputFile, boolean setRootElement) throws Exception {

--- a/core/src/test/resources/Align/Abc/abc-wrongorder.xml
+++ b/core/src/test/resources/Align/Abc/abc-wrongorder.xml
@@ -1,0 +1,1 @@
+<a xmlns="urn:test"><c/><b/></a>


### PR DESCRIPTION
This PR allows XML to be aligned (elements put to the correct order, according to the XSD) rather than only validated. It also allows values to be substituted from parameters, like for JSON input