### PR TITLE
Remove Sonar from the 7.9 build as Sonar no longer supports JDK11

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -62,13 +62,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
@@ -86,12 +79,6 @@ jobs:
       run: |
         echo "PROFILES=${{ env.PROFILES }},proprietary" >> $GITHUB_ENV
 
-      # Secrets are not available when commits are made by Dependabot or from GH forks
-    - name: Update environment when JDK == 11
-      if: ${{ matrix.java == '11' && env.USE_PROPRIETARY == 'true' }}
-      run: |
-        echo "MAVEN_GOALS=${{ env.MAVEN_GOALS }} org.sonarsource.scanner.maven:sonar-maven-plugin:sonar" >> $GITHUB_ENV
-
       # Use Maven Wrapper so we can build with an older version of Maven, see PR #4579.
     - name: Build with Maven
       env:
@@ -99,9 +86,8 @@ jobs:
         TZ: Europe/Amsterdam
         JAVA_OPTS: "-Xms1G -XX:+UseParallelGC"
         jdk11: true # allows the use of the JDK11 profile, when running JDK11
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # SonarCloud
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # SonarCloud
-      run: ./mvnw -B -V -T1 ${{env.MAVEN_GOALS}} -P${{env.PROFILES}} -Dsonar.projectKey=ibissource_iaf
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./mvnw -B -V -T1 ${{env.MAVEN_GOALS}} -P${{env.PROFILES}}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Build of 7.9-release branch now fails with error due to Sonar no longer supporting JDK11.

Not an issue for other branches.