### PR TITLE
Remove redundant containsKey check

### DIFF
--- a/core/src/main/java/org/frankframework/http/rest/ApiDispatchConfig.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiDispatchConfig.java
@@ -39,9 +39,6 @@ public class ApiDispatchConfig {
 	}
 
 	public ApiListener getApiListener(ApiListener.HttpMethod method) {
-		if(!methods.containsKey(method))
-			return null;
-
 		return methods.get(method);
 	}
 


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#get-java.lang.Object-

get
V get(Object key)
Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.