### PR TITLE
Fix configuration versions page & api giving back sql error

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
@@ -37,8 +37,8 @@
                 <td><input icheck type="checkbox" (ngModelChange)="scheduleReload(config)" name="autoreload" [(ngModel)]="config.autoreload" /></td>
                 <td><i class="fa fa-check btn-xs" *ngIf="config.loaded" aria-hidden="true"></i></td>
                 <td class="hideBtn1170 minw180px">
-                  <button title="Delete" (click)="deleteConfig(config)" class="btn btn-xs btn-danger pull-right" type="button"><i class="fa fa-times aria-hidden='true'"></i> <span>Delete</span></button>
-                  <button title="Download" (click)="download(config)" class="btn btn-xs btn-info pull-right" type="button"><i class="fa fa-cloud-download aria-hidden='true'"></i> <span>Download</span></button>
+                  <button title="Delete" (click)="deleteConfig(config)" class="btn btn-xs btn-danger pull-right" type="button"><i class="fa fa-times aria-hidden='true'"></i> <span> Delete</span></button>
+                  <button title="Download" (click)="download(config)" class="btn btn-xs btn-info pull-right" type="button"><i class="fa fa-cloud-download aria-hidden='true'"></i> <span> Download</span></button>
                 </td>
               </tr>
             </tbody>

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
@@ -1,6 +1,3 @@
-<!-- Angular ui-router hack-->
-<div ui-view></div>
-
 <div class="wrapper wrapper-content animated fadeInRight">
   <div class="row">
     <div class="col-lg-12 table-responsive">
@@ -13,7 +10,7 @@
               type="button"
             ><i class="fa fa-arrow-circle-o-left" aria-hidden="true"></i> <span> Back</span></button>
           </div>
-          <h4>Manage {{configuration}}</h4>
+          <h4>Manage {{configuration.name}}</h4>
         </div>
         <div class="ibox-content">
           <h2>Version History</h2>

--- a/core/src/main/java/org/frankframework/management/bus/dto/ConfigurationDTO.java
+++ b/core/src/main/java/org/frankframework/management/bus/dto/ConfigurationDTO.java
@@ -15,7 +15,7 @@
 */
 package org.frankframework.management.bus.dto;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -89,7 +89,7 @@ public class ConfigurationDTO {
 		this.user = classLoader.getUser();
 	}
 
-	public void setDatabaseAttributes(String filename, Date creationDate, String user, Boolean active, Boolean autoreload) {
+	public void setDatabaseAttributes(String filename, Instant creationDate, String user, Boolean active, Boolean autoreload) {
 		this.filename = filename;
 		this.created = DateFormatUtils.format(creationDate, DateFormatUtils.GENERIC_DATETIME_FORMATTER);
 		this.user = user;

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -19,8 +19,8 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -240,7 +240,7 @@ public class ConfigManagement extends BusEndpointBase {
 							String user = rs.getString(4);
 							boolean active = rs.getBoolean(5);
 							boolean autoreload = rs.getBoolean(6);
-							Date creationDate = rs.getDate(7);
+							Instant creationDate = rs.getTimestamp(7).toInstant();
 
 							configDoa.setDatabaseAttributes(filename, creationDate, user, active, autoreload);
 							configurations.add(configDoa);


### PR DESCRIPTION
* Fixes configuration details page showing `[Object object]` instead of configuration name
* Fixes sql error caused by `rs.getDate` not being able to convert TIMESTAMP column in `ConfigManagement.getConfigsFromDatabase`