### PR TITLE
Try to determine if a datasource already does pooling

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/jndi/AbstractXADataSourceFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/jndi/AbstractXADataSourceFactory.java
@@ -30,7 +30,7 @@ public abstract class AbstractXADataSourceFactory extends PoolingJndiDataSourceF
 
 		if(maxPoolSize > 1) {
 			log.info("DataSource [{}] is not XA enabled, creating connection pool for the datasource", dataSourceName);
-			return createPool((DataSource)dataSource);
+			return createPool((DataSource)dataSource, dataSourceName);
 		}
 		log.info("DataSource [{}] is not XA enabled and pooling not configured, used without augmentation", dataSourceName);
 		return (DataSource) dataSource;

--- a/test/src/main/webapp/META-INF/context.xml
+++ b/test/src/main/webapp/META-INF/context.xml
@@ -102,11 +102,13 @@
 
 	<!-- Postgres XA does not work without BTM/Narayana, gives ClassCastException casting the XA datasource to Java datasource, so add non-XA for those cases -->
 	<Resource name="jdbc/ibis4test-postgres" auth="Container"
-		factory="org.apache.naming.factory.BeanFactory"
-		type="org.postgresql.ds.PGSimpleDataSource"
-		url="jdbc:postgresql://${jdbc.hostname:-localhost}:5432/testiaf"
-		user="${testiaf_user/username:-testiaf_user}"
-		password="${testiaf_user/password:-testiaf_user00}"
+			  type="javax.sql.DataSource"
+			  driverClassName="org.postgresql.Driver"
+			  url="jdbc:postgresql://${jdbc.hostname:-localhost}:5432/testiaf"
+			  username="${testiaf_user/username:-testiaf_user}"
+			  password="${testiaf_user/password:-testiaf_user00}"
+			  maxTotal="10"
+			  maxWaitMillis="5000"
 	/>
 
 	<Resource name="jdbc/ibis4test-db2-xa" auth="Container"


### PR DESCRIPTION
Only works for non-XA datasources currently, for XA datasources we need to still consider what is best to do as many XA drivers already implement pooling even if it's not configured.

I'm not sure about these changes, want to see if all works well in the Jenkins matrix builds. Am open to suggestions for better way to check.
