### PR TITLE
Fix order of select to make it driver / JDK version independent.

### DIFF
--- a/test/src/test/testtool/TransactionHandling/FailureInNonDbPipe/scenario01/md-select.xml
+++ b/test/src/test/testtool/TransactionHandling/FailureInNonDbPipe/scenario01/md-select.xml
@@ -9,5 +9,6 @@
 				<name>VALUE</name>
 			</column>
 		</columns>
+		<order>NAME</order>
 	</select>
 </manageDatabaseREQ>

--- a/test/src/test/testtool/TransactionHandling/FailureInNonDbPipe/scenario02/md-select.xml
+++ b/test/src/test/testtool/TransactionHandling/FailureInNonDbPipe/scenario02/md-select.xml
@@ -9,5 +9,6 @@
 				<name>VALUE</name>
 			</column>
 		</columns>
+		<order>NAME</order>
 	</select>
 </manageDatabaseREQ>


### PR DESCRIPTION
All Larva tests should now pass under JDK17 and also JDK21.