### PR TITLE
Actually implement type=file attribute when using multipartXml

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
@@ -408,7 +408,9 @@ public class HttpSender extends HttpSenderBase {
 	}
 
 	protected FormBodyPart elementToFormBodyPart(Element element, PipeLineSession session) throws IOException {
-		String partName = element.getAttribute("name"); //Name of the part
+		String part = element.getAttribute("name"); //Name of the part
+		boolean isFile = "file".equals(element.getAttribute("type")); //text of file, empty == text
+		String filename = element.getAttribute("filename"); //if type == file, the filename
 		String partSessionKey = element.getAttribute("sessionKey"); //SessionKey to retrieve data from
 		String partMimeType = element.getAttribute("mimeType"); //MimeType of the part
 		Message partObject = session.getMessage(partSessionKey);
@@ -417,9 +419,16 @@ public class HttpSender extends HttpSenderBase {
 			mimeType = MimeType.valueOf(partMimeType);
 		}
 
-		String name = partObject.isBinary() || StringUtils.isBlank(partName) ? partSessionKey : partName;
-		String filename = StringUtils.isNotBlank(partName) ? partName : null;
-		return FormBodyPartBuilder.create(name, new MessageContentBody(partObject, mimeType, filename)).build();
+		final String filenameToUse;
+		if(isFile || StringUtils.isNotBlank(filename)) {
+			String filenamebackup = StringUtils.isBlank(part) ? partSessionKey : part;
+			filenameToUse = StringUtils.isNotBlank(filename) ? filename : filenamebackup;
+		} else {
+			filenameToUse = null;
+		}
+
+		String partname = isFile || StringUtils.isBlank(part) ? partSessionKey : part;
+		return FormBodyPartBuilder.create(partname, new MessageContentBody(partObject, mimeType, filenameToUse)).build();
 	}
 
 	@Override

--- a/core/src/test/resources/Http/Responses/simpleMtomFromParametersAndMultipartXml.txt
+++ b/core/src/test/resources/Http/Responses/simpleMtomFromParametersAndMultipartXml.txt
@@ -32,7 +32,6 @@ Content-ID: <document.pdf>
 --IGNORE
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
-Content-Disposition: attachment; name="string.txt"; filename="string.txt"
 Content-ID: <string.txt>
 
 mock pdf content

--- a/core/src/test/resources/Http/Responses/simpleMtomFromParametersAndMultipartXmlNoPartName.txt
+++ b/core/src/test/resources/Http/Responses/simpleMtomFromParametersAndMultipartXmlNoPartName.txt
@@ -25,6 +25,7 @@ mock pdf content
 --IGNORE
 Content-Type: application/pdf
 Content-Transfer-Encoding: binary
+Content-Disposition: attachment; name="part_file"; filename="part_file"
 Content-ID: <part_file>
 
 <dummy xml file/>

--- a/core/src/test/resources/Http/Responses/simpleMultipartFromParametersAndMultipartXml.txt
+++ b/core/src/test/resources/Http/Responses/simpleMultipartFromParametersAndMultipartXml.txt
@@ -29,7 +29,7 @@ Content-Transfer-Encoding: binary
 
 <dummy xml file/>
 --IGNORE
-Content-Disposition: form-data; name="string.txt"; filename="string.txt"
+Content-Disposition: form-data; name="string.txt"
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 

--- a/core/src/test/resources/Http/Responses/simpleMultipartFromParametersAndMultipartXmlNoPartName.txt
+++ b/core/src/test/resources/Http/Responses/simpleMultipartFromParametersAndMultipartXmlNoPartName.txt
@@ -23,7 +23,7 @@ Content-Transfer-Encoding: binary
 
 mock pdf content
 --IGNORE
-Content-Disposition: form-data; name="part_file"
+Content-Disposition: form-data; name="part_file"; filename="part_file"
 Content-Type: application/pdf
 Content-Transfer-Encoding: binary
 


### PR DESCRIPTION
With #3564 and #3924 in mind, actually use the `type="file"` attribute to distinguish if a part should have a filename or not.
In a future version we also need to fix #3917 behavior where it should only lookup the filename (when not set in the part xml) but present in the MessageContext.