### PR TITLE
Close CMIS HTTP Client properly to avoid leaking threads

### DIFF
--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomAtomPubSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomAtomPubSpi.java
@@ -18,12 +18,12 @@ package nl.nn.adapterframework.extensions.cmis;
 import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
 
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
-import org.apache.chemistry.opencmis.client.bindings.spi.webservices.CmisWebServicesSpi;
+import org.apache.chemistry.opencmis.client.bindings.spi.atompub.CmisAtomPubSpi;
 
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
+public class CmisCustomAtomPubSpi extends CmisAtomPubSpi {
 	private final BindingSession bindingSession;
 
 	/**
@@ -31,9 +31,9 @@ public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
 	 *
 	 * @param session
 	 */
-	public CmisCustomWebServicesSpi(BindingSession session) {
+	public CmisCustomAtomPubSpi(BindingSession session) {
 		super(session);
-		log.warn("Creating instance of {}", getClass().getSimpleName());
+		log.warn("Creating instance of [{}]", getClass().getSimpleName());
 		this.bindingSession = session;
 	}
 

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomAtomPubSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomAtomPubSpi.java
@@ -15,8 +15,6 @@
  */
 package nl.nn.adapterframework.extensions.cmis;
 
-import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
-
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
 import org.apache.chemistry.opencmis.client.bindings.spi.atompub.CmisAtomPubSpi;
 
@@ -33,21 +31,13 @@ public class CmisCustomAtomPubSpi extends CmisAtomPubSpi {
 	 */
 	public CmisCustomAtomPubSpi(BindingSession session) {
 		super(session);
-		log.warn("Creating instance of [{}]", getClass().getSimpleName());
+		log.debug("Creating instance of [{}]", getClass().getSimpleName());
 		this.bindingSession = session;
 	}
 
 	@Override
 	public void close() {
-		log.warn("Closing {}", getClass().getSimpleName());
-		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
-		if (invoker instanceof CmisHttpInvoker) {
-			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;
-			log.warn("Closing CMIS Invoker {}", cmisHttpInvoker);
-			cmisHttpInvoker.close();
-		} else {
-			log.warn("{} does not have instance of CmisHttpInvoker: {}", getClass().getSimpleName(), invoker);
-		}
+		CmisUtils.closeBindingSession(this, bindingSession);
 		super.close();
 	}
 }

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomBrowserBindingSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomBrowserBindingSpi.java
@@ -18,12 +18,12 @@ package nl.nn.adapterframework.extensions.cmis;
 import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
 
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
-import org.apache.chemistry.opencmis.client.bindings.spi.webservices.CmisWebServicesSpi;
+import org.apache.chemistry.opencmis.client.bindings.spi.browser.CmisBrowserBindingSpi;
 
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
-public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
+public class CmisCustomBrowserBindingSpi extends CmisBrowserBindingSpi {
 	private final BindingSession bindingSession;
 
 	/**
@@ -31,9 +31,9 @@ public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
 	 *
 	 * @param session
 	 */
-	public CmisCustomWebServicesSpi(BindingSession session) {
+	public CmisCustomBrowserBindingSpi(BindingSession session) {
 		super(session);
-		log.warn("Creating instance of {}", getClass().getSimpleName());
+		log.warn("Creating instance of [{}]", getClass().getSimpleName());
 		this.bindingSession = session;
 	}
 

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomBrowserBindingSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomBrowserBindingSpi.java
@@ -15,8 +15,6 @@
  */
 package nl.nn.adapterframework.extensions.cmis;
 
-import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
-
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
 import org.apache.chemistry.opencmis.client.bindings.spi.browser.CmisBrowserBindingSpi;
 
@@ -33,21 +31,13 @@ public class CmisCustomBrowserBindingSpi extends CmisBrowserBindingSpi {
 	 */
 	public CmisCustomBrowserBindingSpi(BindingSession session) {
 		super(session);
-		log.warn("Creating instance of [{}]", getClass().getSimpleName());
+		log.debug("Creating instance of [{}]", getClass().getSimpleName());
 		this.bindingSession = session;
 	}
 
 	@Override
 	public void close() {
-		log.warn("Closing {}", getClass().getSimpleName());
-		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
-		if (invoker instanceof CmisHttpInvoker) {
-			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;
-			log.warn("Closing CMIS Invoker {}", cmisHttpInvoker);
-			cmisHttpInvoker.close();
-		} else {
-			log.warn("{} does not have instance of CmisHttpInvoker: {}", getClass().getSimpleName(), invoker);
-		}
+		CmisUtils.closeBindingSession(this, bindingSession);
 		super.close();
 	}
 }

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
@@ -1,0 +1,30 @@
+package nl.nn.adapterframework.extensions.cmis;
+
+import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
+
+import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
+import org.apache.chemistry.opencmis.client.bindings.spi.webservices.CmisWebServicesSpi;
+
+public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
+	private final BindingSession bindingSession;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param session
+	 */
+	public CmisCustomWebServicesSpi(BindingSession session) {
+		super(session);
+		this.bindingSession = session;
+	}
+
+	@Override
+	public void close() {
+		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
+		if (invoker instanceof CmisHttpInvoker) {
+			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;
+			cmisHttpInvoker.close();
+		}
+		super.close();
+	}
+}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
@@ -20,6 +20,9 @@ import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHel
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
 import org.apache.chemistry.opencmis.client.bindings.spi.webservices.CmisWebServicesSpi;
 
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
 public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
 	private final BindingSession bindingSession;
 
@@ -30,15 +33,20 @@ public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
 	 */
 	public CmisCustomWebServicesSpi(BindingSession session) {
 		super(session);
+		log.warn("Creating instance of CmisCustomWebServicesSpi");
 		this.bindingSession = session;
 	}
 
 	@Override
 	public void close() {
+		log.warn("Closing CmisCustomWebServicesSpi");
 		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
 		if (invoker instanceof CmisHttpInvoker) {
 			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;
+			log.warn("Closing CMIS Invoker {}", cmisHttpInvoker);
 			cmisHttpInvoker.close();
+		} else {
+			log.warn("CmisCustomWebServicesSpi does not have instance of CmisHttpInvoker: {}", invoker);
 		}
 		super.close();
 	}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
@@ -15,8 +15,6 @@
  */
 package nl.nn.adapterframework.extensions.cmis;
 
-import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;
-
 import org.apache.chemistry.opencmis.client.bindings.spi.BindingSession;
 import org.apache.chemistry.opencmis.client.bindings.spi.webservices.CmisWebServicesSpi;
 
@@ -33,21 +31,13 @@ public class CmisCustomWebServicesSpi extends CmisWebServicesSpi {
 	 */
 	public CmisCustomWebServicesSpi(BindingSession session) {
 		super(session);
-		log.warn("Creating instance of {}", getClass().getSimpleName());
+		log.debug("Creating instance of {}", getClass().getSimpleName());
 		this.bindingSession = session;
 	}
 
 	@Override
 	public void close() {
-		log.warn("Closing {}", getClass().getSimpleName());
-		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
-		if (invoker instanceof CmisHttpInvoker) {
-			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;
-			log.warn("Closing CMIS Invoker {}", cmisHttpInvoker);
-			cmisHttpInvoker.close();
-		} else {
-			log.warn("{} does not have instance of CmisHttpInvoker: {}", getClass().getSimpleName(), invoker);
-		}
+		CmisUtils.closeBindingSession(this, bindingSession);
 		super.close();
 	}
 }

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisCustomWebServicesSpi.java
@@ -1,3 +1,18 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
 package nl.nn.adapterframework.extensions.cmis;
 
 import static org.apache.chemistry.opencmis.client.bindings.impl.CmisBindingsHelper.HTTP_INVOKER_OBJECT;

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
@@ -33,34 +33,32 @@ import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisConnectionException;
 import org.apache.chemistry.opencmis.commons.impl.UrlBuilder;
 import org.apache.chemistry.opencmis.commons.spi.AuthenticationProvider;
-import org.apache.logging.log4j.Logger;
 
+import lombok.extern.log4j.Log4j2;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.SenderException;
 import nl.nn.adapterframework.encryption.KeystoreType;
 import nl.nn.adapterframework.http.HttpSenderBase.HttpMethod;
 import nl.nn.adapterframework.parameters.Parameter;
 import nl.nn.adapterframework.util.EnumUtils;
-import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.StreamUtil;
 
+@Log4j2
 public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
-
-	private Logger log = LogUtil.getLogger(CmisHttpInvoker.class);
 
 	private CmisHttpSender sender = null;
 
 	//To stub during testing
 	protected CmisHttpSender createSender() {
 		CmisHttpSender cmisHttpSender = new CmisHttpSender() {};
-		log.warn("CmisHttpInvoker [{}] created new CmisHttpSender [{}]", this, cmisHttpSender);
+		log.debug("CmisHttpInvoker [{}] created new CmisHttpSender [{}]", this, cmisHttpSender);
 		return cmisHttpSender;
 	}
 
 	@Override
 	public void close() {
 		if (sender != null) {
-			log.warn("Closing CmisHttpSender [{}] from CmisHttpInvoker [{}]", sender, this);
+			log.debug("Closing CmisHttpSender [{}] from CmisHttpInvoker [{}]", sender, this);
 			try {
 				sender.close();
 			} catch (SenderException e) {
@@ -68,7 +66,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 			}
 			sender = null;
 		} else {
-			log.warn("Closing CmisHttpInvoker [{}] but does not have a sender to close", this);
+			log.debug("Closing CmisHttpInvoker [{}] but does not have a sender to close", this);
 		}
 	}
 
@@ -204,7 +202,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 			}
 		}
 
-		Response response = null;
+		Response response;
 
 		try {
 			sender = getInstance(session);
@@ -213,7 +211,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 
 			// init headers if not exist
 			if(headers == null)
-				headers = new HashMap<String, String>();
+				headers = new HashMap<>();
 
 			if (contentType != null)
 				headers.put("Content-Type", contentType);
@@ -228,11 +226,11 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 					offset = BigInteger.ZERO;
 				}
 
-				sb.append(offset.toString());
+				sb.append(offset);
 				sb.append('-');
 
 				if (length != null && length.signum() == 1) {
-					sb.append(offset.add(length.subtract(BigInteger.ONE)).toString());
+					sb.append(offset.add(length.subtract(BigInteger.ONE)));
 				}
 
 				headers.put("Range", sb.toString());
@@ -271,7 +269,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 				}
 			}
 
-			log.trace("invoking CmisHttpSender: content-type["+contentType+"] headers["+headers.toString()+"]");
+			log.trace("invoking CmisHttpSender: content-type[{}] headers[{}]", contentType, headers);
 
 			response = sender.invoke(method, url.toString(), headers, writer, session);
 		} catch (Exception e) {
@@ -279,7 +277,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 			throw new CmisConnectionException(url.toString(), -1, e);
 		}
 
-		log.trace("received result code["+response.getResponseCode()+"] headers["+response.getHeaders().toString()+"]");
+		log.trace("received result code[{}] headers[{}]", response::getResponseCode, response::getHeaders);
 		return response;
 	}
 }

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
@@ -192,7 +192,7 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 
 		if(url.toString().equals(CmisSessionBuilder.OVERRIDE_WSDL_URL)) {
 			try {
-				Map<String, List<String>> headerFields = new HashMap<String, List<String>>();
+				Map<String, List<String>> headerFields = new HashMap<>();
 				String wsdl = (String) session.get(CmisSessionBuilder.OVERRIDE_WSDL_KEY);
 				InputStream inputStream = new ByteArrayInputStream(wsdl.getBytes(StreamUtil.DEFAULT_INPUT_STREAM_ENCODING));
 				return new Response(200, "ok", headerFields, inputStream, null);

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2018 Nationale-Nederlanden, 2021 - 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
@@ -44,7 +44,7 @@ import nl.nn.adapterframework.util.EnumUtils;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.StreamUtil;
 
-public class CmisHttpInvoker implements HttpInvoker {
+public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 
 	private Logger log = LogUtil.getLogger(CmisHttpInvoker.class);
 
@@ -53,6 +53,18 @@ public class CmisHttpInvoker implements HttpInvoker {
 	//To stub during testing
 	protected CmisHttpSender createSender() {
 		return new CmisHttpSender() {};
+	}
+
+	@Override
+	public void close() {
+		if (sender != null) {
+			try {
+				sender.close();
+			} catch (SenderException e) {
+				log.warn("Unexpected exception closing CmisHttpSender", e);
+			}
+			sender = null;
+		}
 	}
 
 	private CmisHttpSender getInstance(BindingSession session) throws SenderException, ConfigurationException {

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvoker.java
@@ -52,18 +52,23 @@ public class CmisHttpInvoker implements HttpInvoker, AutoCloseable {
 
 	//To stub during testing
 	protected CmisHttpSender createSender() {
-		return new CmisHttpSender() {};
+		CmisHttpSender cmisHttpSender = new CmisHttpSender() {};
+		log.warn("CmisHttpInvoker [{}] created new CmisHttpSender [{}]", this, cmisHttpSender);
+		return cmisHttpSender;
 	}
 
 	@Override
 	public void close() {
 		if (sender != null) {
+			log.warn("Closing CmisHttpSender [{}] from CmisHttpInvoker [{}]", sender, this);
 			try {
 				sender.close();
 			} catch (SenderException e) {
 				log.warn("Unexpected exception closing CmisHttpSender", e);
 			}
 			sender = null;
+		} else {
+			log.warn("Closing CmisHttpInvoker [{}] but does not have a sender to close", this);
 		}
 	}
 

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -347,6 +347,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 
 	private void closeCmisSession(Session session) {
 		log.warn("{} CMIS Session Close, SPI Binding class name: [{}]", getLogPrefix(), session.getSessionParameters().get(SessionParameter.BINDING_SPI_CLASS));
+		session.clear();
 		CmisBinding binding = session.getBinding();
 		if (binding != null) {
 			log.warn("{} Closing CMIS Bindings instance [{}:{}]", getLogPrefix(), binding.getClass().getSimpleName(), binding);
@@ -354,7 +355,6 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		} else {
 			log.warn("{} Session has no CMIS Bindings", getLogPrefix());
 		}
-		session.clear();
 	}
 
 	@Override

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -53,6 +53,7 @@ import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisNotSupportedException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
+import org.apache.chemistry.opencmis.commons.spi.CmisBinding;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
@@ -331,11 +332,19 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	}
 
 	@Override
-	public void close() throws SenderException {
+	public void close() {
 		if (globalSession != null) {
-			globalSession.clear();
+			closeCmisSession(globalSession);
 			globalSession = null;
 		}
+	}
+
+	private void closeCmisSession(Session session) {
+		CmisBinding binding = session.getBinding();
+		if (binding != null) {
+			binding.close();
+		}
+		session.clear();
 	}
 
 	@Override
@@ -378,7 +387,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 			}
 		} finally {
 			if (cmisSession != null && runtimeSession) {
-				cmisSession.clear();
+				closeCmisSession(cmisSession);
 				cmisSession = null;
 			}
 		}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -43,6 +43,7 @@ import org.apache.chemistry.opencmis.client.api.QueryResult;
 import org.apache.chemistry.opencmis.client.api.Session;
 import org.apache.chemistry.opencmis.client.api.Tree;
 import org.apache.chemistry.opencmis.commons.PropertyIds;
+import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.data.ContentStream;
 import org.apache.chemistry.opencmis.commons.data.ObjectInFolderList;
 import org.apache.chemistry.opencmis.commons.data.ObjectList;
@@ -267,6 +268,10 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		if(!isKeepSession()) {
 			runtimeSession = true;
 		}
+
+		if (runtimeSession) {
+			log.warn("{} using runtime session", getLogPrefix());
+		}
 	}
 
 	/**
@@ -334,15 +339,20 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	@Override
 	public void close() {
 		if (globalSession != null) {
+			log.warn("{} Closing global CMIS session", getLogPrefix());
 			closeCmisSession(globalSession);
 			globalSession = null;
 		}
 	}
 
 	private void closeCmisSession(Session session) {
+		log.warn("{} CMIS Session Close, SPI Binding class name: [{}]", getLogPrefix(), session.getSessionParameters().get(SessionParameter.BINDING_SPI_CLASS));
 		CmisBinding binding = session.getBinding();
 		if (binding != null) {
+			log.warn("{} Closing CMIS Bindings instance [{}:{}]", getLogPrefix(), binding.getClass().getSimpleName(), binding);
 			binding.close();
+		} else {
+			log.warn("{} Session has no CMIS Bindings", getLogPrefix());
 		}
 		session.clear();
 	}
@@ -387,6 +397,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 			}
 		} finally {
 			if (cmisSession != null && runtimeSession) {
+				log.warn("{} Closing CMIS runtime session", getLogPrefix());
 				closeCmisSession(cmisSession);
 				cmisSession = null;
 			}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -233,7 +233,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 
 	private Session globalSession;
 
-	private CmisSessionBuilder sessionBuilder = new CmisSessionBuilder(this);
+	private final CmisSessionBuilder sessionBuilder = new CmisSessionBuilder(this);
 
 	//TODO remove this when fileContentSessionKey gets removed
 	private boolean convert2Base64 = false;

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016-2019 Nationale-Nederlanden, 2020-2022 WeAreFrank
+   Copyright 2016-2019 Nationale-Nederlanden, 2020-2024 WeAreFrank
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -270,7 +270,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		}
 
 		if (runtimeSession) {
-			log.warn("{} using runtime session", getLogPrefix());
+			log.info("{} using runtime session", getLogPrefix());
 		}
 	}
 
@@ -339,21 +339,21 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	@Override
 	public void close() {
 		if (globalSession != null) {
-			log.warn("{} Closing global CMIS session", getLogPrefix());
+			log.debug("{} Closing global CMIS session", getLogPrefix());
 			closeCmisSession(globalSession);
 			globalSession = null;
 		}
 	}
 
 	private void closeCmisSession(Session session) {
-		log.warn("{} CMIS Session Close, SPI Binding class name: [{}]", getLogPrefix(), session.getSessionParameters().get(SessionParameter.BINDING_SPI_CLASS));
+		log.debug("{} CMIS Session Close, SPI Binding class name: [{}]", getLogPrefix(), session.getSessionParameters().get(SessionParameter.BINDING_SPI_CLASS));
 		session.clear();
 		CmisBinding binding = session.getBinding();
 		if (binding != null) {
-			log.warn("{} Closing CMIS Bindings instance [{}:{}]", getLogPrefix(), binding.getClass().getSimpleName(), binding);
+			log.debug("{} Closing CMIS Bindings instance [{}:{}]", getLogPrefix(), binding.getClass().getSimpleName(), binding);
 			binding.close();
 		} else {
-			log.warn("{} Session has no CMIS Bindings", getLogPrefix());
+			log.debug("{} Session has no CMIS Bindings", getLogPrefix());
 		}
 	}
 
@@ -397,7 +397,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 			}
 		} finally {
 			if (cmisSession != null && runtimeSession) {
-				log.warn("{} Closing CMIS runtime session", getLogPrefix());
+				log.debug("{} Closing CMIS runtime session", getLogPrefix());
 				closeCmisSession(cmisSession);
 				cmisSession = null;
 			}
@@ -409,7 +409,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 			throw new SenderException(getLogPrefix() + "input string cannot be empty but must contain a documentId");
 		}
 
-		CmisObject object = null;
+		CmisObject object;
 		try {
 			object = getCmisObject(cmisSession, message);
 		} catch (CmisObjectNotFoundException e) {
@@ -503,7 +503,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	}
 
 	private Message sendMessageForActionCreate(Session cmisSession, Message message, PipeLineSession session, ParameterValueList pvl) throws SenderException {
-		String fileName = null;
+		String fileName;
 		try {
 			fileName = session.getMessage( getParameterOverriddenAttributeValue(pvl, "filenameSessionKey", getFilenameSessionKey()) ).asString();
 		} catch (IOException e) {

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
@@ -144,11 +144,15 @@ public class CmisSessionBuilder {
 		if (getBindingType() == BindingTypes.ATOMPUB) {
 			parameterMap.setAtomPubBindingUrl(url);
 			parameterMap.setUsernameTokenAuthentication(false);
+			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomAtomPubSpi.class.getName());
+			log.warn("Added custom BINDING_SPI_CLASS CmisCustomAtomPubSpi to new CmisSession");
 		} else if (getBindingType() == BindingTypes.BROWSER) {
 			parameterMap.setBrowserBindingUrl(url);
 			parameterMap.setBasicAuthentication();
 			//Add parameter dateTimeFormat to send dates in ISO format instead of milliseconds.
 			parameterMap.put(SessionParameter.BROWSER_DATETIME_FORMAT, DateTimeFormat.EXTENDED.value());
+			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomBrowserBindingSpi.class.getName());
+			log.warn("Added custom BINDING_SPI_CLASS CmisCustomBrowserBindingSpi to new CmisSession");
 		} else {
 			parameterMap.setUsernameTokenAuthentication(true);
 			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomWebServicesSpi.class.getName());

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
@@ -116,7 +116,7 @@ public class CmisSessionBuilder {
 
 	/**
 	 * @param userName to connect or empty when no username
-	 * @param password 
+	 * @param password
 	 * @return a {@link Session} connected to the CMIS repository
 	 * @throws CmisSessionException when the CmisSessionBuilder fails to connect to cmis repository
 	 */
@@ -151,6 +151,8 @@ public class CmisSessionBuilder {
 			parameterMap.put(SessionParameter.BROWSER_DATETIME_FORMAT, DateTimeFormat.EXTENDED.value());
 		} else {
 			parameterMap.setUsernameTokenAuthentication(true);
+			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomWebServicesSpi.class.getName());
+
 			// OpenCMIS requires an entrypoint url (wsdl), if this url has been secured and is not publicly accessible,
 			// we can manually override this wsdl by reading it from the classpath.
 			//TODO: Does this work with any binding type?
@@ -192,8 +194,8 @@ public class CmisSessionBuilder {
 		//SSL
 		if (keystore!=null || truststore!=null || allowSelfSignedCertificates) {
 			CredentialFactory keystoreCf = new CredentialFactory(keystoreAuthAlias, null, keystorePassword);
-			CredentialFactory keystoreAliasCf = StringUtils.isNotEmpty(keystoreAliasAuthAlias) || StringUtils.isNotEmpty(keystoreAliasPassword) 
-							?  new CredentialFactory(keystoreAliasAuthAlias, null, keystoreAliasPassword) 
+			CredentialFactory keystoreAliasCf = StringUtils.isNotEmpty(keystoreAliasAuthAlias) || StringUtils.isNotEmpty(keystoreAliasPassword)
+							?  new CredentialFactory(keystoreAliasAuthAlias, null, keystoreAliasPassword)
 							: keystoreCf;
 			CredentialFactory truststoreCf = new CredentialFactory(truststoreAuthAlias,  null, truststorePassword);
 
@@ -229,7 +231,7 @@ public class CmisSessionBuilder {
 		if(timeout > 0)
 			parameterMap.put(SessionParameter.CONNECT_TIMEOUT, timeout);
 
-		// Custom IBIS HttpSender to support ssl connections and proxies
+		// Custom CMIS HttpSender to support ssl connections and proxies
 		parameterMap.setHttpInvoker(nl.nn.adapterframework.extensions.cmis.CmisHttpInvoker.class);
 
 		SessionFactory sessionFactory = SessionFactoryImpl.newInstance();
@@ -276,7 +278,7 @@ public class CmisSessionBuilder {
 		keystorePassword = string;
 		return this;
 	}
-	
+
 	public CmisSessionBuilder setKeyManagerAlgorithm(String keyManagerAlgorithm) {
 		this.keyManagerAlgorithm = keyManagerAlgorithm;
 		return this;
@@ -435,7 +437,7 @@ public class CmisSessionBuilder {
 			}
 		}).toString();
 	}
-	
+
 	public String getKeystore() {
 		return keystore;
 	}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Nationale-Nederlanden
+   Copyright 2019 Nationale-Nederlanden, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import org.apache.chemistry.opencmis.client.SessionParameterMap;
 import org.apache.chemistry.opencmis.client.api.Session;
 import org.apache.chemistry.opencmis.client.api.SessionFactory;
+import org.apache.chemistry.opencmis.client.bindings.CmisBindingFactory;
 import org.apache.chemistry.opencmis.client.runtime.SessionFactoryImpl;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.data.RepositoryInfo;
@@ -134,7 +135,7 @@ public class CmisSessionBuilder {
 			throw new CmisSessionException("illegal value for bindingtype [" + getBindingType() + "], overrideEntryPointWSDL only supports webservices");
 		}
 
-		log.debug("connecting to url ["+ url +"] repository ["+ repository +"]");
+		log.debug("connecting to url [{}] repository [{}]", url, repository);
 
 		SessionParameterMap parameterMap = new SessionParameterMap();
 
@@ -145,18 +146,26 @@ public class CmisSessionBuilder {
 			parameterMap.setAtomPubBindingUrl(url);
 			parameterMap.setUsernameTokenAuthentication(false);
 			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomAtomPubSpi.class.getName());
-			log.warn("Added custom BINDING_SPI_CLASS CmisCustomAtomPubSpi to new CmisSession");
+			log.debug("Added custom BINDING_SPI_CLASS CmisCustomAtomPubSpi to new CmisSession");
+
+			// Apply defaults that should be set by CmisBindingFactory but are now skipped with custom binding type
+			parameterMap.put(SessionParameter.AUTH_SOAP_USERNAMETOKEN, "false");
 		} else if (getBindingType() == BindingTypes.BROWSER) {
 			parameterMap.setBrowserBindingUrl(url);
 			parameterMap.setBasicAuthentication();
 			//Add parameter dateTimeFormat to send dates in ISO format instead of milliseconds.
 			parameterMap.put(SessionParameter.BROWSER_DATETIME_FORMAT, DateTimeFormat.EXTENDED.value());
 			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomBrowserBindingSpi.class.getName());
-			log.warn("Added custom BINDING_SPI_CLASS CmisCustomBrowserBindingSpi to new CmisSession");
-		} else {
+			log.debug("Added custom BINDING_SPI_CLASS CmisCustomBrowserBindingSpi to new CmisSession");
+
+			// Apply defaults that should be set by CmisBindingFactory but are now skipped with custom binding type
+			parameterMap.put(SessionParameter.BROWSER_SUCCINCT, "true");
+			parameterMap.put(SessionParameter.AUTH_SOAP_USERNAMETOKEN, "false");
+
+		} else { // BindingTypes.WEBSERVICES
 			parameterMap.setUsernameTokenAuthentication(true);
 			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomWebServicesSpi.class.getName());
-			log.warn("Added custom BINDING_SPI_CLASS CmisCustomWebServicesSpi to new CmisSession");
+			log.debug("Added custom BINDING_SPI_CLASS CmisCustomWebServicesSpi to new CmisSession");
 
 			// OpenCMIS requires an entrypoint url (wsdl), if this url has been secured and is not publicly accessible,
 			// we can manually override this wsdl by reading it from the classpath.
@@ -174,15 +183,12 @@ public class CmisSessionBuilder {
 						//eg. if the named charset is not supported
 						throw new CmisSessionException("error reading overrideEntryPointWSDL["+overrideEntryPointWSDL+"]");
 					}
-				}
-				else {
+				} else {
 					throw new CmisSessionException("cannot find overrideEntryPointWSDL["+overrideEntryPointWSDL+"]");
 				}
-			}
-			else {
+			} else {
 				parameterMap.setWebServicesBindingUrl(url);
 
-				parameterMap.put(SessionParameter.BINDING_TYPE, BindingType.WEBSERVICES.value());
 				parameterMap.put(SessionParameter.WEBSERVICES_REPOSITORY_SERVICE, url + "/RepositoryService.svc?wsdl");
 				parameterMap.put(SessionParameter.WEBSERVICES_NAVIGATION_SERVICE, url + "/NavigationService.svc?wsdl");
 				parameterMap.put(SessionParameter.WEBSERVICES_OBJECT_SERVICE, url + "/ObjectService.svc?wsdl");
@@ -192,6 +198,9 @@ public class CmisSessionBuilder {
 				parameterMap.put(SessionParameter.WEBSERVICES_MULTIFILING_SERVICE, url + "/MultiFilingService.svc?wsdl");
 				parameterMap.put(SessionParameter.WEBSERVICES_POLICY_SERVICE, url + "/PolicyService.svc?wsdl");
 				parameterMap.put(SessionParameter.WEBSERVICES_ACL_SERVICE, url + "/ACLService.svc?wsdl");
+			}
+			if (!parameterMap.containsKey(SessionParameter.AUTH_SOAP_USERNAMETOKEN)) {
+				parameterMap.put(SessionParameter.AUTH_SOAP_USERNAMETOKEN, "true");
 			}
 		}
 		parameterMap.setRepositoryId(repository);
@@ -239,9 +248,24 @@ public class CmisSessionBuilder {
 		// Custom CMIS HttpSender to support ssl connections and proxies
 		parameterMap.setHttpInvoker(nl.nn.adapterframework.extensions.cmis.CmisHttpInvoker.class);
 
+		// Since we specify our own Binding SPI classes to fix a leak, we have to set binding-type for the binding factory to "CUSTOM".
+		parameterMap.put(SessionParameter.BINDING_TYPE, BindingType.CUSTOM.value());
+
+		// Set up session parameters that would normally be done by the CmisBindingFactory but have to be
+		// done here manually b/c of using "custom bindings".
+		if (!parameterMap.containsKey(SessionParameter.AUTHENTICATION_PROVIDER_CLASS)) {
+			parameterMap.put(SessionParameter.AUTHENTICATION_PROVIDER_CLASS, CmisBindingFactory.STANDARD_AUTHENTICATION_PROVIDER);
+		}
+		if (!parameterMap.containsKey(SessionParameter.TYPE_DEFINITION_CACHE_CLASS)) {
+			parameterMap.put(SessionParameter.TYPE_DEFINITION_CACHE_CLASS, CmisBindingFactory.DEFAULT_TYPE_DEFINITION_CACHE_CLASS);
+		}
+		if (!parameterMap.containsKey(SessionParameter.AUTH_HTTP_BASIC)) {
+			parameterMap.put(SessionParameter.AUTH_HTTP_BASIC, "true");
+		}
+
 		SessionFactory sessionFactory = SessionFactoryImpl.newInstance();
 		Session session = sessionFactory.createSession(parameterMap);
-		log.debug("connected with repository [" + getRepositoryInfo(session) + "]");
+		log.debug("connected with repository [{}]", ()->getRepositoryInfo(session));
 
 		return session;
 	}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSessionBuilder.java
@@ -152,6 +152,7 @@ public class CmisSessionBuilder {
 		} else {
 			parameterMap.setUsernameTokenAuthentication(true);
 			parameterMap.put(SessionParameter.BINDING_SPI_CLASS, CmisCustomWebServicesSpi.class.getName());
+			log.warn("Added custom BINDING_SPI_CLASS CmisCustomWebServicesSpi to new CmisSession");
 
 			// OpenCMIS requires an entrypoint url (wsdl), if this url has been secured and is not publicly accessible,
 			// we can manually override this wsdl by reading it from the classpath.

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisUtils.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisUtils.java
@@ -165,7 +165,7 @@ public class CmisUtils {
 	}
 
 	public static void closeBindingSession(CmisSpi owner, BindingSession bindingSession) {
-		log.warn("Closing {}", owner.getClass().getSimpleName());
+		log.debug("Closing {}", owner.getClass().getSimpleName());
 		Object invoker = bindingSession.get(HTTP_INVOKER_OBJECT);
 		if (invoker instanceof CmisHttpInvoker) {
 			CmisHttpInvoker cmisHttpInvoker = (CmisHttpInvoker) invoker;

--- a/core/src/main/java/nl/nn/adapterframework/http/HttpSenderBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpSenderBase.java
@@ -481,6 +481,7 @@ public abstract class HttpSenderBase extends SenderWithParametersBase implements
 		try {
 			//Close the HttpClient and ConnectionManager to release resources and potential open connections
 			if(httpClient != null) {
+				log.warn("Close HTTP Client (should close down background threads)");
 				httpClient.close();
 			}
 		} catch (IOException e) {

--- a/core/src/main/java/nl/nn/adapterframework/http/HttpSenderBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpSenderBase.java
@@ -481,7 +481,7 @@ public abstract class HttpSenderBase extends SenderWithParametersBase implements
 		try {
 			//Close the HttpClient and ConnectionManager to release resources and potential open connections
 			if(httpClient != null) {
-				log.warn("Close HTTP Client (should close down background threads)");
+				log.debug("Close HTTP Client (should close down background threads)");
 				httpClient.close();
 			}
 		} catch (IOException e) {
@@ -712,7 +712,7 @@ public abstract class HttpSenderBase extends SenderWithParametersBase implements
 
 			// Only give warnings for 4xx (client errors) and 5xx (server errors)
 			if (statusCode >= 400 && statusCode < 600) {
-				log.warn(getLogPrefix()+"status ["+statusline.toString()+"]");
+				log.warn(getLogPrefix()+"status ["+ statusline +"]");
 			} else {
 				log.debug(getLogPrefix()+"status ["+statusCode+"]");
 			}


### PR DESCRIPTION
This should close the Apache HTTP Client used by Cmis Sender, however I do not yet have tests for this so the PR is still in draft.

However from this branch a version could be built to use for testing, I think.