### PR TITLE
Restore forward name in ConfigurationException thrown in isUserInRolePipe

### DIFF
--- a/core/src/main/java/org/frankframework/pipes/IsUserInRolePipe.java
+++ b/core/src/main/java/org/frankframework/pipes/IsUserInRolePipe.java
@@ -61,7 +61,7 @@ public class IsUserInRolePipe extends FixedForwardPipe {
 		if (StringUtils.isNotEmpty(getNotInRoleForwardName())) {
 			notInRoleForward = findForward(getNotInRoleForwardName());
 			if (notInRoleForward==null) {
-				throw new ConfigurationException("notInRoleForwardName not found");
+				throw new ConfigurationException("could not find forward for notInRoleForwardName ["+ getNotInRoleForwardName()+"]");
 			}
 		}
 	}

--- a/core/src/test/java/org/frankframework/pipes/IsUserInRolePipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IsUserInRolePipeTest.java
@@ -44,7 +44,13 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 
 	@Test
 	void requiresNotInRoleForward() {
-		assertThrows(ConfigurationException.class, () -> pipe.configure(), "notInRoleForwardName not found");
+		assertThrows(ConfigurationException.class, () -> pipe.configure(), "notInRoleForwardName [null] not found");
+	}
+
+	@Test
+	void requiresNotInRoleForwardSetButNotFound() {
+		pipe.setNotInRoleForwardName(NOT_IN_ROLE_FORWARD_NAME);
+		assertThrows(ConfigurationException.class, () -> pipe.configure(), "notInRoleForwardName ["+NOT_IN_ROLE_FORWARD_NAME+"] not found");
 	}
 
 	@Test


### PR DESCRIPTION
Dit is in de review niet opgemerkt maar bij nader inzien is dit niet toch niet zo handig.

Ik ging er vanuit dat als de notInRoleForward null is, het geen zin heeft om dan nog te vermelden om welke naam het ging.

Echter bij een tweede blik hierop blijkt dat het toch voor kan komen dat getNotInRoleForwardName() een gevulde string is en dat de gerelateerde forward niet gevonden kan worden.

Het lijkt mij een goed idee om dit te herstellen naar throw new ConfigurationException("could not find forward for notInRoleForwardName ["+ getNotInRoleForwardName()+"]");