### PR TITLE
Show error while parallel attribute is true in ForEachChildElementPipe

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
@@ -417,7 +417,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 					List<Throwable> exceptions = new ArrayList<>();
 					for (ParallelSenderExecutor pse : executorList) {
 						count++;
-						String itemResult="";
+						String itemResult;
 						if (pse.getThrowable() == null) {
 							SenderResult senderResult = pse.getReply();
 							if (senderResult.isSuccess()) {

--- a/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
@@ -422,10 +422,10 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 							if (senderResult.isSuccess()) {
 								itemResult = senderResult.getResult().asString();
 							} else {
-								itemResult = "<exception>"+ XmlEncodingUtils.encodeChars(senderResult.getResult().asString())+"</exception>";
+								throw new SenderException("Something went wrong during parallel execution of iterating pipe: " + senderResult.getResult().asString());
 							}
 						} else {
-							itemResult = "<exception>"+ XmlEncodingUtils.encodeChars(pse.getThrowable().getMessage())+"</exception>";
+							throw new SenderException("Something went wrong during parallel execution of iterating pipe: " + pse.getThrowable().getMessage());
 						}
 						addResult(count, pse.getRequest(), itemResult);
 					}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
@@ -438,7 +438,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 							}
 						}
 						if(!exceptions.isEmpty()){
-							SenderException se = new SenderException("Something went wrong in one of the parallel running pipes: ");
+							SenderException se = new SenderException("An error occurred during parallel execution");
 							exceptions.stream().forEach(se::addSuppressed);
 							throw se;
 						}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
@@ -427,8 +427,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 								if(isIgnoreExceptions()){
 									itemResult = "<exception>"+ XmlEncodingUtils.encodeChars(senderResult.getResult().asString())+"</exception>";
 								} else {
-									SenderException se = new SenderException(senderResult.getResult().asString());
-									exceptions.add(se);
+									exceptions.add(new SenderException(senderResult.getResult().asString()));
 								}
 							}
 						} else {


### PR DESCRIPTION
- We were reported that error message is not reported even though there is an error in one of the threads that are created thanks to the " parallel = 'true' " attribute in ForEachChildElementPipe.
- In this PR, we throw an exception in case an error occurs during parallel execution in order to be able to report it back.
- This is the issue reported in zaakbrug repo: https://github.com/wearefrank/zaakbrug/issues/144