### PR TITLE
Version pin JUnit to 5.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,19 +535,19 @@
 			<dependency>
 				<groupId>org.junit.vintage</groupId>
 				<artifactId>junit-vintage-engine</artifactId>
-				<version>[5.9.1,)</version>
+				<version>5.10.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter</artifactId>
-				<version>[5.9.1,)</version>
+				<version>5.10.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-params</artifactId>
-				<version>[5.9.1,)</version>
+				<version>5.10.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
* Version 5.10.2 is causing issues atm

Version 5.10.2 reverts some updates from 5.10.1 so it should not break it, but it does.
https://junit.org/junit5/docs/5.10.2/release-notes/