### PR TITLE
Fix broken XADataSource check in PoolingJndiDataSourceFactory

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/jndi/AbstractXADataSourceFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/jndi/AbstractXADataSourceFactory.java
@@ -1,0 +1,40 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.jndi;
+
+import javax.sql.CommonDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+public abstract class AbstractXADataSourceFactory extends PoolingJndiDataSourceFactory {
+
+	@Override
+	protected DataSource augmentDatasource(CommonDataSource dataSource, String dataSourceName) {
+		if (dataSource instanceof XADataSource) {
+			log.info("DataSource [{}] is XA enabled, registering with a Transaction Manager", dataSourceName);
+			return createXADataSource((XADataSource) dataSource, dataSourceName);
+		}
+
+		if(maxPoolSize > 1) {
+			log.info("DataSource [{}] is not XA enabled, creating connection pool for the datasource", dataSourceName);
+			return createPool((DataSource)dataSource);
+		}
+		log.info("DataSource [{}] is not XA enabled and pooling not configured, used without augmentation", dataSourceName);
+		return (DataSource) dataSource;
+	}
+
+	protected abstract DataSource createXADataSource(XADataSource xaDataSource, String dataSourceName);
+}

--- a/core/src/main/java/nl/nn/adapterframework/jndi/PoolingJndiDataSourceFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/jndi/PoolingJndiDataSourceFactory.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
-import javax.sql.XADataSource;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DataSourceConnectionFactory;
@@ -62,22 +61,14 @@ public class PoolingJndiDataSourceFactory extends JndiDataSourceFactory {
 		testQuery = appConstants.getString("transactionmanager.jdbc.connection.testQuery", testQuery);
 	}
 
+	@Override
 	protected DataSource augmentDatasource(CommonDataSource dataSource, String dataSourceName) {
-		if (dataSource instanceof XADataSource) {
-			log.info("DataSource [{}] is XA enabled, registering with a Transaction Manager", dataSourceName);
-			return createXADataSource((XADataSource) dataSource, dataSourceName);
-		}
-
 		if(maxPoolSize > 1) {
-			log.info("DataSource [{}] is not XA enabled, creating connection pool for the datasource", dataSourceName);
+			log.info("Creating connection pool for datasource [{}]", dataSourceName);
 			return createPool((DataSource)dataSource);
 		}
-		log.info("DataSource [{}] is not XA enabled and pooling not configured, used without augmentation", dataSourceName);
+		log.info("Pooling not configured, using datasource [{}] without augmentation", dataSourceName);
 		return (DataSource) dataSource;
-	}
-
-	protected DataSource createXADataSource(XADataSource xaDataSource, String dataSourceName) {
-		throw new UnsupportedOperationException("non-XA DataSourceFactory [" + this.getClass().getName() + "] cannot create XA-DataSources");
 	}
 
 	protected DataSource createPool(DataSource dataSource) {

--- a/core/src/main/java/nl/nn/adapterframework/jta/btm/BtmDataSourceFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/btm/BtmDataSourceFactory.java
@@ -25,10 +25,10 @@ import org.springframework.jdbc.datasource.DelegatingDataSource;
 import bitronix.tm.resource.jdbc.PoolingDataSource;
 import lombok.Getter;
 import lombok.Setter;
-import nl.nn.adapterframework.jndi.PoolingJndiDataSourceFactory;
+import nl.nn.adapterframework.jndi.AbstractXADataSourceFactory;
 import nl.nn.adapterframework.util.AppConstants;
 
-public class BtmDataSourceFactory extends PoolingJndiDataSourceFactory implements DisposableBean {
+public class BtmDataSourceFactory extends AbstractXADataSourceFactory implements DisposableBean {
 
 	private @Getter @Setter int maxIdleTime = 60;
 

--- a/core/src/main/java/nl/nn/adapterframework/jta/narayana/NarayanaDataSourceFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/narayana/NarayanaDataSourceFactory.java
@@ -32,11 +32,11 @@ import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import nl.nn.adapterframework.jdbc.datasource.OpenManagedDataSource;
-import nl.nn.adapterframework.jndi.PoolingJndiDataSourceFactory;
+import nl.nn.adapterframework.jndi.AbstractXADataSourceFactory;
 import nl.nn.adapterframework.util.AppConstants;
 
 @Log4j2
-public class NarayanaDataSourceFactory extends PoolingJndiDataSourceFactory {
+public class NarayanaDataSourceFactory extends AbstractXADataSourceFactory {
 
 	private @Setter NarayanaJtaTransactionManager transactionManager;
 
@@ -62,7 +62,7 @@ public class NarayanaDataSourceFactory extends PoolingJndiDataSourceFactory {
 
 			GenericObjectPool<PoolableConnection> connectionPool = createConnectionPool(poolableConnectionFactory);
 
-			ds = new OpenManagedDataSource<PoolableConnection>(connectionPool, cf.getTransactionRegistry());
+			ds = new OpenManagedDataSource<>(connectionPool, cf.getTransactionRegistry());
 			log.info("created XA-enabled PoolingDataSource [{}]", ds);
 		} else {
 			ds = new NarayanaDataSource(xaDataSource, dataSourceName);


### PR DESCRIPTION
PoolingJndiDataSourceFactory shouldn't check for DataSource to be XA or not XA. It shouldn't know anything about XA.

Perhaps not the best fix but it seems to work.