### PR TITLE
v7.9-branch - SoapWrapper should try unwrapping with soap version 1.1 too (#6032)

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/soap/SoapWrapper.java
+++ b/core/src/main/java/nl/nn/adapterframework/soap/SoapWrapper.java
@@ -168,6 +168,10 @@ public class SoapWrapper {
 		String extractedMessage;
 		if (soapVersion == SoapVersion.SOAP12) {
 			extractedMessage = transformerS12.transform(message.asSource());
+			// If session had the wrong SOAP version stored (e.g. multiple SoapWrappers), try SOAP 1.1 too. (#6032)
+			if (StringUtils.isEmpty(extractedMessage)) {
+				extractedMessage = transformerS11.transform(message.asSource());
+			}
 		} else if (soapVersion == SoapVersion.NONE) {
 			return null;
 		} else {
@@ -198,6 +202,7 @@ public class SoapWrapper {
 		if (session == null) return null;
 		Object soapVersionObject = session.getOrDefault(SoapWrapper.SOAP_VERSION_SESSION_KEY, null);
 		if (soapVersionObject instanceof SoapVersion) {
+			log.debug("Found SOAP version in session: {}", ((SoapVersion) soapVersionObject).name());
 			return (SoapVersion) soapVersionObject;
 		}
 		return null;

--- a/core/src/main/java/nl/nn/adapterframework/soap/SoapWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/soap/SoapWrapperPipe.java
@@ -25,6 +25,8 @@ import org.xml.sax.SAXException;
 
 import lombok.Getter;
 import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.configuration.ConfigurationWarnings;
+import nl.nn.adapterframework.configuration.SuppressKeys;
 import nl.nn.adapterframework.core.IWrapperPipe;
 import nl.nn.adapterframework.core.PipeLine;
 import nl.nn.adapterframework.core.PipeLineSession;
@@ -85,6 +87,10 @@ public class SoapWrapperPipe extends FixedForwardPipe implements IWrapperPipe {
 	public void configure() throws ConfigurationException {
 		super.configure();
 		soapWrapper = SoapWrapper.getInstance();
+		if (getDirection() == Direction.UNWRAP && soapVersion != null) {
+			ConfigurationWarnings.add(this, log, "SoapWrapperPipe does NOT support unwrapping with a specified SoapVersion. " +
+					"It is auto-detected: remove soapVersion property from wrapper.", SuppressKeys.CONFIGURATION_VALIDATION);
+		}
 		if (getDirection() == Direction.UNWRAP && PipeLine.INPUT_WRAPPER_NAME.equals(getName())) {
 			if (StringUtils.isEmpty(getSoapHeaderSessionKey())) {
 				setSoapHeaderSessionKey(DEFAULT_SOAP_HEADER_SESSION_KEY);
@@ -284,6 +290,7 @@ public class SoapWrapperPipe extends FixedForwardPipe implements IWrapperPipe {
 
 	protected Message wrapMessage(Message message, String soapHeader, PipeLineSession session) throws IOException {
 		String soapNamespace = determineSoapNamespace(session);
+		log.debug("Using SOAP namespace [{}] for Wrapping message", soapNamespace);
 		if (soapNamespace == null) {
 			return message;
 		}


### PR DESCRIPTION
* Prevents bug of reusing stored SoapVersion from previous SoapWrappers