### PR TITLE
Refactor pages-topnavbar.component.ts to more TypeScript compliant solution

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
@@ -8,14 +8,14 @@ import { NotificationService } from 'src/angularjs/app/services/notification.ser
   styleUrls: ['./pages-topnavbar.component.scss']
 })
 export class PagesTopnavbarComponent implements OnInit, OnDestroy{
-  notificationCount: number = this.Notification.getCount();
+  notificationCount = this.Notification.getCount();
   notificationList: NotificationService["list"] = [];
 
-  @Input() dtapSide: string = "";
-  @Input() dtapStage: string = "";
-  @Input() serverTime: string = "";
-  @Input() userName: string = "";
-  @Input() loggedin: boolean = false;
+  @Input() dtapSide = "";
+  @Input() dtapStage = "";
+  @Input() serverTime = "";
+  @Input() userName = "";
+  @Input() loggedin = false;
   @Output() onOpenFeedback = new EventEmitter<number>();
 
   private _subscriptions = new Subscription();


### PR DESCRIPTION
not required to explicitly define the type for a variable when its clear from its initialization value what type is.