### PR TITLE
Refactor custom-view component to more TypeScript compliant solution

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -4,6 +4,8 @@ import { AppConstants } from 'src/angularjs/app/app.module';
 import { AppService } from 'src/angularjs/app/app.service';
 import { APPCONSTANTS } from 'src/app/app.module';
 
+type CustomView = {view: string, name: string, url: string};
+
 @Component({
   selector: 'app-custom-views',
   templateUrl: './custom-views.component.html',
@@ -11,11 +13,7 @@ import { APPCONSTANTS } from 'src/app/app.module';
 })
 export class CustomViewsComponent implements OnInit {
   appConstants: AppConstants;
-  customViews: {
-    view: string,
-    name: string,
-    url: string
-  }[] = [];
+  customViews: CustomView[] = [];
 
   constructor(private appService: AppService, @Inject(APPCONSTANTS) appConstants: AppConstants) {
     this.appConstants = appConstants;
@@ -23,21 +21,16 @@ export class CustomViewsComponent implements OnInit {
 
   ngOnInit() {
     this.appService.appConstants$.pipe(first()).subscribe(() => {
-      let customViews = this.appConstants["customViews.names"];
-      if (customViews == undefined)
-        return;
-
-      if (customViews.length > 0) {
-        let views = customViews.split(",");
+      const customViews = this.appConstants["customViews.names"];
+      if (customViews && customViews.length > 0) {
+        const views = customViews.split(",");
         for (const i in views) {
-          let viewId = views[i];
-          let name = this.appConstants["customViews." + viewId + ".name"];
-          let url = this.appConstants["customViews." + viewId + ".url"];
-          if (name && url) this.customViews.push({
-            view: viewId,
-            name: name,
-            url: url
-          });
+          const view = views[i];
+          const name = this.appConstants["customViews." + viewId + ".name"];
+          const url = this.appConstants["customViews." + viewId + ".url"];
+          if (name && url){
+            this.customViews.push({view, name, url}); 
+          }
         }
       }
     });

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -4,7 +4,7 @@ import { AppConstants } from 'src/angularjs/app/app.module';
 import { AppService } from 'src/angularjs/app/app.service';
 import { APPCONSTANTS } from 'src/app/app.module';
 
-type CustomView = {view: string, name: string, url: string};
+type CustomView = { view: string, name: string, url: string };
 
 @Component({
   selector: 'app-custom-views',
@@ -21,15 +21,15 @@ export class CustomViewsComponent implements OnInit {
 
   ngOnInit() {
     this.appService.appConstants$.pipe(first()).subscribe(() => {
-      const customViews = this.appConstants["customViews.names"];
+      const customViews = this.appConstants['customViews.names'];
       if (customViews && customViews.length > 0) {
         const views = customViews.split(",");
         for (const i in views) {
           const view = views[i];
-          const name = this.appConstants["customViews." + viewId + ".name"];
-          const url = this.appConstants["customViews." + viewId + ".url"];
+          const name = this.appConstants[`customViews.${viewId}.name`];
+          const url = this.appConstants[`customViews.${viewId}.url`];
           if (name && url){
-            this.customViews.push({view, name, url}); 
+            this.customViews.push({ view, name, url }); 
           }
         }
       }

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -26,8 +26,8 @@ export class CustomViewsComponent implements OnInit {
         const views = customViews.split(",");
         for (const i in views) {
           const view = views[i];
-          const name = this.appConstants[`customViews.${viewId}.name`];
-          const url = this.appConstants[`customViews.${viewId}.url`];
+          const name = this.appConstants[`customViews.${view}.name`];
+          const url = this.appConstants[`customViews.${view}.url`];
           if (name && url){
             this.customViews.push({ view, name, url }); 
           }


### PR DESCRIPTION
- double if not required, simplified to one
- use const when not reassigning variables
- object spread: `{name}` is the same as `{name: name}` in typescript
- prefer to define object based types as a generic functional re-usable type
- prefer to use single quotes or use the ` character when embedding variables in strings

I'm trying to understand why this logic has been placed in a subscription in `ngOnInit`, whilst the appConstants value being used in this block of logic is set in the constructor and not taken from the observable emission?

Could the subscription be removed and the logic placed directly in the constructor, since this is the only assignment of `this.appConstants`..?