### PR TITLE
change adapter statistics & message store buttons to anchor tags

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.html
@@ -1,6 +1,3 @@
-<!-- Angular ui-router hack-->
-<div ui-view></div>
-
 <div class="wrapper wrapper-content">
   <!--     <uib-alert ng-repeat="alert in alerts | orderBy:'type'" type="{{alert.type}}" close="closeAlert($index)">{{alert.message}}</uib-alert> -->
 
@@ -305,9 +302,11 @@
             <div class="col-md-6">
               <!-- adapter information -->
               <span class="pull-right">
-                <button [routerLink]="['', adapter.configuration, 'adapter', adapter.name, 'statistics']"
-                  class="btn btn-xs btn-info pull-right m-r-xs" type="button"><i class="fa fa-bar-chart m-r-xs"
-                    aria-hidden="true"></i>More statistics</button>
+                <a
+                  [routerLink]="['', adapter.configuration, 'adapter', adapter.name, 'statistics']"
+                  class="btn btn-xs btn-info pull-right m-r-xs"
+                  type="button"
+                ><i class="fa fa-bar-chart m-r-xs" aria-hidden="true"></i>More statistics</a>
               </span>
               <h4>Adapter information</h4>
               <table class="table">
@@ -424,12 +423,12 @@
                           <span *ngFor="let store of getTransactionalStores(receiver)">
                             <span class="text-{{getProcessStateIconColor(store.name)}}"
                               title="Browse messages with ProcessState: {{store.name}}">
-                              <button
+                              <a
                                 [routerLink]="['', adapter.configuration, 'adapters', adapter.name, 'receivers', receiver.name, 'stores', store.name]"
                                 class="btn btn-xs btn-default" type="button">
                                 <i class="fa {{getProcessStateIcon(store.name)}}"></i>
                                 ({{store.numberOfMessages}})
-                              </button>
+                              </a>
                             </span>
                           </span>
                           <button title="Stop receiver" class="btn btn-xs danger-hover"
@@ -473,13 +472,13 @@
                         <td>
                           <span class="pull-right">
                             <span [ngClass]="pipes.isSenderTransactionalStorage ? 'text-primary' : 'text-success'">
-                              <button *ngIf="pipes.hasMessageLog"
+                              <a *ngIf="pipes.hasMessageLog"
                                 [routerLink]="['', adapter.configuration, 'adapters', adapter.name, 'pipes', pipes.name, 'stores', 'Done']"
                                 class="btn btn-xs btn-default m-l-xs" type="button">
                                 <i
                                   [ngClass]="pipes.isSenderTransactionalStorage ? 'fa fa-sign-out' : 'fa fa-database'"></i>
                                 ({{pipes.messageLogCount}})
-                              </button>
+                              </a>
                             </span>
                           </span>
                         </td>


### PR DESCRIPTION
Adds the ability to ctrl+right click or use the context menu to open the statistics or message/pipe stores in a new tab