### PR TITLE
Move user JAVA_OPTS to back so defaults can be overwritten

### DIFF
--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -2,8 +2,9 @@
 set -e
 
 # Append HeapDump and GC properties to existing JAVA_OPTS
-export JAVA_OPTS="$JAVA_OPTS \
+export JAVA_OPTS="\
 	-XX:HeapDumpPath=/usr/local/tomcat/logs \
-	-XX:+HeapDumpOnOutOfMemoryError"
+	-XX:+HeapDumpOnOutOfMemoryError \
+	$JAVA_OPTS"
 
 exec "$@"


### PR DESCRIPTION
This makes it possible to change the JAVA_OPTS attributes in the Docker image if needed.
On Kubernetes this is needed to change the location of the heap dump.

