### PR TITLE
InputWrapper used to Wrap, should always specify a SoapVersion (#5925)

### DIFF
--- a/core/src/main/java/org/frankframework/soap/SoapWrapperPipe.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapperPipe.java
@@ -103,6 +103,10 @@ public class SoapWrapperPipe extends FixedForwardPipe implements IWrapperPipe {
 				setSoapNamespaceSessionKey(DEFAULT_SOAP_NAMESPACE_SESSION_KEY);
 			}
 		}
+		if (getDirection() == Direction.WRAP && PipeLine.INPUT_WRAPPER_NAME.equals(getName()) && soapVersion == SoapVersion.AUTO) {
+			ConfigurationWarnings.add(this, log, "SoapWrapperPipe should NOT be used to wrap a message in an InputWrapper, without a " +
+					"specified SoapVersion. Add [soapVersion] attribute to the configuration. Now defaults to v1.1 without guarantees. ", SuppressKeys.CONFIGURATION_VALIDATION);
+		}
 		if (getSoapVersion() == null) {
 			soapVersion = SoapVersion.AUTO;
 		}

--- a/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
@@ -17,6 +17,8 @@ import org.frankframework.stream.Message;
 import org.frankframework.testutil.TestAssertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import javax.xml.soap.SOAPConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -213,6 +215,8 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 	@Test
 	public void testWrap() throws Exception {
 		pipe.setOutputNamespace(TARGET_NAMESPACE);
+		pipe.setName(PipeLine.INPUT_WRAPPER_NAME);
+		pipeline.addPipe(pipe);
 		configureAndStartPipe();
 
 		String input = "<root>\n<attrib>1</attrib>\n<attrib>2</attrib>\n</root>";
@@ -223,12 +227,18 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		String actual = prr.getResult().asString();
 
 		TestAssertions.assertEqualsIgnoreCRLF(expected, actual);
+
+		List<String> warnings = getConfigurationWarnings().getWarnings();
+		assertEquals(1, warnings.size());
+		assertTrue(warnings.get(0).contains("should NOT be used to wrap a message in an InputWrapper"));
 	}
 
 	@Test
 	public void testWrapSoapVersionSoap12() throws Exception {
 		pipe.setOutputNamespace(TARGET_NAMESPACE);
 		pipe.setSoapVersion(SoapVersion.SOAP12);
+		pipe.setName(PipeLine.INPUT_WRAPPER_NAME);
+		pipeline.addPipe(pipe);
 		configureAndStartPipe();
 
 		String input = "<root>\n<attrib>1</attrib>\n<attrib>2</attrib>\n</root>";
@@ -239,6 +249,7 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		String actual = prr.getResult().asString();
 
 		TestAssertions.assertEqualsIgnoreCRLF(expected, actual);
+		assertTrue(getConfigurationWarnings().getWarnings().isEmpty());
 	}
 
 	@Test
@@ -258,6 +269,7 @@ public class SoapWrapperPipeTest<P extends SoapWrapperPipe> extends PipeTestBase
 		String actual = prr.getResult().asString();
 
 		TestAssertions.assertEqualsIgnoreCRLF(expected, actual);
+		assertTrue(getConfigurationWarnings().getWarnings().isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Backport