### PR TITLE
Support multiple methods for a single ApiListener 

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2021-2023 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2021-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	public static final String TS_SENT_KEY = "tsSent";
 	public static final String SECURITY_HANDLER_KEY ="securityHandler";
 
+	public static final String HTTP_METHOD_KEY 	   = "HttpMethod";
 	public static final String HTTP_REQUEST_KEY    = "servletRequest";
 	public static final String HTTP_RESPONSE_KEY   = "servletResponse";
 	public static final String SERVLET_CONTEXT_KEY = "servletContext";

--- a/core/src/main/java/org/frankframework/http/RestListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/RestListenerServlet.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013-2015 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2013-2015 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -105,6 +105,7 @@ public class RestListenerServlet extends HttpServletBase {
 		ISecurityHandler securityHandler = new HttpSecurityHandler(request);
 		try (PipeLineSession messageContext= new PipeLineSession()) {
 			messageContext.setSecurityHandler(securityHandler);
+			messageContext.put(PipeLineSession.HTTP_METHOD_KEY, request.getMethod());
 
 			Enumeration<String> paramnames=request.getParameterNames();
 			while (paramnames.hasMoreElements()) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiCacheManager.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiCacheManager.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017, 2021-2022 WeAreFrank!
+   Copyright 2017, 2021-2022, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,8 +51,7 @@ public class ApiCacheManager {
 		return instanceName + "_" + dtapStage.toUpperCase() + "_" + uriPattern;
 	}
 
-	public static String getParentCacheKey(ApiListener listener, String uri) {
-		HttpMethod method = listener.getMethod();
+	public static String getParentCacheKey(ApiListener listener, String uri, HttpMethod method) {
 		String pattern = listener.getCleanPattern();
 		// Not only remove the eTag for the selected resources but also the collection
 		if((method == HttpMethod.PUT || method == HttpMethod.PATCH || method == HttpMethod.DELETE) && pattern != null && pattern.endsWith("/*")) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -15,7 +15,6 @@
 */
 package org.frankframework.http.rest;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -66,7 +65,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);
 	private @Getter String operationId;
 
-	private List<HttpMethod> method = Arrays.asList(HttpMethod.GET);
+	private List<HttpMethod> method = List.of(HttpMethod.GET);
 	public enum HttpMethod {
 		GET,PUT,POST,PATCH,DELETE,OPTIONS;
 	}
@@ -139,12 +138,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private void validateClaimAttribute(String claimAttributeToValidate, String claimAttributeName) throws ConfigurationException {
 		if(StringUtils.isNotEmpty(claimAttributeToValidate)){
 			List<String> invalidClaims = StringUtil.splitToStream(claimAttributeToValidate)
-					.filter(claim ->
-							StringUtil.splitToStream(claim, "=")
-									.filter(part -> part.length() > 0)
-									.collect(Collectors.toList())
-									.size() != 2
-					)
+					.filter(claim -> StringUtil.split(claim, "=").size() != 2)
 					.collect(Collectors.toList());
 
 			if(!invalidClaims.isEmpty()){

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -194,10 +194,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 			}
 		}
 		builder.append(getUriPattern());
-		String methods = getMethod().stream()
-				.map(m -> m.name())
-				.collect(Collectors.joining(","));
-		builder.append("; method: ").append(methods);
+		builder.append("; method: ").append(getMethod());
 
 		if(MediaTypes.ANY != consumes) {
 			builder.append("; consumes: ").append(getConsumes());
@@ -210,7 +207,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	}
 
 	private boolean hasMethod(HttpMethod method){
-		return getMethod().contains(method);
+		return this.method.contains(method);
 	}
 
 	/**
@@ -251,6 +248,16 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 		if(hasMethod(HttpMethod.OPTIONS)) {
 			throw new IllegalArgumentException("method OPTIONS should not be added manually");
 		}
+	}
+
+	public String getMethod(){
+		return method.stream()
+				.map(HttpMethod::name)
+				.collect(Collectors.joining(","));
+	}
+
+	public List<HttpMethod> getMethods(){
+		return method;
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -65,7 +65,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);
 	private @Getter String operationId;
 
-	private List<HttpMethod> method = List.of(HttpMethod.GET);
+	private List<HttpMethod> methods = List.of(HttpMethod.GET);
 	public enum HttpMethod {
 		GET,PUT,POST,PATCH,DELETE,OPTIONS;
 	}
@@ -194,7 +194,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 			}
 		}
 		builder.append(getUriPattern());
-		builder.append("; method: ").append(getMethod());
+		builder.append("; method: ").append(getMethods());
 
 		if(MediaTypes.ANY != consumes) {
 			builder.append("; consumes: ").append(getConsumes());
@@ -207,7 +207,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	}
 
 	private boolean hasMethod(HttpMethod method){
-		return this.method.contains(method);
+		return this.methods.contains(method);
 	}
 
 	/**
@@ -237,11 +237,18 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	}
 
 	/**
+	 * @deprecated The 'method' attribute has been renamed to 'methods'
+	 */
+	public void setMethod(String method){
+		setMethods(method);
+	}
+
+	/**
 	 * HTTP method(s) to listen to, separated by comma
 	 * @ff.default GET
 	 */
-	public void setMethod(String method) {
-		this.method = StringUtil.splitToStream(method)
+	public void setMethods(String methods) {
+		this.methods = StringUtil.splitToStream(methods)
 				.map(s -> EnumUtils.parse(HttpMethod.class, s))
 				.collect(Collectors.toList());
 
@@ -250,14 +257,14 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 		}
 	}
 
-	public String getMethod(){
-		return method.stream()
+	public String getMethods(){
+		return methods.stream()
 				.map(HttpMethod::name)
 				.collect(Collectors.joining(","));
 	}
 
-	public List<HttpMethod> getMethods(){
-		return method;
+	public List<HttpMethod> getAllMethods(){
+		return methods;
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -139,11 +139,17 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private void validateClaimAttribute(String claimAttributeToValidate, String claimAttributeName) throws ConfigurationException {
 		if(StringUtils.isNotEmpty(claimAttributeToValidate)){
 			List<String> invalidClaims = StringUtil.splitToStream(claimAttributeToValidate)
-					.filter(claim -> StringUtil.split(claim, "=").size() != 2)
+					.filter(claim ->
+							StringUtil.splitToStream(claim, "=")
+									.filter(part -> part.length() > 0)
+									.collect(Collectors.toList())
+									.size() != 2
+					)
 					.collect(Collectors.toList());
 
 			if(!invalidClaims.isEmpty()){
-				throw new ConfigurationException("[" + invalidClaims + "] are not a valid key/value pairs for [" + claimAttributeName + "].");
+				String partialMessage = invalidClaims.size() == 1 ? "is not a valid key/value pair" : "are not valid key/value pairs";
+				throw new ConfigurationException("[" + String.join(",", invalidClaims) + "] "+partialMessage+" for [" + claimAttributeName + "].");
 			}
 		}
 	}

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -196,7 +196,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 		builder.append(getUriPattern());
 		String methods = getMethod().stream()
 				.map(m -> m.name())
-				.collect(Collectors.joining(""));
+				.collect(Collectors.joining(","));
 		builder.append("; method: ").append(methods);
 
 		if(MediaTypes.ANY != consumes) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -66,7 +66,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);
 	private @Getter String operationId;
 
-	private @Getter List<HttpMethod> method = Arrays.asList(HttpMethod.GET);
+	private List<HttpMethod> method = Arrays.asList(HttpMethod.GET);
 	public enum HttpMethod {
 		GET,PUT,POST,PATCH,DELETE,OPTIONS;
 	}

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017-2023 WeAreFrank!
+   Copyright 2017-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -212,10 +212,10 @@ public class ApiListenerServlet extends HttpServletBase {
 		 * Initiate and populate messageContext
 		 */
 		try (PipeLineSession messageContext = new PipeLineSession()) {
+			messageContext.put(PipeLineSession.HTTP_METHOD_KEY, method);
 			messageContext.put(PipeLineSession.HTTP_REQUEST_KEY, request);
 			messageContext.put(PipeLineSession.HTTP_RESPONSE_KEY, response);
 			messageContext.put(PipeLineSession.SERVLET_CONTEXT_KEY, getServletContext());
-			messageContext.put("HttpMethod", method);
 			messageContext.setSecurityHandler(new HttpSecurityHandler(request));
 			try {
 				ApiDispatchConfig config = dispatcher.findConfigForUri(uri);
@@ -545,7 +545,7 @@ public class ApiListenerServlet extends HttpServletBase {
 						cache.remove(etagCacheKey);
 
 						// Not only remove the eTag for the selected resources but also the collection
-						String key = ApiCacheManager.getParentCacheKey(listener, uri);
+						String key = ApiCacheManager.getParentCacheKey(listener, uri, method);
 						if(key != null) {
 							LOG.debug("removing parent etag with key[{}]", key);
 							cache.remove(key);

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +82,7 @@ public class ApiListenerServlet extends HttpServletBase {
 
 	public static final String AUTHENTICATION_COOKIE_NAME = "authenticationToken";
 
-	private static final List<String> IGNORE_HEADERS = Arrays.asList("connection", "transfer-encoding", "content-type", "authorization");
+	private static final List<String> IGNORE_HEADERS = List.of("connection", "transfer-encoding", "content-type", "authorization");
 
 	private final int authTTL = AppConstants.getInstance().getInt("api.auth.token-ttl", 60 * 60 * 24 * 7); //Defaults to 7 days
 	private final String CorsAllowOrigin = AppConstants.getInstance().getString("api.auth.cors.allowOrigin", "*"); //Defaults to everything
@@ -638,7 +637,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			String paramName = paramNames.nextElement();
 			String[] paramList = request.getParameterValues(paramName);
 			if(paramList.length > 1) { // contains multiple items
-				List<String> valueList = Arrays.asList(paramList);
+				List<String> valueList = List.of(paramList);
 				if(LOG.isTraceEnabled()) LOG.trace("setting queryParameter [{}] to {}", paramName, valueList);
 				params.put(paramName, valueList);
 			}

--- a/core/src/main/java/org/frankframework/http/rest/ApiPrincipalPipe.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiPrincipalPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017-2021 WeAreFrank!
+   Copyright 2017-2021, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.frankframework.http.rest;
 import java.io.IOException;
 import java.rmi.server.UID;
 import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.servlet.annotation.ServletSecurity;
@@ -45,7 +44,7 @@ import org.frankframework.util.AppConstants;
 public class ApiPrincipalPipe extends FixedForwardPipe {
 
 	private String action = null;
-	List<String> allowedActions = Arrays.asList("get", "set", "create", "remove");
+	List<String> allowedActions = List.of("get", "set", "create", "remove");
 	private IApiCache cache = null;
 	private final int authTTL = AppConstants.getInstance().getInt("api.auth.token-ttl", 60 * 60 * 24 * 7); //Defaults to 7 days
 	private String authenticationMethod = "header";

--- a/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
@@ -90,7 +90,7 @@ public class ApiServiceDispatcher {
 
 		for (Iterator<String> it = patternClients.keySet().iterator(); it.hasNext();) {
 			String uriPattern = it.next();
-			if(log.isTraceEnabled()) log.trace("comparing uri ["+uri+"] to pattern ["+uriPattern+"]");
+			if(log.isTraceEnabled()) log.trace("comparing uri [{}] to pattern [{}]", uri, uriPattern);
 
 			String[] patternSegments = uriPattern.split("/");
 			if (exactMatch && patternSegments.length != uriSegments.length || patternSegments.length < uriSegments.length) {
@@ -120,9 +120,9 @@ public class ApiServiceDispatcher {
 			throw new ListenerException("uriPattern cannot be null or empty");
 
 		synchronized(patternClients) {
-			for(ApiListener.HttpMethod method : listener.getMethods()){
+			for(ApiListener.HttpMethod method : listener.getAllMethods()){
 				patternClients.computeIfAbsent(uriPattern, pattern -> new ApiDispatchConfig(pattern)).register(method, listener);
-				if(log.isTraceEnabled()) log.trace("ApiServiceDispatcher successfully registered uriPattern ["+uriPattern+"] method ["+method+"]");
+				if(log.isTraceEnabled()) log.trace("ApiServiceDispatcher successfully registered uriPattern [{}] method [{}}]", uriPattern, method);
 			}
 		}
 	}
@@ -133,7 +133,7 @@ public class ApiServiceDispatcher {
 			log.warn("uriPattern cannot be null or empty, unable to unregister ServiceClient");
 		}
 		else {
-			for(ApiListener.HttpMethod method : listener.getMethods()){
+			for(ApiListener.HttpMethod method : listener.getAllMethods()){
 				boolean success = false;
 				synchronized (patternClients) {
 					ApiDispatchConfig dispatchConfig = patternClients.get(uriPattern);
@@ -149,9 +149,9 @@ public class ApiServiceDispatcher {
 
 				//keep log statements out of synchronized block
 				if(success) {
-					if(log.isTraceEnabled()) log.trace("ApiServiceDispatcher successfully unregistered uriPattern ["+uriPattern+"] method ["+method+"]");
+					if(log.isTraceEnabled()) log.trace("ApiServiceDispatcher successfully unregistered uriPattern [{}] method [{}}]", uriPattern, method);
 				} else {
-					log.warn("unable to find DispatchConfig for uriPattern ["+uriPattern+"]");
+					log.warn("unable to find DispatchConfig for uriPattern [{}]", uriPattern);
 				}
 			}
 		}
@@ -404,7 +404,7 @@ public class ApiServiceDispatcher {
 			if(config != null) config.clear();
 		}
 		if(!patternClients.isEmpty()) {
-			log.warn("unable to gracefully unregister "+patternClients.size()+" DispatchConfigs");
+			log.warn("unable to gracefully unregister [{}] DispatchConfigs", patternClients.size());
 			patternClients.clear();
 		}
 	}

--- a/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
@@ -121,7 +121,7 @@ public class ApiServiceDispatcher {
 			throw new ListenerException("uriPattern cannot be null or empty");
 
 		synchronized(patternClients) {
-			for(ApiListener.HttpMethod method : listener.getMethod()){
+			for(ApiListener.HttpMethod method : listener.getMethods()){
 				patternClients.computeIfAbsent(uriPattern, pattern -> new ApiDispatchConfig(pattern)).register(method, listener);
 				if(log.isTraceEnabled()) log.trace("ApiServiceDispatcher successfully registered uriPattern ["+uriPattern+"] method ["+method+"]");
 			}
@@ -134,7 +134,7 @@ public class ApiServiceDispatcher {
 			log.warn("uriPattern cannot be null or empty, unable to unregister ServiceClient");
 		}
 		else {
-			for(ApiListener.HttpMethod method : listener.getMethod()){
+			for(ApiListener.HttpMethod method : listener.getMethods()){
 				boolean success = false;
 				synchronized (patternClients) {
 					ApiDispatchConfig dispatchConfig = patternClients.get(uriPattern);

--- a/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
@@ -16,7 +16,6 @@ limitations under the License.
 package org.frankframework.http.rest;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -167,7 +166,7 @@ public class ApiServiceDispatcher {
 	}
 
 	public JsonObject generateOpenApiJsonSchema(ApiDispatchConfig client, String endpoint) {
-		List<ApiDispatchConfig> clientList = Arrays.asList(client);
+		List<ApiDispatchConfig> clientList = List.of(client);
 		return generateOpenApiJsonSchema(clientList, endpoint);
 	}
 
@@ -369,7 +368,7 @@ public class ApiServiceDispatcher {
 					if(StringUtils.isNotEmpty(ple.getResponseRoot()) && outputValidator == null) {
 						reference = ple.getResponseRoot();
 					} else {
-						List<String> references = Arrays.asList(schemaReferenceElement.split(","));
+						List<String> references = List.of(schemaReferenceElement.split(","));
 						if(ple.isSuccessExit()) {
 							reference = references.get(0);
 						} else {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2023 WeAreFrank!
+   Copyright 2022-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.stream.Collectors;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -258,7 +259,10 @@ public class WebServices extends BusEndpointBase {
 
 		public ListenerDAO(ApiListener listener) {
 			this.name = listener.getName();
-			this.method = listener.getMethod().name();
+			this.method = listener.getMethod().stream()
+					.map(m -> m.name())
+					.collect(Collectors.joining(","));
+
 			this.uriPattern = listener.getUriPattern();
 		}
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.stream.Collectors;
 
 import javax.xml.stream.XMLStreamException;
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -258,7 +258,7 @@ public class WebServices extends BusEndpointBase {
 
 		public ListenerDAO(ApiListener listener) {
 			this.name = listener.getName();
-			this.method = listener.getMethod();
+			this.method = listener.getMethods();
 			this.uriPattern = listener.getUriPattern();
 		}
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -259,10 +259,7 @@ public class WebServices extends BusEndpointBase {
 
 		public ListenerDAO(ApiListener listener) {
 			this.name = listener.getName();
-			this.method = listener.getMethod().stream()
-					.map(m -> m.name())
-					.collect(Collectors.joining(","));
-
+			this.method = listener.getMethod();
 			this.uriPattern = listener.getUriPattern();
 		}
 

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerPatternsTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerPatternsTest.java
@@ -17,8 +17,8 @@ package org.frankframework.http.rest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.frankframework.http.rest.ApiListener.HttpMethod;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,7 +30,7 @@ public class ApiListenerPatternsTest {
 	private ApiListener listener;
 
 	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] {
+		return List.of(new Object[][] {
 				{ "*", "/*", "/*" },
 				{ "test", "/test", "/test" },
 				{ "/test", "/test", "/test" },

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerPatternsTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerPatternsTest.java
@@ -55,7 +55,7 @@ public class ApiListenerPatternsTest {
 	public void initApiListenerPatternsTest(String pattern, String expectedUriPattern, String expectedCleanPattern) {
 		listener = new ApiListener();
 		listener.setName("my-api-listener");
-		listener.setMethod(HttpMethod.PUT);
+		listener.setMethod(HttpMethod.PUT.name());
 		listener.setUriPattern(pattern);
 	}
 

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -280,6 +280,17 @@ public class ApiListenerServletTest extends Mockito {
 	}
 
 	@Test
+	public void simpleGetMultiMethod() throws ServletException, IOException, ListenerException, ConfigurationException {
+		String uri="/test1";
+		new ApiListenerBuilder(uri, Arrays.asList(Methods.GET, Methods.POST)).build();
+
+		Response result = service(createRequest(uri, Methods.GET));
+		assertEquals(200, result.getStatus());
+		assertEquals("OPTIONS, GET, POST", result.getHeader("Allow"));
+		assertNull(result.getErrorMessage());
+	}
+
+	@Test
 	public void testAfterServiceMethodThreadContextMustBeCleared() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// arrange
 		ThreadContext.put("fakeMdcKey", "fakeContextValue");
@@ -1737,7 +1748,7 @@ public class ApiListenerServletTest extends Mockito {
 
 			String methods = method.stream()
 					.map(m -> EnumUtils.parse(HttpMethod.class, m.name()).name())
-					.collect(Collectors.joining("."));
+					.collect(Collectors.joining(","));
 			listener.setMethod(methods);
 
 			handler = new MessageHandler();

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.KeyManager;
@@ -669,7 +670,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentUTF8() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMultipartContentCharset";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.JSON, null, "string2").build();
+		new ApiListenerBuilder(uri, Arrays.asList(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON, null, "string2").build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.addTextBody("string1", "<hallo>€ è</hallo>", ContentType.create("text/plain"));
@@ -1711,17 +1712,33 @@ public class ApiListenerServletTest extends Mockito {
 		}
 
 		public ApiListenerBuilder(String uri, Methods method, AuthMethods authMethod) throws ListenerException, ConfigurationException {
-			this(uri, method, null, null, authMethod,null);
+			this(uri, Arrays.asList(method), null, null, authMethod,null);
 		}
 
 		public ApiListenerBuilder(String uri, Methods method, MediaTypes consumes, MediaTypes produces) throws ListenerException, ConfigurationException {
+			this(uri, Arrays.asList(method), consumes, produces, null, null);
+		}
+
+		public ApiListenerBuilder(String uri, List<Methods> method) throws ListenerException, ConfigurationException {
+			this(uri, method, null, null);
+		}
+
+		public ApiListenerBuilder(String uri, List<Methods> method, AuthMethods authMethod) throws ListenerException, ConfigurationException {
+			this(uri, method, null, null, authMethod,null);
+		}
+
+		public ApiListenerBuilder(String uri, List<Methods> method, MediaTypes consumes, MediaTypes produces) throws ListenerException, ConfigurationException {
 			this(uri, method, consumes, produces, null, null);
 		}
 
-		public ApiListenerBuilder(String uri, Methods method, MediaTypes consumes, MediaTypes produces, AuthMethods authMethod, String multipartBodyName) {
+		public ApiListenerBuilder(String uri, List<Methods> method, MediaTypes consumes, MediaTypes produces, AuthMethods authMethod, String multipartBodyName) {
 			listener = spy(ApiListener.class);
 			listener.setUriPattern(uri);
-			listener.setMethod(EnumUtils.parse(HttpMethod.class, method.name()));
+
+			String methods = method.stream()
+					.map(m -> EnumUtils.parse(HttpMethod.class, m.name()).name())
+					.collect(Collectors.joining("."));
+			listener.setMethod(methods);
 
 			handler = new MessageHandler();
 			listener.setHandler(handler);

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -235,7 +235,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void noUri() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
-		new ApiListenerBuilder("test", Methods.GET).build();
+		new ApiListenerBuilder("test", List.of(Methods.GET)).build();
 
 		// Act
 		Response result = service(createRequest(null, Methods.GET));
@@ -248,7 +248,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void uriNotFound() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
-		new ApiListenerBuilder("test", Methods.GET).build();
+		new ApiListenerBuilder("test", List.of(Methods.GET)).build();
 
 		// Act
 		Response result = service(createRequest("/not-test", Methods.GET));
@@ -261,7 +261,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void methodNotAllowed() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/test";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Response result = service(createRequest(uri, Methods.PUT));
 		assertEquals(405, result.getStatus());
@@ -271,7 +271,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void simpleGet() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/test1";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Response result = service(createRequest(uri, Methods.GET));
 		assertEquals(200, result.getStatus());
@@ -282,7 +282,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void simpleGetMultiMethod() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/test1";
-		new ApiListenerBuilder(uri, Arrays.asList(Methods.GET, Methods.POST)).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET, Methods.POST)).build();
 
 		Response result = service(createRequest(uri, Methods.GET));
 		assertEquals(200, result.getStatus());
@@ -307,7 +307,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void simpleGetWithSlashes() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/test2";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Response result = service(createRequest(uri, Methods.GET));
 		assertEquals(200, result.getStatus());
@@ -318,7 +318,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void preFlightRequest() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/preflight/";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Response result = service(createRequest(uri, Methods.OPTIONS));
 		assertEquals(200, result.getStatus());
@@ -333,7 +333,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void preFlightRequestWithRequestHeader() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/preflight/";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Access-Control-Request-Headers", "Message-Id,CustomHeader");
@@ -351,7 +351,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void corsGetRequest() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/not-preflight/";
-		new ApiListenerBuilder(uri, Methods.POST).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("origin", "https://frankframework.org");
@@ -371,7 +371,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void apiListenerThatProducesXML() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/ApiListenerThatProducesXML/";
-		new ApiListenerBuilder(uri, Methods.PUT, null, MediaTypes.XML).build();
+		new ApiListenerBuilder(uri, List.of(Methods.PUT), null, MediaTypes.XML).build();
 
 		Response result = service(createRequest(uri, Methods.PUT, "<xml>data</xml>"));
 		assertEquals(200, result.getStatus());
@@ -384,7 +384,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void apiListenerThatProducesJSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/ApiListenerThatProducesJSON/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON).build();
 
 		Response result = service(createRequest(uri, Methods.POST, "{}"));
 		assertEquals(200, result.getStatus());
@@ -398,7 +398,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerThatProducesJSONReturnsNoOutput() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/ApiListenerThatProducesJSONReturnsNoOutput/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON)
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON)
 			.withResponseContent("")
 			.build();
 		HttpServletRequest request = createRequest(uri, Methods.POST, "{}");
@@ -421,7 +421,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerThatProducesJSONReturnsNoOutputEmptyStream() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/ApiListenerThatProducesJSONReturnsNoOutput/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON)
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON)
 			.withResponseContent(new ByteArrayInputStream(new byte[0]))
 			.build();
 		HttpServletRequest request = createRequest(uri, Methods.POST, "{}");
@@ -444,7 +444,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerThatProducesJSONReturnsNoOutputEmptyReader() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/ApiListenerThatProducesJSONReturnsNoOutput/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON)
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON)
 			.withResponseContent(new StringReader(""))
 			.build();
 		HttpServletRequest request = createRequest(uri, Methods.POST, "{}");
@@ -467,7 +467,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerThatProducesXMLReturnsNoOutputNonStringResultMessage() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/ApiListenerThatProducesXMLReturnsNoOutputNonStringResultMessage/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.XML).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.XML).build();
 		Map<String, String> headers = new HashMap<>();
 
 		HttpServletRequest request = createRequest(uri, Methods.POST, null, headers);
@@ -490,7 +490,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void clientAcceptHeaderDoesNotLikeJSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/ApiListenerAllow/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON)
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON)
 			.build();
 
 		Map<String, String> headers = new HashMap<>();
@@ -508,7 +508,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void clientAcceptHeaderLovesJSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/ApiListenerAllow/";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -523,7 +523,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerDoesNotLikeContentTypeJSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerDoesNotAcceptContentType";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.XML, null).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.XML, null).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -536,7 +536,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerLovesContentTypeJSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerLovesContentTypeJSON";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.JSON, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.JSON, MediaTypes.JSON).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -553,7 +553,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void listenerRejectsRequestWithoutContentTypeHeaderWhenConsumesAttributeSet() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/listenerDoesNotAcceptRequestWithoutContentTypeHeader";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.XML, null).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.XML, null).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -571,7 +571,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void listenerAcceptsRequestWithoutContentTypeHeaderWhenConsumesAttributeNotSet() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/listenerAcceptsContentTypeJSON";
-		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), null, MediaTypes.JSON).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -591,7 +591,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerDetectContentTypeAndCharsetISO8859() throws Exception {
 		String uri="/listenerDetectMimeType";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.TEXT, MediaTypes.DETECT).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.TEXT, MediaTypes.DETECT).build();
 
 		URL url = ClassLoaderUtils.getResourceURL("/Util/MessageUtils/iso-8859-1.txt");
 		Message message = new UrlMessage(url);
@@ -609,7 +609,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentDetectContentTypeAndCharsetISO8859() throws Exception {
 		String uri="/listenerMultipartContent_DETECT";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.DETECT).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.DETECT).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setBoundary("gc0p4Jq0M2Yt08jU534c0p");
@@ -633,7 +633,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentISO8859_JSON() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMultipartContent_JSON";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setBoundary("gc0p4Jq0M2Yt08jU534c0p");
@@ -657,7 +657,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentISO8859_ANY() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMultipartContent_ANY";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.ANY).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.ANY).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setBoundary("gc0p4Jq0M2Yt08jU534c0p");
@@ -681,7 +681,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentUTF8() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMultipartContentCharset";
-		new ApiListenerBuilder(uri, Arrays.asList(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON, null, "string2").build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON, null, "string2").build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.addTextBody("string1", "<hallo>€ è</hallo>", ContentType.create("text/plain"));
@@ -713,7 +713,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMtomContent() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMtomContent";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART_RELATED, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART_RELATED, MediaTypes.JSON).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setMtomMultipart();
@@ -744,7 +744,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void listenerMultipartContentNoContentType() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/listenerMultipartContentNoContentType";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.addTextBody("string1", "<request/>", ContentType.create("text/xml"));//explicitly sent as UTF-8
@@ -763,7 +763,7 @@ public class ApiListenerServletTest extends Mockito {
 
 		// Arrange
 		String uri="/listenerMultipartContentNoContent";
-		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.JSON).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), MediaTypes.MULTIPART, MediaTypes.JSON).build();
 
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		HttpServletRequest request = createRequest(uri, Methods.POST, builder.build());
@@ -780,7 +780,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void getRequestWithQueryParameters() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/queryParamTest";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -797,7 +797,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void getRequestWithQueryListParameters() throws Exception {
 		String uri="/queryParamTestWithListsItems";
-		new ApiListenerBuilder(uri, Methods.GET).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -806,7 +806,7 @@ public class ApiListenerServletTest extends Mockito {
 
 		assertEquals(200, result.getStatus());
 		assertEquals("60", session.get("maxSpeed"));
-		List<String> transportList = Arrays.asList("car","bike","moped");
+		List<String> transportList = List.of("car","bike","moped");
 		assertEquals(transportList, session.get("transport"));
 		assertEquals("OPTIONS, GET", result.getHeader("Allow"));
 		assertNull(result.getErrorMessage());
@@ -815,7 +815,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void getRequestWithDynamicPath() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/dynamic/";
-		new ApiListenerBuilder(uri+"{poef}", Methods.GET).build();
+		new ApiListenerBuilder(uri+"{poef}", List.of(Methods.GET)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -831,7 +831,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void getRequestWithAsteriskPath() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/dynamic/";
-		new ApiListenerBuilder(uri+"*", Methods.GET).build();
+		new ApiListenerBuilder(uri+"*", List.of(Methods.GET)).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Accept", "application/json");
@@ -847,7 +847,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void customExitCode() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/exitcode";
-		new ApiListenerBuilder(uri, Methods.GET)
+		new ApiListenerBuilder(uri, List.of(Methods.GET))
 			.withExitCode(234)
 			.build();
 
@@ -866,7 +866,7 @@ public class ApiListenerServletTest extends Mockito {
 		// Arrange
 		String uri="/etag1";
 		Message repeatableMessage = new Message("{\"tralalalallala\":true}", new MessageContext().withModificationTime(DateFormatUtils.parseToInstant("2023-01-13 14:02:00", DateFormatUtils.GENERIC_DATETIME_FORMATTER)));
-		new ApiListenerBuilder(uri, Methods.GET)
+		new ApiListenerBuilder(uri, List.of(Methods.GET))
 			.withResponseContent(repeatableMessage)
 			.setUpdateEtag(true)
 			.build();
@@ -893,7 +893,7 @@ public class ApiListenerServletTest extends Mockito {
 		// Arrange
 		String uri="/etag2";
 		Message repeatableMessage = Message.asMessage(new Message("{\"tralalalallala\":true}").asByteArray());
-		new ApiListenerBuilder(uri, Methods.GET)
+		new ApiListenerBuilder(uri, List.of(Methods.GET))
 			.withResponseContent(repeatableMessage)
 			.build();
 
@@ -917,7 +917,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void eTagGetEtagMatches() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri = "/etag31";
-		new ApiListenerBuilder(uri, Methods.GET)
+		new ApiListenerBuilder(uri, List.of(Methods.GET))
 			.withExitCode(201)
 			.withResponseContent("{\"tralalalallala\":true}")
 			.build();
@@ -941,7 +941,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void eTagGetEtagDoesNotMatch() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri = "/etag32";
-		new ApiListenerBuilder(uri, Methods.GET)
+		new ApiListenerBuilder(uri, List.of(Methods.GET))
 			.withResponseContent("{\"tralalalallala\":true}")
 			.build();
 		String etagCacheKey = ApiCacheManager.buildCacheKey(uri);
@@ -963,7 +963,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void eTagPostEtagIfMatches() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/etag45";
-		new ApiListenerBuilder(uri, Methods.POST).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST)).build();
 		String etagCacheKey = ApiCacheManager.buildCacheKey(uri);
 		ApiCacheManager.getInstance().put(etagCacheKey, "my-etag-value");
 
@@ -980,7 +980,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void eTagPostEtagDoesNotMatch() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/etag46";
-		new ApiListenerBuilder(uri, Methods.POST).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST)).build();
 		String etagCacheKey = ApiCacheManager.buildCacheKey(uri);
 		ApiCacheManager.getInstance().put(etagCacheKey, "my-etag-value");
 
@@ -997,7 +997,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void cookieAuthentication401() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/cookie";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.COOKIE).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.COOKIE).build();
 
 		Map<String, String> headers = new HashMap<>();
 		Response result = service(createRequest(uri, Methods.POST, "{\"tralalalallala\":true}", headers));
@@ -1011,7 +1011,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void cookieNotFoundInCache401() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/cookie";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.COOKIE).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.COOKIE).build();
 
 		Map<String, String> headers = new HashMap<>();
 		MockHttpServletRequest request = createRequest(uri, Methods.POST, "{\"tralalalallala\":true}", headers);
@@ -1028,7 +1028,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void cookieAuthentication200() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/cookie";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.COOKIE).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.COOKIE).build();
 		String authToken = "random-token_thing";
 
 		ApiPrincipal principal = new ApiPrincipal();
@@ -1054,7 +1054,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void headerAuthentication401() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/cookie";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.HEADER).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.HEADER).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Authorization", "blalablaaaa");
@@ -1069,7 +1069,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void headerAuthentication200() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/header";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.HEADER).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.HEADER).build();
 		String authToken = "random-token_thing";
 
 		ApiPrincipal principal = new ApiPrincipal();
@@ -1092,7 +1092,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void authRoleAuthentication401() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/authRole2";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.AUTHROLE).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.AUTHROLE).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Authorization", "am9objpkb2U=");
@@ -1112,7 +1112,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void authRoleAuthentication200() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri = "/authRole2";
-		new ApiListenerBuilder(uri, Methods.POST, AuthMethods.AUTHROLE).build();
+		new ApiListenerBuilder(uri, List.of(Methods.POST), AuthMethods.AUTHROLE).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("Authorization", "am9objpkb2U=");
@@ -1132,7 +1132,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void testRequestWithMessageId() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri = "/messageIdTest1";
-		new ApiListenerBuilder(uri, Methods.POST)
+		new ApiListenerBuilder(uri, List.of(Methods.POST))
 			.setMessageIdHeader("X-Message-ID")
 			.setCorrelationIdHeader("X-Correlation-ID")
 			.build();
@@ -1157,7 +1157,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void testRequestWithMessageIdAndCorrelationId() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri = "/messageIdTest2";
-		new ApiListenerBuilder(uri, Methods.POST)
+		new ApiListenerBuilder(uri, List.of(Methods.POST))
 			.setMessageIdHeader("X-Message-ID")
 			.setCorrelationIdHeader("X-Correlation-ID")
 			.build();
@@ -1187,7 +1187,7 @@ public class ApiListenerServletTest extends Mockito {
 
 		// Arrange
 		String uri = "/messageWithJson2XmlValidator";
-		new ApiListenerBuilder(uri, method, null, MediaTypes.XML).build();
+		new ApiListenerBuilder(uri, List.of(method), null, MediaTypes.XML).build();
 
 		Map<String, String> headers = new HashMap<>();
 		headers.put("accept", "application/xml");
@@ -1220,7 +1220,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void setupParseAcceptHeaderAndValidateProduces(String acceptHeaderValue, MediaTypes produces) throws Exception {
 		// Arrange
 		String uri = "/messageWithAcceptHeaderAndProduces"+produces;
-		new ApiListenerBuilder(uri, Methods.GET, null, produces).build();
+		new ApiListenerBuilder(uri, List.of(Methods.GET), null, produces).build();
 
 		Map<String, String> headers = new HashMap<>();
 		if(acceptHeaderValue != null) {
@@ -1241,7 +1241,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void testEndpointDoesNotAcceptHeader(String acceptHeaderValue) throws Exception {
 		// Arrange
 		String uri = "/messageThatDoesNotAcceptAcceptHeader";
-		new ApiListenerBuilder(uri, Methods.GET, null, MediaTypes.JSON)
+		new ApiListenerBuilder(uri, List.of(Methods.GET), null, MediaTypes.JSON)
 			.build();
 
 		Map<String, String> headers = new HashMap<>();
@@ -1261,7 +1261,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void testRequestExceptionHandling() throws Exception {
 		// Arrange
 		String uri = "/testThrowsError";
-		new ApiListenerBuilder(uri, Methods.GET, null, null)
+		new ApiListenerBuilder(uri, List.of(Methods.GET), null, null)
 			.withShouldThrow(true)
 			.build();
 
@@ -1277,7 +1277,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithRequiredIssuer() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setAuthenticationMethod(AuthenticationMethods.JWT)
@@ -1293,7 +1293,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithoutRequiredIssuer() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setAuthenticationMethod(AuthenticationMethods.JWT)
 			.build();
@@ -1308,7 +1308,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithIllegalRequiredIssuer() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setAuthenticationMethod(AuthenticationMethods.JWT)
 			.setRequiredIssuer("test")
@@ -1324,7 +1324,7 @@ public class ApiListenerServletTest extends Mockito {
 	@Test
 	public void testJwtTokenParsingWithJwtHeader() throws Exception {
 		final String JWT_HEADER = "X-JWT-Assertion";
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 				.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 				.setRequiredIssuer("JWTPipeTest")
 				.setAuthenticationMethod(AuthenticationMethods.JWT)
@@ -1344,7 +1344,7 @@ public class ApiListenerServletTest extends Mockito {
 		String token="eyJhbGciOiJSUzI1NiJ9."
 				+ "eyJpc3MiOiJKV1RQaXBlVGVHzdCIsInN1YiI6IlVuaXRUZXN0IiwiYXVkIjoiRnJhbWV3b3JrIiwianRpIjoiMTIzNCJ9."
 				+ "U1VsMoITf5kUEHtzfgJTyRWEDZ2gjtTuQI3DVRrJcpden2pjCsAWwl4VOr6McmQkcndZj0GPvN4w3NkJR712ltlsIXw1zMm67vuFY0_id7TP2zIJh3jMkKrTuSPE-SBXZyVnIq22Q54R1VMnOTjO6spbrbYowIzyyeAC7U1RzyB3aKxTgeYJS6auLBaiR3-SWoXs_hBnbIIgYT7AC2e76ICpMlFPQS_e2bcqe1B-yz69se8ZlJgwWK-YhqHMoOCA9oQy3t_cObQI0KSzg7cYDkkQ17cWF3SoyTSTs6Cek_Y97Z17lJX2RVBayPc2uI_oWWuaIUbukxAOIUkgpgtf6g";
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 		.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 		.setAuthenticationMethod(AuthenticationMethods.JWT)
 		.build();
@@ -1362,7 +1362,7 @@ public class ApiListenerServletTest extends Mockito {
 		String token="eyJhbGciOiJSUzI1NiJ9."
 				+ "eyJpc3MiOiJKV1RQaXBlVGVzdCIsInN1YiI6IlVuaXRUZXN0IiwiYXVkIjoiRnJhbWV3b3JrIiwianRpIjoiMTIzNCJ9."
 				+ "U1VsMoITf5kUEHtzfgJTyRWKEDZ2gjtTuQI3DVRrJcpden2pjCsAWwl4VOr6McmQkcndZj0GPvN4w3NkJR712ltlsIXw1zMm67vuFY0_id7TP2zIJh3jMkKrTuSPE-SBXZyVnIq22Q54R1VMnOTjO6spbrbYowIzyyeAC7U1RzyB3aKxTgeYJS6auLBaiR3-SWoXs_hBnbIIgYT7AC2e76ICpMlFPQS_e2bcqe1B-yz69se8ZlJgwWK-YhqHMoOCA9oQy3t_cObQI0KSzg7cYDkkQ17cWF3SoyTSTs6Cek_Y97Z17lJX2RVBayPc2uI_oWWuaIUbukxAOIUkgpgtf6g";
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setAuthenticationMethod(AuthenticationMethods.JWT)
 			.build();
@@ -1377,7 +1377,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithRequiredClaims() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setRequiredClaims("sub, aud")
@@ -1394,7 +1394,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithExactMatchClaims() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setExactMatchClaims("sub=UnitTest, aud=Framework")
@@ -1411,7 +1411,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithAnyMatchClaims() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setAnyMatchClaims("aud=nomatch, sub=UnitTest")
@@ -1428,7 +1428,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenParsingWithExactAndAnyMatchClaims() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setExactMatchClaims("sub=UnitTest")
@@ -1446,7 +1446,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenMissingRequiredClaims() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setRequiredClaims("sub, aud, kid")
@@ -1462,7 +1462,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenUnexpectedValueForExactMatchClaim() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setExactMatchClaims("sub=UnitTest, aud=test")
@@ -1478,7 +1478,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenNoMatchForAnyMatchClaim() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setAnyMatchClaims("sub=test, aud=test")
@@ -1494,7 +1494,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenWithRoleClaim() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setRoleClaim("sub")
@@ -1510,7 +1510,7 @@ public class ApiListenerServletTest extends Mockito {
 
 	@Test
 	public void testJwtTokenWithRoleClaimAndEmptyAuthRoles() throws Exception {
-		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(Methods.GET))
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
 			.setRequiredIssuer("JWTPipeTest")
 			.setRoleClaim("sub")
@@ -1717,18 +1717,6 @@ public class ApiListenerServletTest extends Mockito {
 
 		private final ApiListener listener;
 		private MessageHandler handler;
-
-		public ApiListenerBuilder(String uri, Methods method) throws ListenerException, ConfigurationException {
-			this(uri, method, null, null);
-		}
-
-		public ApiListenerBuilder(String uri, Methods method, AuthMethods authMethod) throws ListenerException, ConfigurationException {
-			this(uri, Arrays.asList(method), null, null, authMethod,null);
-		}
-
-		public ApiListenerBuilder(String uri, Methods method, MediaTypes consumes, MediaTypes produces) throws ListenerException, ConfigurationException {
-			this(uri, Arrays.asList(method), consumes, produces, null, null);
-		}
 
 		public ApiListenerBuilder(String uri, List<Methods> method) throws ListenerException, ConfigurationException {
 			this(uri, method, null, null);

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package org.frankframework.http.rest;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,9 +27,12 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.ListenerException;
 import org.frankframework.http.rest.ApiListener.AuthenticationMethods;
 import org.frankframework.http.rest.ApiListener.HttpMethod;
 import org.frankframework.lifecycle.DynamicRegistration.Servlet;
@@ -257,5 +261,134 @@ public class ApiListenerTest {
 		listener.setProduces(MediaTypes.XML);
 		listener.configure();
 		assertEquals("uriPattern: [/aap, /noot]/dummy; method: PUT; consumes: JSON; produces: XML", listener.getPhysicalDestinationName());
+	}
+
+	@Test
+	public void testValidatingMissingUriPattern() {
+		// Given
+		listener.setUriPattern("");
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "uriPattern cannot be empty");
+	}
+
+	@Test
+	public void testValidatingMissingJwksURL() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "jwksUrl cannot be empty");
+	}
+
+	@Test
+	public void testCannotConsumeGET(){
+		// Given
+		listener.setMethod(HttpMethod.GET.name());
+		listener.setConsumes(MediaTypes.JSON);
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "cannot set consumes attribute when using method [GET]");
+	}
+
+	@Test
+	public void testCannotConsumeGETMultiMethod(){
+		// Given
+		listener.setMethod(methodsAsString(HttpMethod.GET, HttpMethod.POST));
+		listener.setConsumes(MediaTypes.JSON);
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "cannot set consumes attribute when using method [GET]");
+	}
+
+	@Test
+	public void testCannotConsumeDELETE(){
+		// Given
+		listener.setMethod(HttpMethod.DELETE.name());
+		listener.setConsumes(MediaTypes.JSON);
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "cannot set consumes attribute when using method [DELETE]");
+	}
+
+	@Test
+	public void testCannotConsumeDELETEMultiMethod(){
+		// Given
+		listener.setMethod(methodsAsString(HttpMethod.DELETE, HttpMethod.POST));
+		listener.setConsumes(MediaTypes.JSON);
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "cannot set consumes attribute when using method [DELETE]");
+	}
+
+	@Test
+	public void testValidatingAnyMatchClaims() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setAnyMatchClaims("claim=value,claim2=value2");
+
+		// Expect/When
+		assertDoesNotThrow(() -> listener.configure());
+	}
+
+	@Test
+	public void testValidatingAnyMatchClaimsInvalid() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setAnyMatchClaims("claim=value,claim2,claim3=value=too_long");
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "[claim2,claim3=value=too_long] are not valid key/value pairs for [anyMatchClaims].");
+	}
+
+	@Test
+	public void testValidatingAnyMatchClaimsOneInvalid() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setAnyMatchClaims("claim2");
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "[claim2] is not a valid key/value pair for [anyMatchClaims].");
+	}
+
+	@Test
+	public void testValidatingExactMatchClaims() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setExactMatchClaims("claim=value,claim2=value2");
+
+		// Expect/When
+		assertDoesNotThrow(() -> listener.configure());
+	}
+
+	@Test
+	public void testValidatingExactMatchClaimsInvalid() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setExactMatchClaims("claim=value,claim2,claim3=value=too_long");
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "[claim2,claim3=value=too_long] are not valid key/value pairs for [exactMatchClaims].");
+	}
+
+	@Test
+	public void testValidatingExactMatchClaimsOneInvalid() {
+		// Given
+		listener.setAuthenticationMethod(AuthenticationMethods.JWT);
+		listener.setJwksURL("dummy");
+		listener.setExactMatchClaims("claim2");
+
+		// Expect/When
+		assertThrows(ConfigurationException.class, () -> listener.configure(), "[claim2] is not a valid key/value pair for [exactMatchClaims].");
+	}
+
+
+	private String methodsAsString(HttpMethod ...args){
+		return Arrays.stream(args).map(m -> m.name()).collect(Collectors.joining(","));
 	}
 }

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
@@ -45,13 +45,13 @@ public class ApiListenerTest {
 	public void setUp() {
 		listener = new ApiListener();
 		listener.setName("my-api-listener");
-		listener.setMethod(HttpMethod.PUT);
+		listener.setMethod(HttpMethod.PUT.name());
 		listener.setUriPattern("dummy");
 	}
 
 	@Test
 	public void testOptionsMethod() {
-		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> listener.setMethod(HttpMethod.OPTIONS));
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> listener.setMethod(HttpMethod.OPTIONS.name()));
 		assertEquals("method OPTIONS should not be added manually", ex.getMessage());
 	}
 

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.ListenerException;
 import org.frankframework.http.rest.ApiListener.AuthenticationMethods;
 import org.frankframework.http.rest.ApiListener.HttpMethod;
 import org.frankframework.lifecycle.DynamicRegistration.Servlet;

--- a/core/src/test/java/org/frankframework/http/rest/ApiServiceDispatcherTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiServiceDispatcherTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -83,7 +82,7 @@ public class ApiServiceDispatcherTest {
 	}
 
 	private ApiListener createServiceClient(ApiListenerServletTest.Methods method, String uri) {
-		return createServiceClient(Arrays.asList(method), uri);
+		return createServiceClient(List.of(method), uri);
 	}
 
 	private ApiListener createServiceClient(List<ApiListenerServletTest.Methods> method, String uri) {
@@ -110,7 +109,7 @@ public class ApiServiceDispatcherTest {
 	@Test
 	void testMultipleMethodsSameEndpointSameListener() throws Exception {
 		String uri = "testEndpoint1";
-		dispatcher.registerServiceClient(createServiceClient(Arrays.asList(ApiListenerServletTest.Methods.GET, ApiListenerServletTest.Methods.POST), uri));
+		dispatcher.registerServiceClient(createServiceClient(List.of(ApiListenerServletTest.Methods.GET, ApiListenerServletTest.Methods.POST), uri));
 		testMultipleMethods(uri);
 	}
 

--- a/core/src/test/java/org/frankframework/http/rest/OpenApiTestBase.java
+++ b/core/src/test/java/org/frankframework/http/rest/OpenApiTestBase.java
@@ -174,7 +174,7 @@ public class OpenApiTestBase extends Mockito {
 		}
 		public AdapterBuilder setListener(String uriPattern, String method, String produces, String operationId) {
 			listener = new ApiListener();
-			if (method!=null) listener.setMethod(EnumUtils.parse(HttpMethod.class,method));
+			if (method!=null) listener.setMethod(EnumUtils.parse(HttpMethod.class,method).name());
 			listener.setUriPattern(uriPattern);
 			if (produces!=null) listener.setProduces(EnumUtils.parse(MediaTypes.class,produces));
 			if(StringUtils.isNotEmpty(operationId)) {

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
@@ -63,7 +63,7 @@ public class TestWebServices extends BusTestBase {
 		Adapter adapter = SpringUtils.createBean(configuration, Adapter.class);
 		adapter.setName("ApiTestAdapter");
 		ApiListener listener = new ApiListener();
-		listener.setMethod(HttpMethod.POST);
+		listener.setMethod(HttpMethod.POST.name());
 		listener.setUriPattern(API_LISTENER_ENDPOINT);
 		Receiver receiver = new Receiver();
 		receiver.setName("ReceiverName2");


### PR DESCRIPTION
closes #5443 once implemented.

first draft, new test cases proof that ApiListener is succesfully registered with multiple methods.

might want to add more test cases to proof the added functionality.

open to suggestions for improvement