### PR TITLE
Remove leading comma in Access-Control-Allow-Methods response header

### DIFF
--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors; 
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors; 
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
@@ -239,9 +239,9 @@ public class ApiListenerServlet extends HttpServletBase {
 						response.setHeader("Access-Control-Allow-Headers", headers);
 					response.setHeader("Access-Control-Expose-Headers", CorsExposeHeaders);
 
-					String methods = config.getMethods().stream()  
-	                  .map(ApiListener.HttpMethod::name)  
-	                  .collect(Collectors.joining(", "));
+					String methods = config.getMethods().stream()
+						.map(ApiListener.HttpMethod::name)
+						.collect(Collectors.joining(", "));
 					response.setHeader("Access-Control-Allow-Methods", methods);
 
 					//Only cut off OPTIONS (aka preflight) requests

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -238,11 +238,10 @@ public class ApiListenerServlet extends HttpServletBase {
 						response.setHeader("Access-Control-Allow-Headers", headers);
 					response.setHeader("Access-Control-Expose-Headers", CorsExposeHeaders);
 
-					StringBuilder methods = new StringBuilder();
-					for (ApiListener.HttpMethod mtd : config.getMethods()) {
-						methods.append(", ").append(mtd);
-					}
-					response.setHeader("Access-Control-Allow-Methods", methods.toString());
+					String methods = config.getMethods().stream()  
+	                  .map(ApiListener.HttpMethod::name)  
+	                  .collect(Collectors.joining(", "));
+					response.setHeader("Access-Control-Allow-Methods", methods);
 
 					//Only cut off OPTIONS (aka preflight) requests
 					if (method == ApiListener.HttpMethod.OPTIONS) {


### PR DESCRIPTION
Prevents the leading comma..

![image](https://github.com/frankframework/frankframework/assets/37303445/76b86cb7-18ad-4a8e-b874-212bade71372)
