### PR TITLE
Truncate adapter name and descriptions in select form elements

### DIFF
--- a/console/frontend/src/main/frontend/src/app/pipes/with-java-listener.pipe.ts
+++ b/console/frontend/src/main/frontend/src/app/pipes/with-java-listener.pipe.ts
@@ -15,6 +15,7 @@ export class WithJavaListenerPipe implements PipeTransform {
       for (const receiver of receivers) {
         if (receiver.listener.class.startsWith('JavaListener')) {
           schedulerEligibleAdapters.push(adapters[adapter]);
+          break;
         }
       }
     }

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
@@ -42,7 +42,10 @@
               <label class="col-sm-3 control-label">Select an adapter</label>
               <div class="col-sm-9">
                 <select class="form-control m-b" name="adapter" [(ngModel)]="form.adapter" [disabled]="selectedConfiguration == ''">
-                  <option *ngFor="let adapter of adapters | configurationFilter : selectedConfiguration | withJavaListener" [ngValue]="adapter">{{adapter.name + (adapter.description != null? " - "+adapter.description:"")}}</option>
+                  <option
+                    *ngFor="let adapter of adapters | configurationFilter : selectedConfiguration | withJavaListener"
+                    [ngValue]="adapter"
+                  >{{adapter.name + (adapter.description != null? " - "+adapter.description:"") | truncate:150}}</option>
                 </select>
               </div>
             </div>

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
@@ -45,7 +45,9 @@
                   <option
                     *ngFor="let adapter of adapters | configurationFilter : selectedConfiguration | withJavaListener"
                     [ngValue]="adapter"
-                  >{{adapter.name + (adapter.description != null? " - "+adapter.description:"") | truncate:150}}</option>
+                  >{{adapter.name + (
+                      adapter.description != null ? (" - " + adapter.description) : ""
+                    ) | truncate:150}}</option>
                 </select>
               </div>
             </div>

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
@@ -45,9 +45,7 @@
                   <option
                     *ngFor="let adapter of adapters | configurationFilter : selectedConfiguration | withJavaListener"
                     [ngValue]="adapter"
-                  >{{adapter.name + (
-                      adapter.description != null ? (" - " + adapter.description) : ""
-                    ) | truncate:150}}</option>
+                  >{{adapter.name + adapter.description != null ? (" - " + adapter.description) : "" | truncate:150}}</option>
                 </select>
               </div>
             </div>

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -22,7 +22,7 @@
                 <select class="form-control" name="adapter" [(ngModel)]="form.adapter"
                   [disabled]="selectedConfiguration ==''">
                   <option *ngFor="let adapter of adapters | configurationFilter:selectedConfiguration | keyvalue" [value]="adapter.value.name">
-                    {{adapter.value.name + (adapter.value.description != null? " - "+adapter.value.description:"") | truncate:150}}</option>
+                    {{adapter.value.name + adapter.value.description != null ? (" - " + adapter.value.description) : "" | truncate:150}}</option>
                 </select>
               </div>
             </div>

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -22,7 +22,7 @@
                 <select class="form-control" name="adapter" [(ngModel)]="form.adapter"
                   [disabled]="selectedConfiguration ==''">
                   <option *ngFor="let adapter of adapters | configurationFilter:selectedConfiguration | keyvalue" [value]="adapter.value.name">
-                    {{adapter.value.name + (adapter.value.description != null? " - "+adapter.value.description:"")}}</option>
+                    {{adapter.value.name + (adapter.value.description != null? " - "+adapter.value.description:"") | truncate:150}}</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
* Truncates adapter name and description shown in adapter dropdown lists
* Fixes small issue in add/edit scheduler page where it shows duplicates of adapters

![image](https://github.com/frankframework/frankframework/assets/4380412/ce8d2c1e-b6cc-4a07-b8a0-716bb09f2fcf)
