### PR TITLE
v8.0-branch - SoapWrapper should try unwrapping with soap version 1.1 too (#6032)

### DIFF
--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -39,8 +39,13 @@ import org.apache.wss4j.dom.message.WSSecSignature;
 import org.apache.wss4j.dom.message.WSSecTimestamp;
 import org.apache.wss4j.dom.message.WSSecUsernameToken;
 import org.apache.xml.security.algorithms.JCEMapper;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.SenderException;
+import org.frankframework.stream.Message;
 import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.LogUtil;
+import org.frankframework.util.StreamUtil;
 import org.frankframework.util.TransformerPool;
 import org.frankframework.util.XmlUtils;
 import org.w3c.dom.Document;
@@ -48,12 +53,6 @@ import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import lombok.Setter;
-
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.PipeLineSession;
-import org.frankframework.core.SenderException;
-import org.frankframework.stream.Message;
-import org.frankframework.util.StreamUtil;
 
 /**
  * Utility class that wraps and unwraps messages from (and into) a SOAP Envelope.
@@ -168,6 +167,10 @@ public class SoapWrapper {
 		String extractedMessage;
 		if (soapVersion == SoapVersion.SOAP12) {
 			extractedMessage = transformerS12.transform(message.asSource());
+			// If session had the wrong SOAP version stored (e.g. multiple SoapWrappers), try SOAP 1.1 too. (#6032)
+			if (StringUtils.isEmpty(extractedMessage)) {
+				extractedMessage = transformerS11.transform(message.asSource());
+			}
 		} else if (soapVersion == SoapVersion.NONE) {
 			return null;
 		} else {
@@ -198,6 +201,7 @@ public class SoapWrapper {
 		if (session == null) return null;
 		Object soapVersionObject = session.getOrDefault(SoapWrapper.SOAP_VERSION_SESSION_KEY, null);
 		if (soapVersionObject instanceof SoapVersion) {
+			log.debug("Found SOAP version in session: {}", ((SoapVersion) soapVersionObject).name());
 			return (SoapVersion) soapVersionObject;
 		}
 		return null;

--- a/core/src/main/java/org/frankframework/soap/SoapWrapperPipe.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapperPipe.java
@@ -21,13 +21,9 @@ import java.util.Map;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.util.CredentialFactory;
-import org.frankframework.util.TransformerPool;
-import org.frankframework.util.XmlUtils;
-import org.xml.sax.SAXException;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarnings;
+import org.frankframework.configuration.SuppressKeys;
 import org.frankframework.core.IWrapperPipe;
 import org.frankframework.core.PipeLine;
 import org.frankframework.core.PipeLineSession;
@@ -37,6 +33,12 @@ import org.frankframework.core.PipeStartException;
 import org.frankframework.doc.Default;
 import org.frankframework.pipes.FixedForwardPipe;
 import org.frankframework.stream.Message;
+import org.frankframework.util.CredentialFactory;
+import org.frankframework.util.TransformerPool;
+import org.frankframework.util.XmlUtils;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
 
 /**
  * Pipe to wrap or unwrap a message from/into a SOAP Envelope.
@@ -84,6 +86,10 @@ public class SoapWrapperPipe extends FixedForwardPipe implements IWrapperPipe {
 	public void configure() throws ConfigurationException {
 		super.configure();
 		soapWrapper = SoapWrapper.getInstance();
+		if (getDirection() == Direction.UNWRAP && soapVersion != null) {
+			ConfigurationWarnings.add(this, log, "SoapWrapperPipe does NOT support unwrapping with a specified SoapVersion. " +
+					"It is auto-detected: remove soapVersion property from wrapper.", SuppressKeys.CONFIGURATION_VALIDATION);
+		}
 		if (getDirection() == Direction.UNWRAP && PipeLine.INPUT_WRAPPER_NAME.equals(getName())) {
 			if (StringUtils.isEmpty(getSoapHeaderSessionKey())) {
 				setSoapHeaderSessionKey(DEFAULT_SOAP_HEADER_SESSION_KEY);
@@ -270,6 +276,7 @@ public class SoapWrapperPipe extends FixedForwardPipe implements IWrapperPipe {
 
 	protected Message wrapMessage(Message message, String soapHeader, PipeLineSession session) throws IOException {
 		String soapNamespace = determineSoapNamespace(session);
+		log.debug("Using SOAP namespace [{}] for Wrapping message", soapNamespace);
 		if (soapNamespace == null) {
 			return message;
 		}

--- a/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
@@ -1,11 +1,5 @@
 package org.frankframework.pipes;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import javax.xml.soap.SOAPConstants;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IWrapperPipe.Direction;
 import org.frankframework.core.PipeForward;
@@ -22,6 +16,13 @@ import org.frankframework.soap.SoapWrapperPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.TestAssertions;
 import org.junit.jupiter.api.Test;
+
+import javax.xml.soap.SOAPConstants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase<P> {
 
@@ -70,7 +71,7 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		pipe.setRemoveOutputNamespaces(true);
 		configureAndStartPipe();
 
-		P wrapPipeSoap = createWrapperSoapPipe(SoapVersion.SOAP11);
+		P wrapPipeSoap = createWrapperSoapPipe(SoapVersion.SOAP11, true);
 
 		// Arrange
 		String inputSoap12 = "<soapenv:Envelope xmlns:soapenv=\"" + SOAPConstants.URI_NS_SOAP_1_2_ENVELOPE + "\"><soapenv:Body>" + DEFAULT_BODY_END;
@@ -96,7 +97,7 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		pipe.configure();
 		pipe.start();
 
-		P wrapPipeSoap = createWrapperSoapPipe(SoapVersion.SOAP12);
+		P wrapPipeSoap = createWrapperSoapPipe(SoapVersion.SOAP12, true);
 
 		// Arrange
 		String inputSoap11 = "<soapenv:Envelope xmlns:soapenv=\"" + SOAPConstants.URI_NS_SOAP_1_1_ENVELOPE + "\"><soapenv:Body>" + DEFAULT_BODY_END;
@@ -113,19 +114,6 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		assertTrue(actual.contains(SOAPConstants.URI_NS_SOAP_1_2_ENVELOPE));
 		pipeLineSession.close();
 		wrapPipeSoap.stop();
-	}
-
-	private P createWrapperSoapPipe(final SoapVersion soapVersion) throws ConfigurationException, PipeStartException {
-		P wrapPipeSoap = createPipe();
-		wrapPipeSoap.setDirection(Direction.WRAP);
-		autowireByType(wrapPipeSoap);
-		wrapPipeSoap.registerForward(new PipeForward("success", "READY"));
-		wrapPipeSoap.setName(PipeLine.OUTPUT_WRAPPER_NAME);
-		wrapPipeSoap.setSoapVersion(soapVersion);
-		pipeline.addPipe(wrapPipeSoap);
-		wrapPipeSoap.configure();
-		wrapPipeSoap.start();
-		return wrapPipeSoap;
 	}
 
 	@Test
@@ -463,8 +451,8 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 	@Test
 	void shouldUseConfiguredPipelineSoapVersion11() throws Exception {
 		// Arrange: Simulate soapOutputWrapper having soap version 1.1 (expecting soap 1.1 namespace in the output)
-		setupUnwrapAutoPipe();
-		P outputWrapper = createWrapperSoapPipe(SoapVersion.SOAP11);
+		setupUnwrapSoapPipe(SoapVersion.AUTO, true);
+		P outputWrapper = createWrapperSoapPipe(SoapVersion.SOAP11, true);
 
 		// Act: message through unwrap & wrap pipes
 		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap12), session);
@@ -483,8 +471,8 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 	@Test
 	void shouldUseConfiguredPipelineSoapVersion12() throws Exception {
 		// Arrange: Simulate soapOutputWrapper having soap version 1.2 (expecting soap 1.2 namespace in the output)
-		setupUnwrapAutoPipe();
-		P outputWrapper = createWrapperSoapPipe(SoapVersion.SOAP12);
+		setupUnwrapSoapPipe(SoapVersion.AUTO, true);
+		P outputWrapper = createWrapperSoapPipe(SoapVersion.SOAP12, true);
 		session = new PipeLineSession();
 
 		// Act: message SOAP11 through unwrap & wrap pipes
@@ -501,8 +489,8 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 	@Test
 	void shouldUseConfiguredPipelineSoapVersionAuto() throws Exception {
 		// Arrange: Wrapper pipe SoapVersion not set. Should go to AUTO.
-		setupUnwrapAutoPipe();
-		P outputWrapper = createWrapperSoapPipe(null);
+		setupUnwrapSoapPipe(SoapVersion.AUTO, true);
+		P outputWrapper = createWrapperSoapPipe(null, true);
 		session = new PipeLineSession();
 
 		// Act: message SOAP12 through unwrap & wrap pipes
@@ -516,13 +504,80 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		outputWrapper.stop();
 	}
 
-	private void setupUnwrapAutoPipe() throws ConfigurationException, PipeStartException {
-		// Arrange - Simulate soapInputWrapper unwrapping the input and creating soapNamespace sessionKey using the namespace from the input
+	@Test
+	void shouldUnwrapEvenThoughSessionHasDifferentSoapVersionStored() throws Exception {
+		// Scenario:
+		// <inputWrapper direction="UNWRAP" storeResultInSessionKey="originalMessage"/> Note: input=1.2, stored version in session
+		// <inputWrapper soapVersion="1.1"> Note: output=1.1
+		// <outputWrapper direction="UNWRAP" removeOutputNamespaces="true" soapVersion="1.1"/> Note: input=1.1, should be unwrapped fine with 1.1
+
+		// Arrange: inputWrapper 1 - unwrap
+		setupUnwrapSoapPipe(SoapVersion.AUTO, false);
 		pipe.setDirection(Direction.UNWRAP);
-		pipe.setSoapVersion(SoapVersion.AUTO);
-		pipe.setName(PipeLine.INPUT_WRAPPER_NAME);
+		pipe.setStoreResultInSessionKey("originalMessage");
 		pipe.configure();
 		pipe.start();
+
+		// Arrange: inputWrapper 2 - wrap
+		P outputWrapper = createPipe();
+		autowireByType(outputWrapper);
+		outputWrapper.registerForward(new PipeForward("success", PipeLine.OUTPUT_WRAPPER_NAME + "2"));
+		outputWrapper.setName(PipeLine.OUTPUT_WRAPPER_NAME + "1");
+		outputWrapper.setSoapVersion(SoapVersion.SOAP11);
+		pipeline.addPipe(outputWrapper);
+		outputWrapper.configure();
+		outputWrapper.start();
+
+		// Arrange: outputWrapper 2 - unwrap
+		P outputWrapper2 = createWrapperSoapPipe(SoapVersion.SOAP11, false);
+		outputWrapper2.setName(PipeLine.OUTPUT_WRAPPER_NAME + "2");
+		outputWrapper2.setDirection(Direction.UNWRAP);
+		outputWrapper2.setRemoveOutputNamespaces(true);
+		outputWrapper2.registerForward(new PipeForward("success", "READY"));
+		outputWrapper2.configure();
+		outputWrapper2.start();
+		pipeline.addPipe(outputWrapper2);
+
+		session = new PipeLineSession();
+
+		// Act: message SOAP12 through pipes
+		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap12), session);
+		PipeRunResult pipeRunResult2 = doPipe(outputWrapper, pipeRunResult1.getResult(), session);
+		PipeRunResult pipeRunResult3 = doPipe(outputWrapper2, pipeRunResult2.getResult(), session);
+
+		// Assert: but the output is without SOAP namespaces, as it is unwrapped.
+		String result = pipeRunResult3.getResult().asString();
+		assertNotNull(result);
+		assertFalse(result.contains(SoapVersion.SOAP11.namespace), "result should be unwrapped for sure");
+		assertFalse(result.contains(SoapVersion.SOAP12.namespace), "result should be unwrapped for sure");
+		assertTrue(result.contains("FindDocuments_Response"), "result should contain original message, without namespaces");
+		outputWrapper.stop();
+	}
+
+	private P createWrapperSoapPipe(final SoapVersion soapVersion, boolean started) throws ConfigurationException, PipeStartException {
+		P wrapPipeSoap = createPipe();
+		wrapPipeSoap.setDirection(Direction.WRAP);
+		autowireByType(wrapPipeSoap);
+		wrapPipeSoap.registerForward(new PipeForward("success", "READY"));
+		wrapPipeSoap.setName(PipeLine.OUTPUT_WRAPPER_NAME);
+		wrapPipeSoap.setSoapVersion(soapVersion);
+		pipeline.addPipe(wrapPipeSoap);
+		if (started) {
+			wrapPipeSoap.configure();
+			wrapPipeSoap.start();
+		}
+		return wrapPipeSoap;
+	}
+
+	private void setupUnwrapSoapPipe(final SoapVersion soapVersion, boolean started) throws ConfigurationException, PipeStartException {
+		// Arrange - Simulate soapInputWrapper unwrapping the input and creating soapNamespace sessionKey using the namespace from the input
+		pipe.setDirection(Direction.UNWRAP);
+		pipe.setSoapVersion(soapVersion);
+		pipe.setName(PipeLine.INPUT_WRAPPER_NAME);
+		if (started) {
+			pipe.configure();
+			pipe.start();
+		}
 	}
 
 }


### PR DESCRIPTION
* Prevents bug of reusing stored SoapVersion from previous SoapWrappers