### PR TITLE
Fix wrong targetStates type breaking (error) message store in the console

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.html
@@ -127,12 +127,12 @@
               type="button">Select All</button>
             <button title="Unselect All Messages" (click)="unselectAll()" class="btn btn-default btn-sm space-it-out"
               type="button">Unselect All</button>
-            <span *ngFor="let targetState of targetStates">
+            <span *ngFor="let targetState of targetStates | keyvalue">
               <button [ladda]="changingProcessState" data-style="slide-right"
-                (click)="changeProcessState(targetState.name)"
+                (click)="changeProcessState(targetState.value.name)"
                 class="btn btn-default btn-sm space-it-out" type="button"><i
-                  class="fa {{getProcessStateIcon(targetState.name)}}"></i> Move to
-                {{targetState.name}}</button>
+                  class="fa {{getProcessStateIcon(targetState.value.name)}}"></i> Move to
+                {{targetState.value.name}}</button>
             </span>
             <button [ladda]="messagesDownloading" data-style="slide-right" title="Download Selected Messages"
               (click)="downloadMessages()" class="btn btn-info btn-sm space-it-out" type="button"><i

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
@@ -16,7 +16,7 @@ import { WebStorageService } from 'src/app/services/web-storage.service';
   styleUrls: ['./storage-list.component.scss']
 })
 export class StorageListComponent implements OnInit, AfterViewInit {
-  targetStates: { name: string; }[] = [];
+  targetStates: Record<string, { name: string; }> = {};
 
   truncated = false;
   truncateButtonText = "Truncate displayed data";
@@ -117,7 +117,7 @@ export class StorageListComponent implements OnInit, AfterViewInit {
         }
         this.Session.set('search', searchSession);
         this.storageService.getStorageList(queryParams).subscribe({ next: (response) => {
-          this.targetStates = response.targetStates ?? [];
+          this.targetStates = response.targetStates ?? {};
           callback({
             draw: data["draw"],
             recordsTotal: response.totalMessages,

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage.service.ts
@@ -10,7 +10,7 @@ export type MessageStore = {
   messageCount: number;
   recordsFiltered: number;
   messages: Message[];
-  targetStates?: { name: string; }[];
+  targetStates?: Record<string, { name: string; }>;
 }
 
 export type Message = {

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -130,7 +130,7 @@ export class TestPipelineComponent implements OnInit {
         this.form.message = returnData.message;
       }
     }, error: (errorData) => {
-      let error = (errorData && errorData.error) ? errorData.error : "An error occured!";
+      const error =  errorData.error?.error ?? "An error occured!";
       this.result = "";
       this.addNote("warning", error);
       this.processingMessage = false;


### PR DESCRIPTION
7.9 fix for having wrong `targetStates` type breaking (error) message store in the console
Fixes #5594