### PR TITLE
Rename jdbc minPoolSize to minIdle

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/datasource/JdbcPoolUtil.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/JdbcPoolUtil.java
@@ -56,7 +56,7 @@ public class JdbcPoolUtil {
 			return;
 		}
 		info.append("maxPoolSize [").append(dataSource.getMaxPoolSize()).append(CLOSE);
-		info.append("minPoolSize [").append(dataSource.getMinPoolSize()).append(CLOSE);
+		info.append("minIdle [").append(dataSource.getMinPoolSize()).append(CLOSE);
 		info.append("totalPoolSize [").append(dataSource.getTotalPoolSize()).append(CLOSE);
 		info.append("inPoolSize [").append(dataSource.getInPoolSize()).append("]");
 	}

--- a/core/src/main/java/org/frankframework/jndi/PoolingJndiDataSourceFactory.java
+++ b/core/src/main/java/org/frankframework/jndi/PoolingJndiDataSourceFactory.java
@@ -44,7 +44,7 @@ public class PoolingJndiDataSourceFactory extends JndiDataSourceFactory {
 
 	public static final String DEFAULT_DATASOURCE_NAME_PROPERTY = "jdbc.datasource.default";
 	public static final String GLOBAL_DEFAULT_DATASOURCE_NAME = AppConstants.getInstance().getProperty(DEFAULT_DATASOURCE_NAME_PROPERTY);
-	@Getter @Setter protected int minPoolSize = 0;
+	@Getter @Setter protected int minIdle = 0;
 	@Getter @Setter protected int maxPoolSize = 20;
 	@Getter @Setter protected int maxIdle = 2;
 	@Getter @Setter protected int maxLifeTime = 0;
@@ -54,7 +54,7 @@ public class PoolingJndiDataSourceFactory extends JndiDataSourceFactory {
 	public PoolingJndiDataSourceFactory() {
 		super();
 		AppConstants appConstants = AppConstants.getInstance();
-		minPoolSize = appConstants.getInt("transactionmanager.jdbc.connection.minPoolSize", minPoolSize);
+		minIdle = appConstants.getInt("transactionmanager.jdbc.connection.minIdle", minIdle);
 		maxPoolSize = appConstants.getInt("transactionmanager.jdbc.connection.maxPoolSize", maxPoolSize);
 		maxIdle = appConstants.getInt("transactionmanager.jdbc.connection.maxIdle", maxIdle);
 		maxLifeTime = appConstants.getInt("transactionmanager.jdbc.connection.maxLifeTime", maxLifeTime);
@@ -105,7 +105,7 @@ public class PoolingJndiDataSourceFactory extends JndiDataSourceFactory {
 		}
 		poolableConnectionFactory.setFastFailValidation(true);
 		GenericObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);
-		connectionPool.setMinIdle(minPoolSize);
+		connectionPool.setMinIdle(minIdle);
 		connectionPool.setMaxTotal(maxPoolSize);
 		connectionPool.setMaxIdle(maxIdle);
 		connectionPool.setTestOnBorrow(true);

--- a/core/src/main/java/org/frankframework/jta/btm/BtmDataSourceFactory.java
+++ b/core/src/main/java/org/frankframework/jta/btm/BtmDataSourceFactory.java
@@ -30,6 +30,7 @@ import lombok.Setter;
 
 public class BtmDataSourceFactory extends AbstractXADataSourceFactory implements DisposableBean {
 
+	private @Getter @Setter int minPoolSize = 0;
 	private @Getter @Setter int maxIdleTime = 60;
 
 	public BtmDataSourceFactory() {

--- a/core/src/main/java/org/frankframework/jta/narayana/NarayanaDataSourceFactory.java
+++ b/core/src/main/java/org/frankframework/jta/narayana/NarayanaDataSourceFactory.java
@@ -43,7 +43,7 @@ public class NarayanaDataSourceFactory extends AbstractXADataSourceFactory {
 	public NarayanaDataSourceFactory() {
 		// For backwards compatibility, apply these configuration constants if they're found.
 		AppConstants appConstants = AppConstants.getInstance();
-		minPoolSize = appConstants.getInt("transactionmanager.narayana.jdbc.connection.minPoolSize", minPoolSize);
+		minIdle = appConstants.getInt("transactionmanager.narayana.jdbc.connection.minIdle", minIdle);
 		maxPoolSize = appConstants.getInt("transactionmanager.narayana.jdbc.connection.maxPoolSize", maxPoolSize);
 		maxIdle = appConstants.getInt("transactionmanager.narayana.jdbc.connection.maxIdle", maxIdle);
 		maxLifeTime = appConstants.getInt("transactionmanager.narayana.jdbc.connection.maxLifeTime", maxLifeTime);

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -115,8 +115,12 @@ jdbc.required=true
 jdbc.datasource.default=jdbc/${instance.name.lc}
 
 ## JDBC Connection Pool properties
-# Minimum number of physical connections to maintain.
+# Deprecated, use instead `transactionmanager.jdbc.connection.minIdle`
 transactionmanager.jdbc.connection.minPoolSize=0
+# Minimum number of physical connections that should be maintained in IDLE state when the pool is not full.
+# Keeping idle connections available in the pool can increase performance.
+# Does not apply to BTM transaction manager.
+transactionmanager.jdbc.connection.minIdle=${transactionmanager.jdbc.connection.minPoolSize}
 # Maximum number of physical connections that you can create in this pool.
 transactionmanager.jdbc.connection.maxPoolSize=20
 # Maximum number of physical connections that are allowed to be idle in the pool.
@@ -128,10 +132,13 @@ transactionmanager.jdbc.connection.checkInterval=300
 # Optional test-query for validation of the connection. If not set, JDBC4 driver based validation will be used.
 transactionmanager.jdbc.connection.testQuery=
 
-
-# BTM specific: Amount of time a connection can be unused or idle until it can be discarded.
+## BTM-specific properties for XA datasource connection pools.
+# BTM specific: Amount of time a connection can be unused or idle until it can be discarded in XA datasources when using BTM.
+# Non-XA datasources are created with the regular pooling properties.
 transactionmanager.btm.jdbc.connection.maxIdleTime=60
-
+# BTM specific: Minimum size of the pool for XA datasources when using BTM.
+# Non-XA datasources are created with the regular pooling properties.
+transactionmanager.btm.jdbc.connection.minPoolSize=0
 
 ## JMS Connection Pool properties for BTM
 # Minimum number of physical connections to maintain.
@@ -158,6 +165,11 @@ transactionmanager.narayana.jms.connection.maxSessions=500
 transactionmanager.narayana.jms.connection.checkInterval=300
 # Max time to wait (in seconds) for a connection to become available if no connections are available from the pool
 transactionmanager.narayana.jms.connections.sessionWaitTimeout=15
+
+# Deprecated. Use instead transactionmanager.jdbc.connection.minIdle
+transactionmanager.narayana.jdbc.connection.minPoolSize=${transactionmanager.jdbc.connection.minIdle}
+# Deprecated. Use instead transactionmanager.jdbc.connection.minIdle.
+transactionmanager.narayana.jdbc.connection.minIdle=${transactionmanager.narayana.jdbc.connection.minPoolSize}
 
 # control parameters for accessing JdbcTransactionalStorage
 jdbc.storage.useIndexHint=false

--- a/core/src/test/java/org/frankframework/jta/btm/BtmDataSourceFactoryTest.java
+++ b/core/src/test/java/org/frankframework/jta/btm/BtmDataSourceFactoryTest.java
@@ -20,6 +20,10 @@ public class BtmDataSourceFactoryTest {
 	void testSetup() {
 		// Arrange
 		AppConstants appConstants = AppConstants.getInstance();
+		appConstants.setProperty("transactionmanager.jdbc.connection.minIdle", "10");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxPoolSize", "20");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxIdleTime", "30");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxLifeTime", "40");
 		appConstants.setProperty("transactionmanager.btm.jdbc.connection.minPoolSize", "1");
 		appConstants.setProperty("transactionmanager.btm.jdbc.connection.maxPoolSize", "2");
 		appConstants.setProperty("transactionmanager.btm.jdbc.connection.maxIdleTime", "3");

--- a/core/src/test/java/org/frankframework/jta/narayana/NarayanaDataSourceFactoryTest.java
+++ b/core/src/test/java/org/frankframework/jta/narayana/NarayanaDataSourceFactoryTest.java
@@ -17,12 +17,22 @@ public class NarayanaDataSourceFactoryTest {
 	public void testSetup() {
 		// Arrange
 		AppConstants appConstants = AppConstants.getInstance();
+		appConstants.setProperty("transactionmanager.jdbc.connection.minIdle", "10");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxPoolSize", "20");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxIdle", "30");
+		appConstants.setProperty("transactionmanager.jdbc.connection.maxLifeTime", "40");
+		appConstants.setProperty("transactionmanager.narayana.jdbc.connection.minPoolSize", "1");
 		appConstants.setProperty("transactionmanager.narayana.jdbc.connection.maxPoolSize", "2");
+		appConstants.setProperty("transactionmanager.narayana.jdbc.connection.maxIdle", "3");
+		appConstants.setProperty("transactionmanager.narayana.jdbc.connection.maxLifeTime", "4");
 
 		// Act
 		NarayanaDataSourceFactory factory = new NarayanaDataSourceFactory();
 
 		// Assert
+		assertEquals(1, factory.getMinIdle());
 		assertEquals(2, factory.getMaxPoolSize());
+		assertEquals(3, factory.getMaxIdle());
+		assertEquals(4, factory.getMaxLifeTime());
 	}
 }


### PR DESCRIPTION
* Make name of configuration property clearer and make it more clear that BTM specific options only apply to XA datasource connection pools.
* Revert old name `transactionmanager.narayana.jdbc.connection.minPoolSize` for `transactionmanager.narayana.jdbc.connection.minIdle`.