### PR TITLE
Change referances from ibissource/iaf to frankframework/frankframework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       - dependency-name: "com.aspose:*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # The following versions are not available for JDK 8, see https://github.com/ibissource/iaf/issues/3503
+      # The following versions are not available for JDK 8, see https://github.com/frankframework/frankframework/issues/3503
       - dependency-name: "org.apache.activemq:activemq-*"
         versions: ["[5.17.0,)"]
       - dependency-name: "org.apache.activemq:artemis-*"
@@ -50,7 +50,7 @@ updates:
       - dependency-name: "com.aspose:*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # The following versions are not available for JDK 8, see https://github.com/ibissource/iaf/issues/3503
+      # The following versions are not available for JDK 8, see https://github.com/frankframework/frankframework/issues/3503
       - dependency-name: "org.apache.activemq:activemq-*"
         versions: ["[5.17.0,)"]
       - dependency-name: "org.apache.activemq:artemis-*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 # How to contribute
 
 Thanks for reading this we're glad you're taking an interest in contributing to our framework.
-We want you working on things you're excited about, there are however plenty of [issues](https://github.com/ibissource/iaf/issues) that can be picked up.
+We want you working on things you're excited about, there are however plenty of [issues](https://github.com/frankframework/frankframework/issues) that can be picked up.
 
 ## Running the Frank!Framework
 
@@ -11,7 +11,7 @@ If you want to experiment with the Frank!Framework, you can use the [Frank!Runne
 
 Initial:
 
-- git clone https://github.com/ibissource/iaf
+- git clone https://github.com/frankframework/frankframework
 - cd iaf
 - mvn
 - cd example
@@ -28,7 +28,7 @@ The jetty-maven-plugin requires Maven 3 and Java 1.8. We tested these instructio
 
 ## Submitting changes
 
-Please send a [GitHub Pull Request](https://github.com/ibissource/iaf/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)). When you send a pull request, make sure all of your commits are atomic (one feature per commit) and that the title is clear, obvious and informative!
+Please send a [GitHub Pull Request](https://github.com/frankframework/frankframework/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://help.github.com/articles/about-pull-requests/)). When you send a pull request, make sure all of your commits are atomic (one feature per commit) and that the title is clear, obvious and informative!
 
 Always write a clear log message for your commits. Add the current year, the name of the copyright owner and the copyright notice (when not already present) to adjusted and new files. See:
 
@@ -161,7 +161,7 @@ You can download Eclipse and load the Frank!Framework sources into it using the 
 ### Import the source code
 
 - Make sure Maven is able to access the internet. E.g. when behind a proxy: Window, Preferences, Maven, User Settings, settings.xml should exist and contain proxy configuration.
-- Window, Open Perspective, Other..., Git, OK, Clone a Git repository, URI: https://github.com/ibissource/iaf.git, Next, Next, Finish.
+- Window, Open Perspective, Other..., Git, OK, Clone a Git repository, URI: https://github.com/frankframework/frankframework.git, Next, Next, Finish.
 - Optionally (when you have access to the proprietary jars some modules depend on) add your Nexus credentials and enable the proprietary profile in your maven settings.xml
 - In the Git Perspective, right click the IAF Repository and click 'Import Projects...'
 - The Import wizard appears which allows you to import many different kinds of projects.
@@ -230,7 +230,7 @@ Please ensure that your Javadoc comments are correct. Eclipse can check this for
 
 ## Developing with IntelliJ
 
-- Clone the source any way you like. E.g. "New | Project from Version Control", or at the commandline: `git clone git@github.com:ibissource/iaf.git`
+- Clone the source any way you like. E.g. "New | Project from Version Control", or at the commandline: `git clone git@github.com:frankframework/frankframework.git`
 - If you cloned from the command line, then: From File -> Open... Select iaf folder and import it as a Maven project.
 - When asked to open the Eclipse project or the Maven project, choose opening the Maven project.
 - Make sure to select Java 11 as a default JDK.

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -51,7 +51,7 @@ More info about using and creating containers can be found in [Docker.md](Docker
 All production-ready containers will be pushed to our [Nexus Repository Manager](https://nexus.frankframework.org/) `frankframework-docker` repository. Helm charts are available [in the charts repository](https://github.com/ibissource/charts).
 
 ## Frank!Manual
-In need of help? Our manual can be found at <http://frank-manual.readthedocs.io>. If you cannot find an answer to your question feel free to [submit a question in discussions](https://github.com/ibissource/iaf/discussions).
+In need of help? Our manual can be found at <http://frank-manual.readthedocs.io>. If you cannot find an answer to your question feel free to [submit a question in discussions](https://github.com/frankframework/frankframework/discussions).
 
 ## Contributing
 Eager to help us expand or enhance our framework?

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,7 @@ Release on Windows 7 behind a proxy
     - git config --global https.proxy http://[proxy-username]:[proxy-password]@[proxy-host]:[proxy-port]
     - git config --global core.autocrlf true
 - cd D:\Temp (or any other folder)
-- git clone https://github.com/ibissource/iaf.git
+- git clone https://github.com/frankframework/frankframework.git
 - git clone https://github.com/ibissource/mvn-repo.git
 - git clone https://[user]@bitbucket.org/ibissource/mvn-repo-proprietary.git
 - cd iaf

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -249,7 +249,6 @@ Performance enhancements
 7.6-RC2
 --------
 [Commits](https://github.com/frankframework/frankframework/compare/v7.6-RC1...v7.6-RC2)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?tag=v7.6-RC2)](https://travis-ci.org/frankframework/frankframework)
 
 - Reduce debug logging and fix JBoss project names (#1592)
 - Fix 'Move to InProcess' in transaction (#1603)
@@ -279,7 +278,6 @@ Performance enhancements
 7.6-RC1
 --------
 [Commits](https://github.com/frankframework/frankframework/compare/v7.5...v7.6-RC1)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?tag=v7.6-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Debug streaming messages
 - Add TextSplitterPipe
@@ -331,7 +329,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC4...v7.5)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5)](https://travis-ci.org/frankframework/frankframework)
 
 - Sync testtool enable/disable buttons (#1036)
 - Fix #1029 handling absolute paths in LocalFileSystem (#1046)
@@ -351,7 +348,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC3...v7.5-RC4)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC4)](https://travis-ci.org/frankframework/frankframework)
 
 - Set receiver color to red when in error (#761)
 - Set property to disable SecurityManager (#746)
@@ -390,7 +386,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC2...v7.5-RC3)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC3)](https://travis-ci.org/frankframework/frankframework)
 
 - Fix GUI 3.0 global console warnings #505
 - Fix configurations being reloaded due to not having a (valid) version #506
@@ -416,7 +411,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC1...v7.5-RC2)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC2)](https://travis-ci.org/frankframework/frankframework)
 
 - Nested stacktrace ends at ForEachChildElementPipe #425
 - Empty JDBC result throws NullPointerException #426
@@ -445,7 +439,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.4...v7.5-RC1)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Make attribute firstPipe in PipeLine optional. When empty, the first Pipe in the Pipeline configuration
   is considedred to be the first. Similarly the success forward defaults to the next Pipe in the PipeLine.
@@ -516,7 +509,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.3...v7.4)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.4)](https://travis-ci.org/frankframework/frankframework)
 
 - Improve validation config warnings
 - ShowConfigurationStatus - improve error view
@@ -537,7 +529,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.2...v7.3)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.3)](https://travis-ci.org/frankframework/frankframework)
 
 - Refactor CmisListener to an event based listener, you can now have multiple listeners listening to different events
 - The cmis bridge functionality on the sender has been removed. In order to use the bridge you need to configure properties in the WAR/EAR file. See CmisSessionBuilder for more information about the properties that can be set
@@ -549,7 +540,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.2...v7.3-RC1)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.3-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Generate IbisDoc and XSD and support beautiful configuration xml. The XSD can be used for code completion of beautiful Ibis configurations in Eclipse
 - Use XSLT 2.0 instead of 1.0 for configuration tweaks (e.g. stub4testtool.xsl)
@@ -593,7 +583,6 @@ Performance enhancements
 --------
 
 [Commits](https://github.com/frankframework/frankframework/compare/v7.1...v7.2)
-[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.2)](https://travis-ci.org/ibissource/iaf)
 
 - Fix NPE in BatchFileTransformerPipe when using an IbisLocalSender
 - Various bugfixes en performance improvements in SOAPProviders (WebServiceListener)
@@ -616,8 +605,7 @@ Performance enhancements
 7.1
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.1-B4...v7.1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.1-B4...v7.1)
 
 - Fix NPE in HttpSender when no charset is supplied in multipart response
 - Modify GetFromSession to get key from input as well as sessionKey
@@ -642,8 +630,7 @@ Performance enhancements
 7.1-B4
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.1-B3...v7.1-B4)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.1-B4)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.1-B3...v7.1-B4)
 
 
 - Prevent poll guard to stop and start listener when recovering
@@ -661,8 +648,7 @@ Performance enhancements
 7.1-B3
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.1-B2...v7.1-B3)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.1-B3)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.1-B2...v7.1-B3)
 
 - Many IAF GUI 3.0 improvements
 - Fix Ladybug
@@ -681,8 +667,7 @@ Performance enhancements
 7.1-B2
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.1-B1...v7.1-B2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.1-B2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.1-B1...v7.1-B2)
 
 - Add updateEtag sessionKey to the ApiListener so it can be changed at runtime
 - Modify HttpSender logging to only give warnings for 4xx (client errors) and 5xx (server errors)
@@ -711,8 +696,7 @@ Performance enhancements
 7.1-B1
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-RC3...v7.1-B1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.1-B1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-RC3...v7.1-B1)
 
 - Move 'Dynamic parameters' from showConfiguration to showEnvironmentVariables
 - Show provided JmsDestinations with usage in showSecurityItems
@@ -798,8 +782,7 @@ Performance enhancements
 7.0-RC3
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-RC2...v7.0-RC3)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-RC3)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-RC2...v7.0-RC3)
 
 - Refactor ReplacerPipe replaceNonXmlChar and fix javadoc
 - Support Unicode supplementary characters (like a smiley) in replace/stripNonValidXmlCharacters (which is used in ReplacerPipe). In the old code a Unicode supplementary character like a smiley was seen as two characters which would both be replaced/stripped. To be backwards compatible the Unicode supplementary characters are still replaced/stripped (by one character instead of two) but can be allowed using allowUnicodeSupplementaryCharacters
@@ -816,8 +799,7 @@ Performance enhancements
 7.0-RC2
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-RC1...v7.0-RC2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-RC2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-RC1...v7.0-RC2)
 
 - Ignore import with namespace but without schemaLocation (fix on previous commit 'Support schema attribute with config in database and refactor ClassUtils.getResourceURL()')
 - Rewrite dependencies on removed URL fallback in ClassUtils.getResourceURL()
@@ -835,8 +817,7 @@ Performance enhancements
 7.0-RC1
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-B3...v7.0-RC1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-RC1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-B3...v7.0-RC1)
 
 - Add support for integer and boolean parameters when using QuerySenders
 - Fix broken "Show configuration warnings only at relevant configuration"
@@ -889,8 +870,7 @@ Performance enhancements
 7.0-B3
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-B2...v7.0-B3)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-B3)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-B2...v7.0-B3)
 
 - Add json to xml and xml to json conversion as well as json validation to xmlvalidators
 - Prevent XML Entity Expansion (XEE) injection
@@ -921,8 +901,7 @@ Performance enhancements
 7.0-B2
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.0-B1...v7.0-B2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-B2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.0-B1...v7.0-B2)
 
 - Fix IFSA no longer gives a warning when the managed connection factory can't be found
 - Add consumes and produces option to rest endpoints to set mediatypes, this also transforms the data from and to JSON/XML when set
@@ -1001,8 +980,7 @@ Performance enhancements
 7.0-B1
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v6.1...v7.0-B1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.0-B1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v6.1...v7.0-B1)
 
 - Replace Apache Commons Collections library v3.2 by v3.2.2
 - Don't temporarily move already temporarily moved messages
@@ -1165,8 +1143,7 @@ Performance enhancements
 6.1
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v6.0...v6.1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v6.1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v6.0...v6.1)
 
 - Equalize/refactor file name determination for FilePipe/Sender (for action "read" also consider attribute fileName and for action "info" also consider attributes fileName and classpath)
 - Add CrlPipe
@@ -1237,8 +1214,7 @@ Performance enhancements
 6.0
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5.6.1...v6.0)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v6.0)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v5.6.1...v6.0)
 
 - Add support for jetty-maven-plugin
 - Add note "Theme Bootstrap is part of a beta version" in main page of IBIS console for theme "bootstrap"
@@ -1427,8 +1403,7 @@ Performance enhancements
 5.6.1
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5.6...v5.6.1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v5.6.1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v5.6...v5.6.1)
 
 - Fixed bug in EsbSoapWrapper where Result element was inserted instead of Status element 
 
@@ -1437,8 +1412,7 @@ Performance enhancements
 5.6
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5.5...v5.6)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v5.6)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v5.5...v5.6)
 
 - Move missing errorStorage warning from MessageKeeper (at adapter level) and logfile to ConfigurationWarnings (top of console main page).
 - Replace (broken) enforceMQCompliancy on JmsSender with MQSender.
@@ -1465,8 +1439,7 @@ Performance enhancements
 5.5
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5.4...v5.5)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v5.5)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v5.4...v5.5)
 
 - Also when not transacted don't retrow exception caught in JMS listener (caused connection to be closed and caused possible other threads on the same listener to experience "javax.jms.IllegalStateException: Consumer closed").
 - Tweaked error logging and configuration warnings about transactional processing.
@@ -1497,8 +1470,7 @@ Performance enhancements
 5.4
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5_3...v5_4)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v5.4)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v5_3...v5_4)
 
 - First steps towards running IBISes on TIBCO AMX (as WebApp in Composite)
 - added "Used SapSystems" to console function "Show Security Items"
@@ -1518,7 +1490,7 @@ Performance enhancements
 5.3
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v5_2...v5_3)
+[Commits](https://github.com/frankframework/frankframework/compare/v5_2...v5_3)
 
 - Better DB2 support.
 - Some steps towards making a release with Maven.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,12 +1,12 @@
 Ibis AdapterFramework release notes
 ===================================
 
-[Tags](https://github.com/ibissource/iaf/releases)
+[Tags](https://github.com/frankframework/frankframework/releases)
 [JavaDocs](https://javadoc.frankframework.org/)
 
 Upcoming (8.0)
 --------------
-[Commits](https://github.com/ibissource/iaf/compare/v7.9-RC1...HEAD)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.9-RC1...HEAD)
 
 ### Non backwards compatible changes
 - CreateRestViewPipe has been removed. It is no longer possible to open the old (blue) user interface.
@@ -16,7 +16,7 @@ Upcoming (8.0)
 
 7.9
 ---
-[Commits](https://github.com/ibissource/iaf/compare/v7.8-RC1...v7.9-RC1)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.8-RC1...v7.9-RC1)
 
 ### Non backwards compatible changes
 
@@ -47,7 +47,7 @@ Upcoming (8.0)
 
 7.8-RC1
 ---
-[Commits](https://github.com/ibissource/iaf/compare/v7.7...v7.8-RC1)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.7...v7.8-RC1)
 
 LCM dependencies (where possible)
 Generic bugfixes
@@ -123,7 +123,7 @@ Performance enhancements
 7.7
 ---
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.6.1...v7.6.2)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.6.1...v7.6.2)
 
 - New FrankDoc XSD and website
 - LCM Dependencies
@@ -197,7 +197,7 @@ Performance enhancements
 
 7.6.2
 --------
-[Commits](https://github.com/ibissource/iaf/compare/v7.6.1...v7.6.2)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.6.1...v7.6.2)
 
 - Fix gui log error message when more then x files (#2426)
 - Ladybug report keeps in progress while adapter is finished (#2496)
@@ -206,7 +206,7 @@ Performance enhancements
 
 7.6.1
 --------
-[Commits](https://github.com/ibissource/iaf/compare/v7.6...7.6-release)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.6...7.6-release)
 
 - Do not close zip archive during processing (#2109)
 - Fix log statements with throwables (#2135)
@@ -231,7 +231,7 @@ Performance enhancements
 
 7.6
 --------
-[Commits](https://github.com/ibissource/iaf/compare/v7.6-RC2...v7.6)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.6-RC2...v7.6)
 
 - Add writeLineSeparator attribute to FileSystemPipe (#1916)
 - Fix exception pipe should to not follow exception forward (#1913)
@@ -248,8 +248,8 @@ Performance enhancements
 
 7.6-RC2
 --------
-[Commits](https://github.com/ibissource/iaf/compare/v7.6-RC1...v7.6-RC2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?tag=v7.6-RC2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.6-RC1...v7.6-RC2)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?tag=v7.6-RC2)](https://travis-ci.org/frankframework/frankframework)
 
 - Reduce debug logging and fix JBoss project names (#1592)
 - Fix 'Move to InProcess' in transaction (#1603)
@@ -278,8 +278,8 @@ Performance enhancements
 
 7.6-RC1
 --------
-[Commits](https://github.com/ibissource/iaf/compare/v7.5...v7.6-RC1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?tag=v7.6-RC1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.5...v7.6-RC1)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?tag=v7.6-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Debug streaming messages
 - Add TextSplitterPipe
@@ -330,8 +330,8 @@ Performance enhancements
 7.5
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.5-RC4...v7.5)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.5)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC4...v7.5)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5)](https://travis-ci.org/frankframework/frankframework)
 
 - Sync testtool enable/disable buttons (#1036)
 - Fix #1029 handling absolute paths in LocalFileSystem (#1046)
@@ -350,8 +350,8 @@ Performance enhancements
 7.5-RC4
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.5-RC3...v7.5-RC4)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.5-RC4)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC3...v7.5-RC4)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC4)](https://travis-ci.org/frankframework/frankframework)
 
 - Set receiver color to red when in error (#761)
 - Set property to disable SecurityManager (#746)
@@ -389,8 +389,8 @@ Performance enhancements
 7.5-RC3
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.5-RC2...v7.5-RC3)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.5-RC3)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC2...v7.5-RC3)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC3)](https://travis-ci.org/frankframework/frankframework)
 
 - Fix GUI 3.0 global console warnings #505
 - Fix configurations being reloaded due to not having a (valid) version #506
@@ -415,8 +415,8 @@ Performance enhancements
 7.5-RC2
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.5-RC1...v7.5-RC2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.5-RC2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.5-RC1...v7.5-RC2)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC2)](https://travis-ci.org/frankframework/frankframework)
 
 - Nested stacktrace ends at ForEachChildElementPipe #425
 - Empty JDBC result throws NullPointerException #426
@@ -444,8 +444,8 @@ Performance enhancements
 7.5-RC1
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.4...v7.5-RC1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.5-RC1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.4...v7.5-RC1)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.5-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Make attribute firstPipe in PipeLine optional. When empty, the first Pipe in the Pipeline configuration
   is considedred to be the first. Similarly the success forward defaults to the next Pipe in the PipeLine.
@@ -515,8 +515,8 @@ Performance enhancements
 7.4
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.3...v7.4)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.4)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.3...v7.4)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.4)](https://travis-ci.org/frankframework/frankframework)
 
 - Improve validation config warnings
 - ShowConfigurationStatus - improve error view
@@ -536,8 +536,8 @@ Performance enhancements
 7.3
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.2...v7.3)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.3)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.2...v7.3)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.3)](https://travis-ci.org/frankframework/frankframework)
 
 - Refactor CmisListener to an event based listener, you can now have multiple listeners listening to different events
 - The cmis bridge functionality on the sender has been removed. In order to use the bridge you need to configure properties in the WAR/EAR file. See CmisSessionBuilder for more information about the properties that can be set
@@ -548,8 +548,8 @@ Performance enhancements
 7.3-RC1
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.2...v7.3-RC1)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.3-RC1)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.2...v7.3-RC1)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.3-RC1)](https://travis-ci.org/frankframework/frankframework)
 
 - Generate IbisDoc and XSD and support beautiful configuration xml. The XSD can be used for code completion of beautiful Ibis configurations in Eclipse
 - Use XSLT 2.0 instead of 1.0 for configuration tweaks (e.g. stub4testtool.xsl)
@@ -592,8 +592,8 @@ Performance enhancements
 7.2
 --------
 
-[Commits](https://github.com/ibissource/iaf/compare/v7.1...v7.2)
-[![Build Status](https://travis-ci.org/ibissource/iaf.png?branch=v7.2)](https://travis-ci.org/ibissource/iaf)
+[Commits](https://github.com/frankframework/frankframework/compare/v7.1...v7.2)
+[![Build Status](https://travis-ci.org/frankframework/frankframework.png?branch=v7.2)](https://travis-ci.org/ibissource/iaf)
 
 - Fix NPE in BatchFileTransformerPipe when using an IbisLocalSender
 - Various bugfixes en performance improvements in SOAPProviders (WebServiceListener)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ best practices and perform security testing before releasing your application.
 | 7.0.x   | :x:                |:x:               | Jun 1, 2018      |
 | < 6.1   | :x:                |:x:               | Dec 13, 2016     |
 
-*Please always update to the latest available release. CVE's are solved on a best-effort basis, on versions not older then 1 year after the initial release date (specified in the table above). For more information see our [Security monitoring procedure](https://github.com/ibissource/iaf/wiki/Security-monitoring-procedure).
+*Please always update to the latest available release. CVE's are solved on a best-effort basis, on versions not older then 1 year after the initial release date (specified in the table above). For more information see our [Security monitoring procedure](https://github.com/frankframework/frankframework/wiki/Security-monitoring-procedure).
 
 ## Reporting a Vulnerability
 

--- a/TESTING_WITH_IAF-TEST.md
+++ b/TESTING_WITH_IAF-TEST.md
@@ -74,7 +74,7 @@ See the Eclipse instructions for an important note about the `log.dir` setting.
 ## 4. Select database
 
 The ibis-adapterframeworkt-test project supports multiple databases. By default, an H2 local database is used.
-Docker projects for a number of other DMBSes are provided in GitHub project https://github.com/ibissource/iaf-ci-images. To use one of the provided databases, run the `rebuild.bat` script in the corresponding directory. (requires Docker to be installed on your machine). To configure the ibis-adapterframeworkt-test application, set in the catalina.properties or the VM Options the property `jdbc.dbms.default` to `oracle`, `mssql`, `mysql`, `mariadb` or `postgres`.
+Docker projects for a number of other DMBSes are provided in GitHub project https://github.com/frankframework/ci-images. To use one of the provided databases, run the `rebuild.bat` script in the corresponding directory. (requires Docker to be installed on your machine). To configure the ibis-adapterframeworkt-test application, set in the catalina.properties or the VM Options the property `jdbc.dbms.default` to `oracle`, `mssql`, `mysql`, `mariadb` or `postgres`.
 
 ## 5. Running the test scenarios
 

--- a/TESTING_WITH_IAF-TEST.md
+++ b/TESTING_WITH_IAF-TEST.md
@@ -2,7 +2,7 @@
 
 To ensure that your contribution doesn't break any logic, we would like you to run the test scenario's within the iaf-test module before committing your changes. To do this, a number of extra dependencies are required. These are placed as runtime-dependencies in the `test/pom.xml` but the overview is placed below for verification, and in case something goes wrong with the dependency management.
 
-This guide was written with the assertion that you are A) using Eclipse, and B) have successfully ran the iaf-example module before. If this is not the case, please follow the steps as described on our [CONTRIBUTING](https://github.com/ibissource/iaf/blob/master/CONTRIBUTING.md#developing-with-eclipse) page. For users of IntelliJ, see chapter 3.
+This guide was written with the assertion that you are A) using Eclipse, and B) have successfully ran the iaf-example module before. If this is not the case, please follow the steps as described on our [CONTRIBUTING](https://github.com/frankframework/frankframework/blob/master/CONTRIBUTING.md#developing-with-eclipse) page. For users of IntelliJ, see chapter 3.
 
 ## 1. Proprietary modules and JAR dependencies
 
@@ -19,7 +19,7 @@ If you want to use Queuing or a DBMS other than H2, you need to ensure the corre
 * For PostgreSQL      : [postgresql-42.2.14](https://jdbc.postgresql.org/download/postgresql-42.2.14.jar)
 * For ActiveMQ        : [activemq-all-5.8.0.jar](https://mvnrepository.com/artifact/org.apache.activemq/activemq-core/5.8.0)
 
-**Versions are subject to change, please check our [pom.xml](https://github.com/ibissource/iaf/blob/master/pom.xml) for the current driver(s) and their corresponding versions.**
+**Versions are subject to change, please check our [pom.xml](https://github.com/frankframework/frankframework/blob/master/pom.xml) for the current driver(s) and their corresponding versions.**
 
 In Tomcat's launch configuration (go to the Java EE perspective to access your Tomcat server, find launch configuration in the Tomcat Overview window), go to the Classpath tab. Click on the User Entries item and click on the [ Add JARs... ] button. Select all JARs in the lib folder, press OK, and press OK again.
 

--- a/console/frontend/src/main/frontend/js/app/components/pages/feedback-modal/feedback.html
+++ b/console/frontend/src/main/frontend/js/app/components/pages/feedback-modal/feedback.html
@@ -23,7 +23,7 @@
 	</div>
 	<div class="modal-footer">
 		<span class="pull-left p-xxs">
-			<a href="//github.com/ibissource/iaf" target="_blank" alt="github.com/ibissource/iaf">github.com/ibissource/iaf</a> |
+			<a href="//github.com/frankframework/frankframework" target="_blank" alt="github.com/frankframework/frankframework">github.com/frankframework/frankframework</a> |
 			<a href="//frank-manual.readthedocs.io" target="_blank" alt="Frank!Manual">Frank!Manual</a>
 		</span>
 		<button type="button" class="btn btn-white" ng-click="close()">Close</button>

--- a/console/frontend/src/main/frontend/js/app/components/pages/information-modal/information.html
+++ b/console/frontend/src/main/frontend/js/app/components/pages/information-modal/information.html
@@ -19,7 +19,7 @@
 	</div>
 	<div class="modal-footer">
 		<span class="pull-left p-xxs">
-			<a href="//github.com/ibissource/iaf" target="_blank" alt="github.com/ibissource/iaf">github.com/ibissource/iaf</a> |
+			<a href="//github.com/frankframework/frankframework" target="_blank" alt="github.com/frankframework/frankframework">github.com/frankframework/frankframework</a> |
 			<a href="//frank-manual.readthedocs.io" target="_blank" alt="Frank!Manual">Frank!Manual</a> |
 			<a ng-click="openCookieModel()" alt="Cookie Information" class="pointer">Cookie Information</a>
 		</span>

--- a/console/frontend/src/main/frontend/js/app/components/pages/pages-footer.component.html
+++ b/console/frontend/src/main/frontend/js/app/components/pages/pages-footer.component.html
@@ -1,5 +1,5 @@
 <div class="footer">
     <div>
-        <strong>Frank</strong><strong class="text-frank">!</strong><strong>Console</strong> powered by: <a href="//frankframework.org" target="_blank" alt="frankframework.org">frankframework.org</a> | <a href="//github.com/ibissource/iaf" target="_blank" alt="github.com/ibissource/iaf">github.com/ibissource/iaf</a>
+        <strong>Frank</strong><strong class="text-frank">!</strong><strong>Console</strong> powered by: <a href="//frankframework.org" target="_blank" alt="frankframework.org">frankframework.org</a> | <a href="//github.com/frankframework/frankframework" target="_blank" alt="github.com/frankframework/frankframework">github.com/frankframework/frankframework</a>
     </div>
 </div>

--- a/console/frontend/src/main/frontend/js/app/components/pages/pages-navigation.component.html
+++ b/console/frontend/src/main/frontend/js/app/components/pages/pages-navigation.component.html
@@ -92,7 +92,7 @@
 				<a ng-click="$ctrl.onOpenFeedback()" class="pointer"><i class="fa fa-commenting-o"></i> <span class="nav-label">Send Feedback!</span></a>
 			</li>
 			<li>
-				<a target="_blank" href="https://github.com/ibissource/iaf" alt="github.com/ibissource/iaf"><i class="fa fa-github"></i> <span class="nav-label">GitHub SourceCode</span></a>
+				<a target="_blank" href="https://github.com/frankframework/frankframework" alt="github.com/frankframework/frankframework"><i class="fa fa-github"></i> <span class="nav-label">GitHub SourceCode</span></a>
 			</li>
 
 			<li>

--- a/console/frontend/src/main/frontend/js/app/views/login/login.component.html
+++ b/console/frontend/src/main/frontend/js/app/views/login/login.component.html
@@ -17,6 +17,6 @@
             <button type="submit" class="btn btn-primary block full-width m-b">Login</button>
         </form>
         <p class="m-t"> <strong>Copyright</strong> <a href="//frankframework.org/">frankframework.org</a> &copy; 2016-2023</p>
-        <p class="m-t"> <small>Powered by: <a href="//frankframework.org">frankframework.org</a> | <a href="//github.com/ibissource/iaf">github.com/ibissource/iaf</a></small> </p>
+        <p class="m-t"> <small>Powered by: <a href="//frankframework.org">frankframework.org</a> | <a href="//github.com/frankframework/frankframework">github.com/frankframework/frankframework</a></small> </p>
     </div>
 </div>

--- a/core/src/main/java/nl/nn/adapterframework/jta/btm/BtmDiskJournal.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/btm/BtmDiskJournal.java
@@ -36,7 +36,7 @@ import nl.nn.adapterframework.util.AppConstants;
  * Since it's not possible to change the current transaction, the most we can do is attempt to
  * retry the log/force actions and hope we don't break the tx-log even further.
  *
- * @see <a href="https://github.com/ibissource/iaf/issues/4615">IbisSource issue</a>
+ * @see <a href="https://github.com/frankframework/frankframework/issues/4615">IbisSource issue</a>
  * @see <a href="https://github.com/bitronix/btm/issues/45">BTM issue</a>
  *
  * @author Niels Meijer

--- a/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
@@ -30,12 +30,12 @@ import nl.nn.adapterframework.util.LogUtil;
 
 /**
  * EntityResolver for XercesXmlValidator to resolve imported schema documents to other schemas used to populate the grammar pool.
- * 
+ *
  * References are resolved by namespace.
- * 
+ *
  * @author Gerrit van Brakel
  */
-public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //ClassLoaderXmlEntityResolver 
+public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //ClassLoaderXmlEntityResolver
 	protected Logger log = LogUtil.getLogger(this);
 
 	private final List<Schema> schemas;
@@ -83,7 +83,7 @@ public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //Cla
 
 		// Throw an exception so the XercesValidationErrorHandler picks this up as ERROR.
 		// Do not rely on the fallback resource resolver, this will bypass configuration classloaders.
-		// See https://github.com/ibissource/iaf/issues/3973
+		// See https://github.com/frankframework/frankframework/issues/3973
 		throw new XNIException("Cannot find resource [" + resourceIdentifier.getExpandedSystemId() +
 			"] from systemId [" + resourceIdentifier.getLiteralSystemId() +
 			"] with base [" + resourceIdentifier.getBaseSystemId() + "]");

--- a/core/src/main/javadoc/overview.html
+++ b/core/src/main/javadoc/overview.html
@@ -8,7 +8,7 @@
 	<p>
 		For more information, you can consult the following sources:
 		<ul>
-			<li>Our source code on <a href="https://github.com/ibissource/iaf" target="_blank">https://github.com/ibissource/iaf</a></li>
+			<li>Our source code on <a href="https://github.com/frankframework/frankframework" target="_blank">https://github.com/frankframework/frankframework</a></li>
 			<li>Our user manual on <a href="https://frank-manual.readthedocs.io" target="_blank">ReadTheDocs</a></li>
 		</ul>
 	</p>

--- a/core/src/test/java/nl/nn/adapterframework/parameters/ParameterTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/parameters/ParameterTest.java
@@ -1610,7 +1610,7 @@ public class ParameterTest {
 	}
 
 	@Test
-	// see https://github.com/ibissource/iaf/issues/3232
+	// see https://github.com/frankframework/frankframework/issues/3232
 	public void testPotentialProblematicSysId() throws ConfigurationException {
 		Parameter p = new Parameter();
 		p.setName("pid");

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ developing Franks! nor to run in production. For that, refer to the ["Frank!Fram
 documentation.
 The Docker images have been customized to run without needing much configuration.
 The images contain the test configurations and secrets to connect with
-our [auxiliary images](https://github.com/frankframework/frankframework-ci-images) which include the databases and Messaging Systems.
+our [auxiliary images](https://github.com/frankframework/ci-images) which include the databases and Messaging Systems.
 
 This folder also contains a docker compose file to make it easy to run.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@ developing Franks! nor to run in production. For that, refer to the ["Frank!Fram
 documentation.
 The Docker images have been customized to run without needing much configuration.
 The images contain the test configurations and secrets to connect with
-our [auxiliary images](https://github.com/ibissource/iaf-ci-images) which include the databases and Messaging Systems.
+our [auxiliary images](https://github.com/frankframework/frankframework-ci-images) which include the databases and Messaging Systems.
 
 This folder also contains a docker compose file to make it easy to run.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1103,9 +1103,9 @@
 	</reporting>
 
 	<scm>
-		<url>https://github.com/ibissource/iaf</url>
-		<connection>scm:git:https://github.com/ibissource/iaf.git</connection>
-		<developerConnection>scm:git:https://github.com/ibissource/iaf.git</developerConnection>
+		<url>https://github.com/frankframework/frankframework</url>
+		<connection>scm:git:https://github.com/frankframework/frankframework.git</connection>
+		<developerConnection>scm:git:https://github.com/frankframework/frankframework.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
 

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/MailFileSystemTestBase.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/MailFileSystemTestBase.java
@@ -71,7 +71,7 @@ public abstract class MailFileSystemTestBase<M,A,FS extends IMailFileSystem<M, A
 	public void testNormalMessageSubject() throws Exception {
 		M emailMessage = getFirstFileFromFolder(null);
 		String subject = fileSystem.getSubject(emailMessage);
-		String expected = "Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)";
+		String expected = "Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)";
 		assertEquals(expected,subject);
 	}
 
@@ -109,7 +109,7 @@ public abstract class MailFileSystemTestBase<M,A,FS extends IMailFileSystem<M, A
 		Map<String,Object> properties = fileSystem.getAdditionalFileProperties(emailMessage);
 		List<String> adresses = (List<String>)properties.get(IMailFileSystem.TO_RECEPIENTS_KEY);
 		String address = adresses.get(0);
-		String expected = "ibissource/iaf <iaf@noreply.github.com>";
+		String expected = "frankframework/frankframework <iaf@noreply.github.com>";
 		assertEquals(expected, address);
 	}
 
@@ -127,7 +127,7 @@ public abstract class MailFileSystemTestBase<M,A,FS extends IMailFileSystem<M, A
 		M emailMessage = getFirstFileFromFolder(null);
 		Map<String,Object> properties = fileSystem.getAdditionalFileProperties(emailMessage);
 		String bestReplyAddress = (String)properties.get(IMailFileSystem.BEST_REPLY_ADDRESS_KEY);
-		String expected = "ibissource/iaf <reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com>";
+		String expected = "frankframework/frankframework <reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com>";
 		assertEquals(expected, bestReplyAddress);
 	}
 

--- a/test-integration/src/test/resources/ExchangeMailAttachedMessage.xml
+++ b/test-integration/src/test/resources/ExchangeMailAttachedMessage.xml
@@ -11,27 +11,27 @@
 	<message>&lt;html&gt;&lt;head&gt;
 &lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;&lt;style type="text/css" style="display:none;"&gt; P {margin-top:0;margin-bottom:0;} &lt;/style&gt;&lt;/head&gt;&lt;body dir="ltr"&gt;&lt;div style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"&gt;probeer het maar!&lt;/div&gt;&lt;div&gt;&lt;div id="Signature"&gt;&lt;div&gt;&lt;div id="divtagdefaultwrapper" dir="ltr" style="font-size:12pt; color:#000000; font-family:Calibri,Helvetica,sans-serif"&gt;&lt;p style="margin-top: 0px; margin-bottom: 0px;"&gt;&lt;/p&gt;&lt;/div&gt;&lt;/div&gt;&lt;/div&gt;&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;</message>
 	<attachments>
-		<attachment name="[ibissource/iaf] Ladybug randomly stops report generation (#875)">
+		<attachment name="[frankframework/frankframework] Ladybug randomly stops report generation (#875)">
 			<recipients>
-				<recipient type="to">ibissource/iaf &lt;iaf@noreply.github.com&gt;</recipient>
+				<recipient type="to">frankframework/frankframework &lt;iaf@noreply.github.com&gt;</recipient>
 				<recipient type="cc">Subscribed &lt;subscribed@noreply.github.com&gt;</recipient>
 			</recipients>
 			<from>ricardovh &lt;notifications@github.com&gt;</from>
 			<sender>ricardovh &lt;notifications@github.com&gt;</sender>
-			<replyTo>ibissource/iaf &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</replyTo>
-			<bestReplyAddress>ibissource/iaf &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</bestReplyAddress>
-			<subject>Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)</subject>
+			<replyTo>frankframework/frankframework &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</replyTo>
+			<bestReplyAddress>frankframework/frankframework &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</bestReplyAddress>
+			<subject>Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)</subject>
 			<DateTimeSent>2020-09-30T12:35:41.000+0200</DateTimeSent>
 			<DateTimeReceived>2020-09-30T12:35:45.000+0200</DateTimeReceived>
 			<message>&lt;html&gt;&lt;head&gt;
-&lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Closed &lt;a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/ibissource/iaf/issues/875" data-hovercard-type="issue" data-hovercard-url="/ibissource/iaf/issues/875/hovercard" href="https://github.com/ibissource/iaf/issues/875"&gt;#875&lt;/a&gt;.&lt;/p&gt;&lt;p style="font-size:small;-webkit-text-size-adjust:none;color:#666;"&gt;—&lt;br&gt;You are receiving this because you are subscribed to this thread.&lt;br&gt;Reply to this email directly, &lt;a href="https://github.com/ibissource/iaf/issues/875#event-3823828368"&gt;view it on GitHub&lt;/a&gt;, or &lt;a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA"&gt;unsubscribe&lt;/a&gt;.&lt;img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""&gt;&lt;/p&gt;&lt;script type="application/ld+json"&gt;[
+&lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Closed &lt;a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/frankframework/frankframework/issues/875" data-hovercard-type="issue" data-hovercard-url="/frankframework/frankframework/issues/875/hovercard" href="https://github.com/frankframework/frankframework/issues/875"&gt;#875&lt;/a&gt;.&lt;/p&gt;&lt;p style="font-size:small;-webkit-text-size-adjust:none;color:#666;"&gt;—&lt;br&gt;You are receiving this because you are subscribed to this thread.&lt;br&gt;Reply to this email directly, &lt;a href="https://github.com/frankframework/frankframework/issues/875#event-3823828368"&gt;view it on GitHub&lt;/a&gt;, or &lt;a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA"&gt;unsubscribe&lt;/a&gt;.&lt;img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""&gt;&lt;/p&gt;&lt;script type="application/ld+json"&gt;[
 {
 "@context": "http://schema.org",
 "@type": "EmailMessage",
 "potentialAction": {
 "@type": "ViewAction",
-"target": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
-"url": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
+"target": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
+"url": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
 "name": "View Issue"
 },
 "description": "View this Issue on GitHub",
@@ -53,10 +53,10 @@
 				<header name="Received-SPF">Pass (protection.outlook.com: domain of github.com designates 192.30.252.206 as permitted sender) receiver=protection.outlook.com; client-ip=192.30.252.206; helo=out-23.smtp.github.com;</header>
 				<header name="DKIM-Signature">v=1; a=rsa-sha256; c=relaxed/relaxed; d=github.com;	s=pf2014; t=1601462142;	bh=JAGSSNaElGjrcCeMSNgIMV1C63UR1ZqzfM7SbX5p24o=;	h=Date:From:Reply-To:To:Cc:In-Reply-To:References:Subject:List-ID:	 List-Archive:List-Post:List-Unsubscribe:From;	b=iNXWOKhYcHzvEs721FG5rOVT0YpSDJYFnbzuhcZNMMp9yCdJVMqElnJ4O1/f+qVaC	 Uw0uXylJXg8btOuEPasjrq+iq7BRoC9L7mM4Y7ZI1VmqWHa+5smZhFNjP2VA8y3811	 wuSbu3QaQDCL1jhScPHbfH/nSqUpfSUZell/SWh8=</header>
 				<header name="Date">Wed, 30 Sep 2020 03:35:41 -0700</header>
-				<header name="Message-ID">&lt;ibissource/iaf/issue/875/issue_event/3823828368@github.com&gt;</header>
-				<header name="In-Reply-To">&lt;ibissource/iaf/issues/875@github.com&gt;</header>
-				<header name="References">&lt;ibissource/iaf/issues/875@github.com&gt;</header>
-				<header name="Subject">Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)</header>
+				<header name="Message-ID">&lt;frankframework/frankframework/issue/875/issue_event/3823828368@github.com&gt;</header>
+				<header name="In-Reply-To">&lt;frankframework/frankframework/issues/875@github.com&gt;</header>
+				<header name="References">&lt;frankframework/frankframework/issues/875@github.com&gt;</header>
+				<header name="Subject">Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)</header>
 				<header name="Mime-Version">1.0</header>
 				<header name="Content-Type">multipart/alternative</header>
 				<header name="Content-Transfer-Encoding">7bit</header>
@@ -64,8 +64,8 @@
 				<header name="X-GitHub-Sender">ricardovh</header>
 				<header name="X-GitHub-Recipient">gvanbrakel</header>
 				<header name="X-GitHub-Reason">subscribed</header>
-				<header name="List-ID">ibissource/iaf &lt;iaf.ibissource.github.com&gt;</header>
-				<header name="List-Archive">https://github.com/ibissource/iaf</header>
+				<header name="List-ID">frankframework/frankframework &lt;iaf.ibissource.github.com&gt;</header>
+				<header name="List-Archive">https://github.com/frankframework/frankframework</header>
 				<header name="List-Post">&lt;mailto:reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</header>
 				<header name="List-Unsubscribe">&lt;mailto:unsub+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;, &lt;https://github.com/notifications/unsubscribe/AA72C6ACM4NFMPYYIEX4PG3SIMCX3ANCNFSM4OGSSZKA&gt;</header>
 				<header name="X-Auto-Response-Suppress">All</header>

--- a/test-integration/src/test/resources/ExchangeMailNormal.xml
+++ b/test-integration/src/test/resources/ExchangeMailNormal.xml
@@ -1,24 +1,24 @@
 <email>
 	<recipients>
-		<recipient type="to">ibissource/iaf &lt;iaf@noreply.github.com&gt;</recipient>
+		<recipient type="to">frankframework/frankframework &lt;iaf@noreply.github.com&gt;</recipient>
 		<recipient type="cc">Subscribed &lt;subscribed@noreply.github.com&gt;</recipient>
 	</recipients>
 	<from>ricardovh &lt;notifications@github.com&gt;</from>
 	<sender>ricardovh &lt;notifications@github.com&gt;</sender>
-	<replyTo>ibissource/iaf &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</replyTo>
-	<bestReplyAddress>ibissource/iaf &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</bestReplyAddress>
-	<subject>Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)</subject>
+	<replyTo>frankframework/frankframework &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</replyTo>
+	<bestReplyAddress>frankframework/frankframework &lt;reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</bestReplyAddress>
+	<subject>Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)</subject>
 	<DateTimeSent>2020-09-30T12:35:41.000+0200</DateTimeSent>
 	<DateTimeReceived>2020-09-30T12:35:45.000+0200</DateTimeReceived>
 	<message>&lt;html&gt;&lt;head&gt;
-&lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Closed &lt;a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/ibissource/iaf/issues/875" data-hovercard-type="issue" data-hovercard-url="/ibissource/iaf/issues/875/hovercard" href="https://github.com/ibissource/iaf/issues/875"&gt;#875&lt;/a&gt;.&lt;/p&gt;&lt;p style="font-size:small;-webkit-text-size-adjust:none;color:#666;"&gt;—&lt;br&gt;You are receiving this because you are subscribed to this thread.&lt;br&gt;Reply to this email directly, &lt;a href="https://github.com/ibissource/iaf/issues/875#event-3823828368"&gt;view it on GitHub&lt;/a&gt;, or &lt;a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA"&gt;unsubscribe&lt;/a&gt;.&lt;img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""&gt;&lt;/p&gt;&lt;script type="application/ld+json"&gt;[
+&lt;meta http-equiv="Content-Type" content="text/html; charset=utf-8"&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Closed &lt;a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/frankframework/frankframework/issues/875" data-hovercard-type="issue" data-hovercard-url="/frankframework/frankframework/issues/875/hovercard" href="https://github.com/frankframework/frankframework/issues/875"&gt;#875&lt;/a&gt;.&lt;/p&gt;&lt;p style="font-size:small;-webkit-text-size-adjust:none;color:#666;"&gt;—&lt;br&gt;You are receiving this because you are subscribed to this thread.&lt;br&gt;Reply to this email directly, &lt;a href="https://github.com/frankframework/frankframework/issues/875#event-3823828368"&gt;view it on GitHub&lt;/a&gt;, or &lt;a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA"&gt;unsubscribe&lt;/a&gt;.&lt;img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""&gt;&lt;/p&gt;&lt;script type="application/ld+json"&gt;[
 {
 "@context": "http://schema.org",
 "@type": "EmailMessage",
 "potentialAction": {
 "@type": "ViewAction",
-"target": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
-"url": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
+"target": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
+"url": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
 "name": "View Issue"
 },
 "description": "View this Issue on GitHub",
@@ -40,10 +40,10 @@
 		<header name="Received-SPF">Pass (protection.outlook.com: domain of github.com designates 192.30.252.206 as permitted sender) receiver=protection.outlook.com; client-ip=192.30.252.206; helo=out-23.smtp.github.com;</header>
 		<header name="DKIM-Signature">v=1; a=rsa-sha256; c=relaxed/relaxed; d=github.com;	s=pf2014; t=1601462142;	bh=JAGSSNaElGjrcCeMSNgIMV1C63UR1ZqzfM7SbX5p24o=;	h=Date:From:Reply-To:To:Cc:In-Reply-To:References:Subject:List-ID:	 List-Archive:List-Post:List-Unsubscribe:From;	b=iNXWOKhYcHzvEs721FG5rOVT0YpSDJYFnbzuhcZNMMp9yCdJVMqElnJ4O1/f+qVaC	 Uw0uXylJXg8btOuEPasjrq+iq7BRoC9L7mM4Y7ZI1VmqWHa+5smZhFNjP2VA8y3811	 wuSbu3QaQDCL1jhScPHbfH/nSqUpfSUZell/SWh8=</header>
 		<header name="Date">Wed, 30 Sep 2020 03:35:41 -0700</header>
-		<header name="Message-ID">&lt;ibissource/iaf/issue/875/issue_event/3823828368@github.com&gt;</header>
-		<header name="In-Reply-To">&lt;ibissource/iaf/issues/875@github.com&gt;</header>
-		<header name="References">&lt;ibissource/iaf/issues/875@github.com&gt;</header>
-		<header name="Subject">Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)</header>
+		<header name="Message-ID">&lt;frankframework/frankframework/issue/875/issue_event/3823828368@github.com&gt;</header>
+		<header name="In-Reply-To">&lt;frankframework/frankframework/issues/875@github.com&gt;</header>
+		<header name="References">&lt;frankframework/frankframework/issues/875@github.com&gt;</header>
+		<header name="Subject">Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)</header>
 		<header name="Mime-Version">1.0</header>
 		<header name="Content-Type">multipart/alternative</header>
 		<header name="Content-Transfer-Encoding">7bit</header>
@@ -51,8 +51,8 @@
 		<header name="X-GitHub-Sender">ricardovh</header>
 		<header name="X-GitHub-Recipient">gvanbrakel</header>
 		<header name="X-GitHub-Reason">subscribed</header>
-		<header name="List-ID">ibissource/iaf &lt;iaf.ibissource.github.com&gt;</header>
-		<header name="List-Archive">https://github.com/ibissource/iaf</header>
+		<header name="List-ID">frankframework/frankframework &lt;iaf.ibissource.github.com&gt;</header>
+		<header name="List-Archive">https://github.com/frankframework/frankframework</header>
 		<header name="List-Post">&lt;mailto:reply+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;</header>
 		<header name="List-Unsubscribe">&lt;mailto:unsub+AA72C6GJP3QDZ2ZAJ4NOTZN5QBAH3EVBNHHCM2YM5Q@reply.github.com&gt;, &lt;https://github.com/notifications/unsubscribe/AA72C6ACM4NFMPYYIEX4PG3SIMCX3ANCNFSM4OGSSZKA&gt;</header>
 		<header name="X-Auto-Response-Suppress">All</header>

--- a/test-integration/src/test/resources/ExchangeMailNormalBody.txt
+++ b/test-integration/src/test/resources/ExchangeMailNormalBody.txt
@@ -1,12 +1,12 @@
 <html><head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><p></p><p>Closed <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/ibissource/iaf/issues/875" data-hovercard-type="issue" data-hovercard-url="/ibissource/iaf/issues/875/hovercard" href="https://github.com/ibissource/iaf/issues/875">#875</a>.</p><p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">—<br>You are receiving this because you are subscribed to this thread.<br>Reply to this email directly, <a href="https://github.com/ibissource/iaf/issues/875#event-3823828368">view it on GitHub</a>, or <a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA">unsubscribe</a>.<img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""></p><script type="application/ld+json">[
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><p></p><p>Closed <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/frankframework/frankframework/issues/875" data-hovercard-type="issue" data-hovercard-url="/frankframework/frankframework/issues/875/hovercard" href="https://github.com/frankframework/frankframework/issues/875">#875</a>.</p><p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">—<br>You are receiving this because you are subscribed to this thread.<br>Reply to this email directly, <a href="https://github.com/frankframework/frankframework/issues/875#event-3823828368">view it on GitHub</a>, or <a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA">unsubscribe</a>.<img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""></p><script type="application/ld+json">[
 {
 "@context": "http://schema.org",
 "@type": "EmailMessage",
 "potentialAction": {
 "@type": "ViewAction",
-"target": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
-"url": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
+"target": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
+"url": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
 "name": "View Issue"
 },
 "description": "View this Issue on GitHub",

--- a/test-integration/src/test/resources/ExchangeMailNormalContents.txt
+++ b/test-integration/src/test/resources/ExchangeMailNormalContents.txt
@@ -1,12 +1,12 @@
 <html><head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><p></p><p>Closed <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/ibissource/iaf/issues/875" data-hovercard-type="issue" data-hovercard-url="/ibissource/iaf/issues/875/hovercard" href="https://github.com/ibissource/iaf/issues/875">#875</a>.</p><p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">—<br>You are receiving this because you are subscribed to this thread.<br>Reply to this email directly, <a href="https://github.com/ibissource/iaf/issues/875#event-3823828368">view it on GitHub</a>, or <a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA">unsubscribe</a>.<img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""></p><script type="application/ld+json">[
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><p></p><p>Closed <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="644549868" data-permission-text="Title is private" data-url="https://github.com/frankframework/frankframework/issues/875" data-hovercard-type="issue" data-hovercard-url="/frankframework/frankframework/issues/875/hovercard" href="https://github.com/frankframework/frankframework/issues/875">#875</a>.</p><p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">—<br>You are receiving this because you are subscribed to this thread.<br>Reply to this email directly, <a href="https://github.com/frankframework/frankframework/issues/875#event-3823828368">view it on GitHub</a>, or <a href="https://github.com/notifications/unsubscribe-auth/AA72C6EQCEEQB2J2GMWU6JTSIMCX3ANCNFSM4OGSSZKA">unsubscribe</a>.<img src="https://github.com/notifications/beacon/AA72C6E5QJWXL4YUN7HSV2LSIMCX3A5CNFSM4OGSSZKKYY3PNVWWK3TUL52HS4DFWZEXG43VMVCXMZLOORHG65DJMZUWGYLUNFXW5KTDN5WW2ZLOORPWSZGO4PVP3EA.gif" height="1" width="1" alt=""></p><script type="application/ld+json">[
 {
 "@context": "http://schema.org",
 "@type": "EmailMessage",
 "potentialAction": {
 "@type": "ViewAction",
-"target": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
-"url": "https://github.com/ibissource/iaf/issues/875#event-3823828368",
+"target": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
+"url": "https://github.com/frankframework/frankframework/issues/875#event-3823828368",
 "name": "View Issue"
 },
 "description": "View this Issue on GitHub",

--- a/test-integration/src/test/resources/ExchangeMailNormalSimple.xml
+++ b/test-integration/src/test/resources/ExchangeMailNormalSimple.xml
@@ -1,3 +1,3 @@
 <email>
-	<subject>Re: [ibissource/iaf] Ladybug randomly stops report generation (#875)</subject>
+	<subject>Re: [frankframework/frankframework] Ladybug randomly stops report generation (#875)</subject>
 </email>


### PR DESCRIPTION
I've considered to not add the test, but I think it's nicer to just replace it everywhere.

I did not replace ibissource/iaf-ci-images because it's not transferred yet.