### PR TITLE
Add default property for forceMessageIdAsCorrelationId on RR EsbJmsListeners

### DIFF
--- a/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/AmountOfPagesPipe.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/AmountOfPagesPipe.java
@@ -18,14 +18,15 @@ package org.frankframework.extensions.aspose.pipe;
 import java.io.IOException;
 import java.io.InputStream;
 
-import com.aspose.pdf.Document;
-import com.aspose.pdf.exceptions.InvalidPasswordException;
-
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
+import org.frankframework.doc.Default;
 import org.frankframework.pipes.FixedForwardPipe;
 import org.frankframework.stream.Message;
+
+import com.aspose.pdf.Document;
+import com.aspose.pdf.exceptions.InvalidPasswordException;
 
 /**
  * Returns the amount of pages of a PDF file.
@@ -57,8 +58,8 @@ public class AmountOfPagesPipe extends FixedForwardPipe {
 
 	/**
 	 * Charset to be used to encode the given input string
-	 * @ff.default UTF-8
 	 */
+	@Default("UTF-8")
 	public void setCharset(String charset){
 		this.charset = charset;
 	}

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -344,7 +344,7 @@ jms.messageClass.default=AUTO
 jms.cleanUpOnClose=true
 # Default value for forceMessageIdAsCorrelationId in the EsbJmsListener for RR protocol,
 # when no attribute is specified in the configuration.
-jms.rr.forceMessageIdAsCorrelationId.default=
+jms.esb.rr.forceMessageIdAsCorrelationId.default=
 
 application.security.jwt.allowWeakSecrets=false
 

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -342,6 +342,9 @@ jms.lookupDestination=true
 jms.messageClass.default=AUTO
 
 jms.cleanUpOnClose=true
+# Default value for forceMessageIdAsCorrelationId in the EsbJmsListener for RR protocol,
+# when no attribute is specified in the configuration.
+jms.rr.forceMessageIdAsCorrelationId.default=
 
 application.security.jwt.allowWeakSecrets=false
 

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/EsbJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/EsbJmsListener.java
@@ -29,6 +29,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.TextMessage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.SuppressKeys;
@@ -62,6 +63,8 @@ public class EsbJmsListener extends JmsListener implements ITransactionRequireme
 
 	private static final AppConstants APP_CONSTANTS = AppConstants.getInstance();
 	private static final String MSGLOG_KEYS = APP_CONSTANTS.getProperty("msg.log.keys");
+	static final String JMS_RR_FORCE_MESSAGE_KEY = "jms.rr.forceMessageIdAsCorrelationId.default";
+	private final String messageIdAsCorrelationIdRR = APP_CONSTANTS.getString(JMS_RR_FORCE_MESSAGE_KEY, null);
 
 	private @Getter MessageProtocol messageProtocol = null;
 	private @Getter boolean copyAEProperties = false;
@@ -80,7 +83,11 @@ public class EsbJmsListener extends JmsListener implements ITransactionRequireme
 	public void configure() throws ConfigurationException {
 		if (getMessageProtocol() == MessageProtocol.RR) {
 			if (getForceMessageIdAsCorrelationId() == null) {
-				setForceMessageIdAsCorrelationId(true);
+				if (StringUtils.isNotBlank(messageIdAsCorrelationIdRR)) {
+					setForceMessageIdAsCorrelationId(Boolean.parseBoolean(messageIdAsCorrelationIdRR));
+				} else {
+					setForceMessageIdAsCorrelationId(true);
+				}
 			}
 			if (getCacheMode()==CacheMode.CACHE_CONSUMER) {
 				ConfigurationWarnings.add(this, log, "attribute [cacheMode] already has a default value [" + CacheMode.CACHE_CONSUMER + "]", SuppressKeys.DEFAULT_VALUE_SUPPRESS_KEY, getReceiver().getAdapter());
@@ -243,20 +250,20 @@ public class EsbJmsListener extends JmsListener implements ITransactionRequireme
 
 	/**
 	 * if true, all JMS properties in the request starting with "ae_" are copied to the reply.
-	 * @ff.default false
 	 */
+	@Default("false")
 	public void setCopyAEProperties(boolean b) {
 		copyAEProperties = b;
 	}
 
+	/** if messageProtocol=RR, default value is: true */
 	@Override
-	@Default("if messageProtocol=<code>RR</code>: </td><td><code>true</code>")
 	public void setForceMessageIdAsCorrelationId(Boolean force) {
 		super.setForceMessageIdAsCorrelationId(force);
 	}
 
+	/** if messageProtocol=FF, default value is: false */
 	@Override
-	@Default("if messageProtocol=<code>FF</code>: <code>false</code>")
 	public void setUseReplyTo(boolean newUseReplyTo) {
 		super.setUseReplyTo(newUseReplyTo);
 	}

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/EsbJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/EsbJmsListener.java
@@ -63,7 +63,7 @@ public class EsbJmsListener extends JmsListener implements ITransactionRequireme
 
 	private static final AppConstants APP_CONSTANTS = AppConstants.getInstance();
 	private static final String MSGLOG_KEYS = APP_CONSTANTS.getProperty("msg.log.keys");
-	static final String JMS_RR_FORCE_MESSAGE_KEY = "jms.rr.forceMessageIdAsCorrelationId.default";
+	static final String JMS_RR_FORCE_MESSAGE_KEY = "jms.esb.rr.forceMessageIdAsCorrelationId.default";
 	private final String messageIdAsCorrelationIdRR = APP_CONSTANTS.getString(JMS_RR_FORCE_MESSAGE_KEY, null);
 
 	private @Getter MessageProtocol messageProtocol = null;

--- a/nn-specials/src/test/java/org/frankframework/extensions/esb/EsbJmsListenerTest.java
+++ b/nn-specials/src/test/java/org/frankframework/extensions/esb/EsbJmsListenerTest.java
@@ -18,6 +18,7 @@ import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IListenerConnector;
 import org.frankframework.soap.SoapWrapper;
 import org.frankframework.testutil.mock.ConnectionFactoryFactoryMock;
+import org.frankframework.util.AppConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,6 +89,17 @@ class EsbJmsListenerTest {
 		jmsListener.configure();
 
 		assertFalse(jmsListener.getForceMessageIdAsCorrelationId());
+	}
+
+	@Test
+	void testConfigureWithRRProtocol_DefaultSetForceMessageIdAsCorrelationId() throws Exception {
+		AppConstants.getInstance().put(EsbJmsListener.JMS_RR_FORCE_MESSAGE_KEY, "false");
+		setUp(); // Reset the listener to re-read the AppConstants
+		jmsListener.setMessageProtocol(EsbJmsListener.MessageProtocol.RR);
+		jmsListener.configure();
+
+		assertFalse(jmsListener.getForceMessageIdAsCorrelationId());
+		AppConstants.getInstance().remove(EsbJmsListener.JMS_RR_FORCE_MESSAGE_KEY);
 	}
 
 	@Test


### PR DESCRIPTION
Also changed some Javadoc default to `@Default`, which is better.