### PR TITLE
Minor code improvement in closing PipeLineSession

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLineSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLineSession.java
@@ -18,7 +18,6 @@ package nl.nn.adapterframework.core;
 import java.security.Principal;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;


### PR DESCRIPTION
The code in this method has been bothering me for a while and I had this change locally for a while now. This cleanup is safe against concurrent modifications, although I think our other code in Message and PipeLineSession had already been cleaned up so this was no longer a problem.

Regardless this is safe and does not create a new Iterator every time!