### PR TITLE
Reduce number of connections to JMS

### DIFF
--- a/core/src/main/java/org/frankframework/jms/MessagingSource.java
+++ b/core/src/main/java/org/frankframework/jms/MessagingSource.java
@@ -212,8 +212,8 @@ public class MessagingSource  {
 		}
 		if (qcfd instanceof JmsPoolConnectionFactory) {
 			JmsPoolConnectionFactory poolcf = ((JmsPoolConnectionFactory)qcfd);
-			result.append("idle connections [").append(poolcf.getNumConnections()).append(CLOSE);
-			result.append("max connections [").append(poolcf.getMaxConnections()).append(CLOSE);
+			result.append("current pool size [").append(poolcf.getNumConnections()).append(CLOSE);
+			result.append("max pool size [").append(poolcf.getMaxConnections()).append(CLOSE);
 			result.append("max sessions per connection [").append(poolcf.getMaxSessionsPerConnection()).append(CLOSE);
 			result.append("block if session pool is full [").append(poolcf.isBlockIfSessionPoolIsFull()).append(CLOSE);
 			result.append("block if session pool is full timeout [").append(poolcf.getBlockIfSessionPoolIsFullTimeout()).append(CLOSE);

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -156,7 +156,7 @@ transactionmanager.btm.journal.maxRetries=500
 
 ## JMS Connection Pool properties for Narayana
 # Maximum number of physical connections that you can create in this pool.
-transactionmanager.narayana.jms.connection.maxPoolSize=20
+transactionmanager.narayana.jms.connection.maxPoolSize=5
 # Amount of time a connection can be unused or idle until it can be discarded.
 transactionmanager.narayana.jms.connection.maxIdleTime=60
 # Maximum number of jms sessions per connection that can be created in the connection pool.


### PR DESCRIPTION
Don't report idle connections, but current amount of connections in the pool