### PR TITLE
Upgrade activation to 1.2.2

### DIFF
--- a/console/backend/pom.xml
+++ b/console/backend/pom.xml
@@ -144,9 +144,9 @@
 			<groupId>com.sun.activation</groupId>
 			<artifactId>jakarta.activation</artifactId>
 		</dependency>
-		<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
+		<dependency><!-- explicit dependency to force version 1.2.2 which handles javax.activation.* imports, compatible with the IBM JRE -->
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
 		</dependency>
 
 		<!-- Test scoped and provided dependencies -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,10 +97,9 @@
 			<version>${micrometer.version}</version>
 		</dependency>
 
-		<!-- explicit dependency to force version 1.1.1 -->
-		<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
+		<dependency><!-- explicit dependency to force version 1.2.2 which handles javax.activation.* imports, compatible with the IBM JRE -->
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
 		</dependency>
 		<dependency><!-- this dependency handles jakarta.activation.* imports -->
 			<groupId>com.sun.activation</groupId>
@@ -724,6 +723,10 @@
 				<exclusion><!-- excluded because we want the stax2 api -->
 					<groupId>javax.xml.stream</groupId>
 					<artifactId>stax-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.activation</groupId>
+					<artifactId>activation</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -268,11 +268,10 @@
 				<version>${project.version}</version>
 			</dependency>
 
-			<!-- explicit dependency to force version 1.1.1 -->
-			<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
-				<groupId>javax.activation</groupId>
-				<artifactId>activation</artifactId>
-				<version>1.1.1</version>
+			<dependency><!-- explicit dependency to force version 1.2.2 which handles javax.activation.* imports, compatible with the IBM JRE -->
+				<groupId>jakarta.activation</groupId>
+				<artifactId>jakarta.activation-api</artifactId>
+				<version>1.2.2</version>
 			</dependency>
 			<dependency><!-- this dependency handles jakarta.activation.* imports -->
 				<groupId>com.sun.activation</groupId>
@@ -980,15 +979,9 @@
 										<excludes>
 											<exclude>javax.activation:javax.activation-api</exclude>
 											<exclude>com.sun.activation:javax.activation</exclude>
-									<!-- 	<exclude>javax.activation:activation</exclude> -->
+											<exclude>javax.activation:activation</exclude>
 										</excludes>
-										<message>use com.sun.activation:jakarta.activation instead of jakarta.activation:jakarta.activation-api</message>
-									</bannedDependencies>
-									<bannedDependencies>
-										<excludes>
-											<exclude>jakarta.activation:jakarta.activation-api</exclude>
-										</excludes>
-										<message>the implementation com.sun.activation:jakarta.activation is included and it contains the api classes too</message>
+										<message>Don't though versions, we should use javax.activation:1.2.2 and jakarta.activation:2.0.1</message>
 									</bannedDependencies>
 									<bannedDependencies>
 										<excludes>


### PR DESCRIPTION
Originally it was thought that using version 1.1.1 would solve issues, however this was not the case...
See #3408 for the original dependency lock