### PR TITLE
Log file sorting

### DIFF
--- a/console/backend/src/main/java/org/frankframework/management/web/ShowLogging.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ShowLogging.java
@@ -41,10 +41,9 @@ public class ShowLogging extends FrankApiBase {
 	@Path("/logging")
 	@Relation("logging")
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response getLogDirectory(@QueryParam("directory") String directory, @QueryParam("sizeFormat") String sizeFormat, @QueryParam("wildcard") String wildcard) {
+	public Response getLogDirectory(@QueryParam("directory") String directory, @QueryParam("wildcard") String wildcard) {
 		RequestMessageBuilder builder = RequestMessageBuilder.create(this, BusTopic.LOGGING, BusAction.GET);
 		builder.addHeader("directory", directory);
-		builder.addHeader("sizeFormat", sizeFormat);
 		builder.addHeader("wildcard", wildcard);
 		return callSyncGateway(builder);
 	}

--- a/console/frontend/src/main/frontend/src/app/app.module.ts
+++ b/console/frontend/src/main/frontend/src/app/app.module.ts
@@ -85,6 +85,7 @@ import { TestServiceListenerComponent } from './views/test-service-listener/test
 import { LoginComponent } from './views/login/login.component';
 import { httpInterceptorProviders } from './http-interceptors';
 import { ToastsContainerComponent } from './components/toasts-container/toasts-container.component';
+import { ThSortableDirective } from './components/th-sortable.directive';
 
 const windowProvider: ValueProvider = {
   provide: Window,
@@ -170,6 +171,7 @@ const windowProvider: ValueProvider = {
     QuickSubmitFormDirective,
     FitHeightDirective,
     SideNavigationDirective,
+    ThSortableDirective,
   ],
   imports: [
     BrowserModule,

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.spec.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ThSortableDirective } from './th-sortable.directive';
+
+describe('ThSortableDirective', () => {
+  it('should create an instance', () => {
+    const directive = new ThSortableDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -14,7 +14,6 @@ export function updateSortableHeaders(headers: QueryList<ThSortableDirective>, c
   }
 }
 
-
 const compare = (v1: string | number, v2: string | number) => (v1 < v2 ? -1 : v1 > v2 ? 1 : 0);
 export function basicTableSort<T extends Record<string, any>>(arr: T[], headers: QueryList<ThSortableDirective>, { column, direction }: SortEvent): T[] {
   updateSortableHeaders(headers, column);
@@ -31,8 +30,6 @@ export function basicTableSort<T extends Record<string, any>>(arr: T[], headers:
 @Directive({
   selector: 'th[sortable]',
   host: {
-    // '[class.asc]': 'direction === "asc"',
-    // '[class.desc]': 'direction === "desc"',
     '(click)': 'nextSort()',
   }
 })

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -1,0 +1,73 @@
+import { Directive, ElementRef, EventEmitter, Input, OnInit, Output, QueryList } from '@angular/core';
+
+export type SortDirection = 'asc' | 'desc' | null;
+export type SortEvent = {
+  column: string;
+  direction: SortDirection;
+}
+
+export function updateSortableHeaders(headers: QueryList<ThSortableDirective>, column: string) {
+  for (const header of headers) {
+    if (header.sortable !== column) {
+      header.direction = null;
+    }
+  }
+}
+
+
+const compare = (v1: string | number, v2: string | number) => (v1 < v2 ? -1 : v1 > v2 ? 1 : 0);
+export function basicTableSort<T extends Record<string, any>>(arr: T[], headers: QueryList<ThSortableDirective>, { column, direction }: SortEvent): T[] {
+  updateSortableHeaders(headers, column);
+
+  if (direction == null || column == '')
+    return arr;
+
+  return [...arr].sort((a, b) => {
+    const order = compare(a[column], b[column]);
+    return direction === 'asc' ? order : -order;
+  });
+}
+
+@Directive({
+  selector: 'th[sortable]',
+  host: {
+    // '[class.asc]': 'direction === "asc"',
+    // '[class.desc]': 'direction === "desc"',
+    '(click)': 'nextSort()',
+  }
+})
+export class ThSortableDirective implements OnInit {
+  @Input() sortable: string = '';
+  @Input() direction: SortDirection = null;
+  @Output() onSort = new EventEmitter<SortEvent>();
+
+  private nextSortOption: Record<string, SortDirection> = {
+    '': 'asc',
+    asc: 'desc',
+    desc: null
+  }
+  private headerText = "";
+
+  constructor(private elementRef: ElementRef<HTMLTableCellElement>) { }
+
+  ngOnInit() {
+    this.headerText = this.elementRef.nativeElement.innerHTML;
+  }
+
+  nextSort() {
+    this.direction = this.nextSortOption[this.direction ?? ''];
+
+    let updateColumnName = "";
+    if (this.direction == null)
+      updateColumnName = this.headerText;
+    else {
+      updateColumnName = this.headerText + (
+        this.direction == 'asc' ? ' <i class="fa fa-arrow-up"></i>' : ' <i class="fa fa-arrow-down"></i>'
+      );
+    }
+    this.elementRef.nativeElement.innerHTML = updateColumnName;
+
+    this.onSort.emit({ column: this.sortable, direction: this.direction });
+  }
+
+}

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -9,7 +9,7 @@ export type SortEvent = {
 export function updateSortableHeaders(headers: QueryList<ThSortableDirective>, column: string) {
   for (const header of headers) {
     if (header.sortable !== column) {
-      header.direction = null;
+      header.updateDirection(null);
     }
   }
 }
@@ -51,19 +51,25 @@ export class ThSortableDirective implements OnInit {
     this.headerText = this.elementRef.nativeElement.innerHTML;
   }
 
-  nextSort() {
-    this.direction = this.nextSortOption[this.direction ?? ''];
-
+  updateIcon(direction: SortDirection) {
     let updateColumnName = "";
-    if (this.direction == null)
+    if (direction == null)
       updateColumnName = this.headerText;
     else {
       updateColumnName = this.headerText + (
-        this.direction == 'asc' ? ' <i class="fa fa-arrow-up"></i>' : ' <i class="fa fa-arrow-down"></i>'
+        direction == 'asc' ? ' <i class="fa fa-arrow-up"></i>' : ' <i class="fa fa-arrow-down"></i>'
       );
     }
     this.elementRef.nativeElement.innerHTML = updateColumnName;
+  }
 
+  updateDirection(newDirection: SortDirection){
+    this.direction = newDirection;
+    this.updateIcon(this.direction);
+  }
+
+  nextSort() {
+    this.updateDirection(this.nextSortOption[this.direction ?? '']);
     this.onSort.emit({ column: this.sortable, direction: this.direction });
   }
 

--- a/console/frontend/src/main/frontend/src/app/pipes/search-filter.pipe.ts
+++ b/console/frontend/src/main/frontend/src/app/pipes/search-filter.pipe.ts
@@ -1,5 +1,4 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { Adapter } from '../app.service';
 
 @Pipe({
   name: 'searchFilter'

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
@@ -32,7 +32,7 @@
               <tbody>
                 <tr *ngFor="let file of sortedlist | searchFilter: fileName">
                   <td class="pointer" (click)="open(file)">{{file.name}}</td>
-                  <td><span *ngIf="file.type == 'file'">{{file.size}}</span></td>
+                  <td><span *ngIf="file.type == 'file'">{{file.sizeDisplay}}</span></td>
                   <td appToDate [time]="file.lastModified"></td>
                   <td class="hideBtn1170" *ngIf="file.type == 'file'">
                     <button (click)="download(file)" class="btn btn-xs pull-right" type="button"><i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i> <span> Download</span></button>

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
@@ -1,6 +1,3 @@
-<!-- Angular ui-router hack-->
-<div ui-view></div>
-
 <div class="wrapper wrapper-content">
   <ngb-alert *ngIf="alert" type="danger" [dismissible]="false">{{alert}}</ngb-alert>
   <div class="row">
@@ -26,15 +23,15 @@
             <table class="table table-striped">
               <thead>
                 <tr>
-                  <th>Name</th>
-                  <th>Size</th>
-                  <th>Date</th>
+                  <th sortable="name" (onSort)="onSort($event)">Name</th>
+                  <th sortable="size" (onSort)="onSort($event)">Size</th>
+                  <th sortable="lastModified" (onSort)="onSort($event)">Date</th>
                   <th>&nbsp;</th>
                 </tr>
               </thead>
               <tbody>
-                <tr *ngFor="let file of list | searchFilter: fileName">
-                  <td class="pointer" (click)=" open(file)">{{file.name}}</td>
+                <tr *ngFor="let file of sortedlist | searchFilter: fileName">
+                  <td class="pointer" (click)="open(file)">{{file.name}}</td>
                   <td><span *ngIf="file.type == 'file'">{{file.size}}</span></td>
                   <td appToDate [time]="file.lastModified"></td>
                   <td class="hideBtn1170" *ngIf="file.type == 'file'">

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
@@ -90,7 +90,6 @@ export class LoggingComponent implements OnInit {
     this.loggingService.getLogging(directory).subscribe({
       next: (data) => {
         this.alert = false;
-        // Object.assign(this, data);
         this.originalList = data.list;
         this.sortedlist = data.list;
         this.directory = data.directory;

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
@@ -1,9 +1,10 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppService } from 'src/app/app.service';
 import { MiscService } from 'src/app/services/misc.service';
 import { LoggingService, LoggingFile } from './logging.service';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { SortEvent, ThSortableDirective, basicTableSort } from 'src/app/components/th-sortable.directive';
 
 @Component({
   selector: 'app-logging',
@@ -16,9 +17,11 @@ export class LoggingComponent implements OnInit {
   directory: string = "";
   path: string = "";
   fileName: string = "";
-  list: LoggingFile[] = [];
+  originalList: LoggingFile[] = [];
+  sortedlist: LoggingFile[] = [];
 
   @ViewChild('iframe') iframeRef!: ElementRef<HTMLIFrameElement>;
+  @ViewChildren(ThSortableDirective) headers!: QueryList<ThSortableDirective>;
 
   constructor(
     private route: ActivatedRoute,
@@ -51,7 +54,7 @@ export class LoggingComponent implements OnInit {
 
   closeFile() {
     this.viewFile = false;
-    this.router.navigate(['/logging'], { queryParams: { directory: this.directory }});
+    this.router.navigate(['/logging'], { queryParams: { directory: this.directory } });
   };
 
   download(file: LoggingFile) {
@@ -84,20 +87,29 @@ export class LoggingComponent implements OnInit {
   };
 
   openDirectory(directory: string) {
-    this.loggingService.getLogging(directory).subscribe({ next: (data) => {
-      this.alert = false;
-      Object.assign(this, data);
-      this.path = data.directory;
-      if (data.count > data.list.length) {
-        this.alert = "Total number of items [" + data.count + "] exceeded maximum number, only showing first [" + (data.list.length - 1) + "] items!";
+    this.loggingService.getLogging(directory).subscribe({
+      next: (data) => {
+        this.alert = false;
+        // Object.assign(this, data);
+        this.originalList = data.list;
+        this.sortedlist = data.list;
+        this.directory = data.directory;
+        this.path = data.directory;
+        if (data.count > data.list.length) {
+          this.alert = "Total number of items [" + data.count + "] exceeded maximum number, only showing first [" + (data.list.length - 1) + "] items!";
+        }
+      }, error: (data) => {
+        this.alert = (data.error) ? data.error.error : "An unknown error occured!";
       }
-    }, error: (data) => {
-      this.alert = (data.error) ? data.error.error : "An unknown error occured!";
-    }});
+    });
   };
 
   copyToClipboard(path: string) {
     const textToCopy = path.trim();
     this.appService.copyToClipboard(textToCopy);
   };
+
+  onSort(event: SortEvent) {
+    this.sortedlist = basicTableSort(this.originalList, this.headers, event);
+  }
 }

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.service.ts
@@ -7,11 +7,12 @@ export const errorLevelsConst = ["DEBUG", "INFO", "WARN", "ERROR"] as const;
 export type ErrorLevels = typeof errorLevelsConst;
 
 export type LoggingFile = {
-  name: string
-  type: string
-  path: string
-  size: string
-  lastModified: number
+  name: string;
+  type: string;
+  path: string;
+  size: number;
+  sizeDisplay: string;
+  lastModified: number;
 }
 
 export type LoggingSettings = {
@@ -32,7 +33,6 @@ export type LogInformation = {
 }
 
 type Logging = {
-  sizeFormat: boolean,
   count: number,
   list: LoggingFile[],
   directory: string,

--- a/core/src/main/java/org/frankframework/lifecycle/ShowLogDirectory.java
+++ b/core/src/main/java/org/frankframework/lifecycle/ShowLogDirectory.java
@@ -73,7 +73,6 @@ public class ShowLogDirectory {
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public Message<String> getLogDirectory(Message<?> message) {
 		String directory = BusMessageUtils.getHeader(message, "directory", defaultLogDirectory);
-		boolean sizeFormat = BusMessageUtils.getBooleanHeader(message, "sizeFormat", true);
 		String wildcard = BusMessageUtils.getHeader(message, "wildcard", defaultLogWildcard);
 
 		if(StringUtils.isNotEmpty(directory) && !FileUtils.readAllowed(FileViewerServlet.permissionRules, directory, BusMessageUtils::hasAnyRole)) {
@@ -81,12 +80,11 @@ public class ShowLogDirectory {
 		}
 
 		Map<String, Object> returnMap = new HashMap<>();
-		Dir2Map dir = new Dir2Map(directory, sizeFormat, wildcard, showDirectories, maxItems);
+		Dir2Map dir = new Dir2Map(directory, wildcard, showDirectories, maxItems);
 
 		returnMap.put("list", dir.getList());
 		returnMap.put("count", dir.size());
 		returnMap.put("directory", dir.getDirectory());
-		returnMap.put("sizeFormat", sizeFormat);
 		returnMap.put("wildcard", wildcard);
 
 		return new JsonResponseMessage(returnMap);

--- a/core/src/main/java/org/frankframework/util/Dir2Map.java
+++ b/core/src/main/java/org/frankframework/util/Dir2Map.java
@@ -27,19 +27,17 @@ import org.apache.commons.io.FilenameUtils;
 public class Dir2Map {
 	private File directory;
 	private String wildcard = "*.*";
-	private boolean sizeFormat = true;
 	private boolean showDirectories = false;
 	private int maxItems = -1;
 	private int fileListSize = 0;
 	private List<Map<String, Object>> fileInfoList = new ArrayList<>();
 
-	public Dir2Map(String directory, boolean sizeFormat, String wildcard, boolean showDirectories, int maxItems) {
-		this(new File(directory), sizeFormat, wildcard, showDirectories, maxItems);
+	public Dir2Map(String directory, String wildcard, boolean showDirectories, int maxItems) {
+		this(new File(directory), wildcard, showDirectories, maxItems);
 	}
 
-	public Dir2Map(File directory, boolean sizeFormat, String wildcard, boolean showDirectories, int maxItems) {
+	public Dir2Map(File directory, String wildcard, boolean showDirectories, int maxItems) {
 		this.directory = directory;
-		this.sizeFormat = sizeFormat;
 		this.wildcard = wildcard;
 		this.showDirectories = showDirectories;
 		this.maxItems = maxItems;
@@ -93,13 +91,14 @@ public class Dir2Map {
 	}
 
 	private Map<String, Object> FileInfo(File file, String displayName) {
-		Map<String, Object> fileInfo = new HashMap<>(5);
+		Map<String, Object> fileInfo = new HashMap<>(6);
 
 		fileInfo.put("name", displayName);
 		fileInfo.put("path", normalizePath(file));
 		fileInfo.put("lastModified", file.lastModified());
 		fileInfo.put("type", file.isDirectory() ? "directory" : "file");
-		fileInfo.put("size", (sizeFormat) ? Misc.toFileSize(file.length(), true) : file.length());
+		fileInfo.put("size", file.length());
+		fileInfo.put("sizeDisplay", Misc.toFileSize(file.length(), true));
 
 		return fileInfo;
 	}


### PR DESCRIPTION
The table of logs in the logging view can now be sorted on any of the named headers
* Added ThSortableDirective for any table element to make use of
* Changed `/logging` api endpoint to give back both `size` (long) & `sizeDisplay` (string) as property & removed the queryparam sizeFormat