### PR TITLE
Fix Javadoc generation for Java 21

### DIFF
--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -67,7 +67,7 @@ import lombok.Getter;
 
 
 public class AmazonS3FileSystem extends FileSystemBase<S3Object> implements IWritableFileSystem<S3Object> {
-	private final @Getter(onMethod = @__(@Override)) String domain = "Amazon";
+	private final @Getter String domain = "Amazon";
 	private static final List<String> AVAILABLE_REGIONS = getAvailableRegions();
 
 	private static final String BUCKET_OBJECT_SEPARATOR = "|";

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
@@ -15,19 +15,19 @@
  */
 package org.frankframework.extensions.cmis;
 
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
-
 import org.frankframework.extensions.cmis.server.CmisEvent;
 import org.frankframework.extensions.cmis.server.CmisEventDispatcher;
 import org.frankframework.http.PushingListenerAdapter;
 import org.frankframework.util.EnumUtils;
 
+import lombok.Getter;
+
 public class CmisEventListener extends PushingListenerAdapter implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "CMIS Event";
+	private final @Getter String domain = "CMIS Event";
 	private CmisEvent cmisEvent = null;
 
 	@Override

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
@@ -15,15 +15,15 @@
  */
 package org.frankframework.extensions.cmis;
 
+import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
+
 import org.frankframework.extensions.cmis.server.CmisEvent;
 import org.frankframework.extensions.cmis.server.CmisEventDispatcher;
 import org.frankframework.http.PushingListenerAdapter;
 import org.frankframework.util.EnumUtils;
-
-import lombok.Getter;
 
 public class CmisEventListener extends PushingListenerAdapter implements HasPhysicalDestination {
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -934,7 +934,7 @@
 						<phase>process-classes</phase>
 						<configuration>
 							<proc>only</proc>
-							<compileSourceRoots>${project.build.directory}/generated-sources</compileSourceRoots>
+							<compileSourceRoots>${project.build.directory}/generated-sources/delombok</compileSourceRoots>
 							<annotationProcessors>
 								<annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</annotationProcessor>
 							</annotationProcessors>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -934,7 +934,7 @@
 						<phase>process-classes</phase>
 						<configuration>
 							<proc>only</proc>
-							<compileSourceRoots>${project.build.directory}/generated-sources/delombok</compileSourceRoots>
+							<compileSourceRoots>${project.build.directory}/generated-sources</compileSourceRoots>
 							<annotationProcessors>
 								<annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</annotationProcessor>
 							</annotationProcessors>

--- a/core/src/main/java/org/frankframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/ExchangeFileSystem.java
@@ -121,7 +121,7 @@ import org.frankframework.xml.SaxElementBuilder;
  * @author Gerrit van Brakel
  */
 public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageReference, ExchangeAttachmentReference, ExchangeService> implements HasKeystore, HasTruststore {
-	private final @Getter(onMethod = @__(@Override)) String domain = "Exchange";
+	private final @Getter String domain = "Exchange";
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 	private @Getter String name = "ExchangeFileSystem";

--- a/core/src/main/java/org/frankframework/filesystem/FtpFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/FtpFileSystem.java
@@ -51,7 +51,7 @@ import lombok.Getter;
 public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTPFileRef> {
 	private final Logger log = LogUtil.getLogger(this);
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "FTP";
+	private final @Getter String domain = "FTP";
 	private String remoteDirectory = "";
 
 	private FTPClient ftpClient;

--- a/core/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
@@ -60,7 +60,7 @@ import jakarta.mail.internet.MimeMultipart;
 import lombok.Getter;
 
 public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IMAPFolder> {
-	private final @Getter(onMethod = @__(@Override)) String domain = "IMAP";
+	private final @Getter String domain = "IMAP";
 
 	private @Getter String host;
 	private @Getter int port = 993;

--- a/core/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -30,11 +30,11 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.PathMessage;
+
+import lombok.Getter;
 
 /**
  * {@link IWritableFileSystem FileSystem} representation of the local filesystem.
@@ -43,7 +43,7 @@ import org.frankframework.stream.PathMessage;
  *
  */
 public class LocalFileSystem extends FileSystemBase<Path> implements IWritableFileSystem<Path> {
-	private final @Getter(onMethod = @__(@Override)) String domain = "LocalFilesystem";
+	private final @Getter String domain = "LocalFilesystem";
 
 	private String root;
 

--- a/core/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -30,11 +30,11 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+
+import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.PathMessage;
-
-import lombok.Getter;
 
 /**
  * {@link IWritableFileSystem FileSystem} representation of the local filesystem.

--- a/core/src/main/java/org/frankframework/filesystem/MailListener.java
+++ b/core/src/main/java/org/frankframework/filesystem/MailListener.java
@@ -61,8 +61,8 @@ import org.frankframework.xml.XmlWriter;
  */
 public abstract class MailListener<M, A, S extends IMailFileSystem<M,A>> extends FileSystemListener<M,S> {
 
-	public final String EMAIL_MESSAGE_TYPE="email";
-	public final String MIME_MESSAGE_TYPE="mime";
+	public static final String EMAIL_MESSAGE_TYPE="email";
+	public static final String MIME_MESSAGE_TYPE="mime";
 
 	private @Getter String storeEmailAsStreamInSessionKey;
 	private @Getter boolean simple = false;

--- a/core/src/main/java/org/frankframework/filesystem/Samba1FileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/Samba1FileSystem.java
@@ -24,9 +24,6 @@ import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.stream.Message;
-import org.frankframework.util.CredentialFactory;
 
 import jcifs.smb.NtlmPasswordAuthentication;
 import jcifs.smb.SmbException;
@@ -35,6 +32,9 @@ import jcifs.smb.SmbFileFilter;
 import jcifs.smb.SmbFileInputStream;
 import jcifs.smb.SmbFileOutputStream;
 import lombok.Getter;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.stream.Message;
+import org.frankframework.util.CredentialFactory;
 
 /**
  * Uses the (old) SMB 1 protocol.

--- a/core/src/main/java/org/frankframework/filesystem/Samba1FileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/Samba1FileSystem.java
@@ -24,6 +24,9 @@ import java.util.Map;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.stream.Message;
+import org.frankframework.util.CredentialFactory;
 
 import jcifs.smb.NtlmPasswordAuthentication;
 import jcifs.smb.SmbException;
@@ -32,9 +35,6 @@ import jcifs.smb.SmbFileFilter;
 import jcifs.smb.SmbFileInputStream;
 import jcifs.smb.SmbFileOutputStream;
 import lombok.Getter;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.stream.Message;
-import org.frankframework.util.CredentialFactory;
 
 /**
  * Uses the (old) SMB 1 protocol.
@@ -42,7 +42,7 @@ import org.frankframework.util.CredentialFactory;
  * Only supports NTLM authentication.
  */
 public class Samba1FileSystem extends FileSystemBase<SmbFile> implements IWritableFileSystem<SmbFile> {
-	private final @Getter(onMethod = @__(@Override)) String domain = "SMB";
+	private final @Getter String domain = "SMB";
 
 	private @Getter String share = null;
 	private @Getter String username = null;

--- a/core/src/main/java/org/frankframework/filesystem/Samba2FileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/Samba2FileSystem.java
@@ -85,7 +85,7 @@ import lombok.Getter;
  *
  */
 public class Samba2FileSystem extends FileSystemBase<SmbFileRef> implements IWritableFileSystem<SmbFileRef> {
-	private final @Getter(onMethod = @__(@Override)) String domain = "SMB";
+	private final @Getter String domain = "SMB";
 
 	private @Getter Samba2AuthType authType = Samba2AuthType.SPNEGO;
 	private @Getter String share = null;

--- a/core/src/main/java/org/frankframework/filesystem/SftpFileSystem.java
+++ b/core/src/main/java/org/frankframework/filesystem/SftpFileSystem.java
@@ -51,7 +51,7 @@ import lombok.Getter;
 public class SftpFileSystem extends SftpSession implements IWritableFileSystem<SftpFileRef> {
 	private final Logger log = LogUtil.getLogger(this);
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "FTP";
+	private final @Getter String domain = "FTP";
 	private String remoteDirectory = "";
 
 	private ChannelSftp ftpClient;

--- a/core/src/main/java/org/frankframework/http/HttpListener.java
+++ b/core/src/main/java/org/frankframework/http/HttpListener.java
@@ -16,14 +16,14 @@
 package org.frankframework.http;
 
 import org.apache.commons.lang3.StringUtils;
+
+import lombok.Getter;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IPushingListener;
 import org.frankframework.core.ListenerException;
 import org.frankframework.http.rest.ApiListener;
 import org.frankframework.receivers.Receiver;
 import org.frankframework.receivers.ServiceDispatcher;
-
-import lombok.Getter;
 
 /**
  * Implementation of a {@link IPushingListener IPushingListener} that enables a {@link Receiver}

--- a/core/src/main/java/org/frankframework/http/HttpListener.java
+++ b/core/src/main/java/org/frankframework/http/HttpListener.java
@@ -16,14 +16,14 @@
 package org.frankframework.http;
 
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.Getter;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IPushingListener;
 import org.frankframework.core.ListenerException;
 import org.frankframework.http.rest.ApiListener;
 import org.frankframework.receivers.Receiver;
 import org.frankframework.receivers.ServiceDispatcher;
+
+import lombok.Getter;
 
 /**
  * Implementation of a {@link IPushingListener IPushingListener} that enables a {@link Receiver}
@@ -37,7 +37,7 @@ import org.frankframework.receivers.ServiceDispatcher;
 @Deprecated
 public class HttpListener extends PushingListenerAdapter implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 	private @Getter String serviceName;
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/HttpSenderBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSenderBase.java
@@ -94,7 +94,7 @@ public abstract class HttpSenderBase extends HttpSessionBase implements HasPhysi
 	public static final String MESSAGE_ID_HEADER = "Message-Id";
 	public static final String CORRELATION_ID_HEADER = "Correlation-Id";
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 
 	private @Setter String sharedResourceRef;
 

--- a/core/src/main/java/org/frankframework/http/RestListener.java
+++ b/core/src/main/java/org/frankframework/http/RestListener.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.HasSpecialDefaultValues;
 import org.frankframework.core.HasPhysicalDestination;
@@ -34,6 +32,8 @@ import org.frankframework.pipes.JsonPipe;
 import org.frankframework.pipes.JsonPipe.Direction;
 import org.frankframework.receivers.Receiver;
 import org.frankframework.stream.Message;
+
+import lombok.Getter;
 
 /**
  * Listener that allows a {@link Receiver} to receive messages as a REST webservice.
@@ -51,7 +51,7 @@ import org.frankframework.stream.Message;
  */
 public class RestListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 	private @Getter String uriPattern;
 	private @Getter String method;
 	private @Getter String etagSessionKey;

--- a/core/src/main/java/org/frankframework/http/RestListener.java
+++ b/core/src/main/java/org/frankframework/http/RestListener.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
+
+import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.HasSpecialDefaultValues;
 import org.frankframework.core.HasPhysicalDestination;
@@ -32,8 +34,6 @@ import org.frankframework.pipes.JsonPipe;
 import org.frankframework.pipes.JsonPipe.Direction;
 import org.frankframework.receivers.Receiver;
 import org.frankframework.stream.Message;
-
-import lombok.Getter;
 
 /**
  * Listener that allows a {@link Receiver} to receive messages as a REST webservice.

--- a/core/src/main/java/org/frankframework/http/WebServiceListener.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceListener.java
@@ -26,6 +26,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.spring.SpringBus;
 import org.apache.cxf.jaxws.EndpointImpl;
+
+import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.HasSpecialDefaultValues;
@@ -39,10 +41,9 @@ import org.frankframework.receivers.ServiceDispatcher;
 import org.frankframework.soap.SoapWrapper;
 import org.frankframework.stream.Message;
 import org.frankframework.util.AppConstants;
+
 import org.frankframework.util.StringUtil;
 import org.frankframework.util.XmlBuilder;
-
-import lombok.Getter;
 
 /**
  * Listener that allows a {@link Receiver} to receive messages as a SOAP webservice.

--- a/core/src/main/java/org/frankframework/http/WebServiceListener.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceListener.java
@@ -26,8 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.spring.SpringBus;
 import org.apache.cxf.jaxws.EndpointImpl;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.HasSpecialDefaultValues;
@@ -41,9 +39,10 @@ import org.frankframework.receivers.ServiceDispatcher;
 import org.frankframework.soap.SoapWrapper;
 import org.frankframework.stream.Message;
 import org.frankframework.util.AppConstants;
-
 import org.frankframework.util.StringUtil;
 import org.frankframework.util.XmlBuilder;
+
+import lombok.Getter;
 
 /**
  * Listener that allows a {@link Receiver} to receive messages as a SOAP webservice.
@@ -68,7 +67,7 @@ import org.frankframework.util.XmlBuilder;
  */
 public class WebServiceListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 	private @Getter boolean soap = true;
 	private @Getter String serviceNamespaceURI;
 	private SoapWrapper soapWrapper = null;

--- a/core/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
@@ -43,6 +43,14 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+
+import jcifs.ntlmssp.NtlmFlags;
+import jcifs.ntlmssp.Type1Message;
+import jcifs.ntlmssp.Type2Message;
+import jcifs.ntlmssp.Type3Message;
+import jcifs.util.Base64;
+import lombok.Getter;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
@@ -54,13 +62,6 @@ import org.frankframework.stream.Message;
 import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.Misc;
 import org.frankframework.util.StreamUtil;
-
-import jcifs.ntlmssp.NtlmFlags;
-import jcifs.ntlmssp.Type1Message;
-import jcifs.ntlmssp.Type2Message;
-import jcifs.ntlmssp.Type3Message;
-import jcifs.util.Base64;
-import lombok.Getter;
 
 /**
  * Sender that sends a message via a WebService based on NTLM authentication.

--- a/core/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
@@ -43,14 +43,6 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
-
-import jcifs.ntlmssp.NtlmFlags;
-import jcifs.ntlmssp.Type1Message;
-import jcifs.ntlmssp.Type2Message;
-import jcifs.ntlmssp.Type3Message;
-import jcifs.util.Base64;
-import lombok.Getter;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
@@ -63,6 +55,13 @@ import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.Misc;
 import org.frankframework.util.StreamUtil;
 
+import jcifs.ntlmssp.NtlmFlags;
+import jcifs.ntlmssp.Type1Message;
+import jcifs.ntlmssp.Type2Message;
+import jcifs.ntlmssp.Type3Message;
+import jcifs.util.Base64;
+import lombok.Getter;
+
 /**
  * Sender that sends a message via a WebService based on NTLM authentication.
  *
@@ -70,7 +69,7 @@ import org.frankframework.util.StreamUtil;
  */
 public class WebServiceNtlmSender extends SenderWithParametersBase implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 	private String contentType = "text/xml; charset="+ StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 	private String url;
 	private int timeout = 10000;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -63,7 +63,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 
 	private static final Pattern VALID_URI_PATTERN_RE = Pattern.compile("([^/]\\*|\\*[^/\\n])");
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Http";
+	private final @Getter String domain = "Http";
 	private @Getter String uriPattern;
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);
 	private @Getter String operationId;
@@ -100,7 +100,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	private @Getter String roleClaim;
 
 	private @Getter String principalNameClaim = "sub";
-	private @Getter(onMethod = @__(@Override)) String physicalDestinationName = null;
+	private @Getter String physicalDestinationName = null;
 
 	private @Getter JwtValidator<SecurityContext> jwtValidator;
 	private @Setter ServletManager servletManager;

--- a/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
@@ -63,7 +63,7 @@ import lombok.Setter;
  * @since 	4.1
  */
 public class JdbcFacade extends JndiBase implements HasPhysicalDestination, IXAEnabled, HasStatistics {
-	private final @Getter(onMethod = @__(@Override)) String domain = "JDBC";
+	private final @Getter String domain = "JDBC";
 	private String datasourceName = null;
 	@Getter private String authAlias = null;
 	@Getter private String username = null;

--- a/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
@@ -20,7 +20,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Map;
 
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.HasPhysicalDestination;
@@ -28,15 +27,15 @@ import org.frankframework.core.IDataIterator;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeStartException;
 import org.frankframework.core.SenderException;
-
-import org.frankframework.doc.ReferTo;
 import org.frankframework.dbms.IDbmsSupport;
+import org.frankframework.doc.ReferTo;
 import org.frankframework.parameters.Parameter;
 import org.frankframework.pipes.StringIteratorPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.util.JdbcUtil;
-
 import org.frankframework.util.SpringUtils;
+
+import lombok.Getter;
 
 
 /**
@@ -47,7 +46,7 @@ import org.frankframework.util.SpringUtils;
  */
 public abstract class JdbcIteratingPipeBase extends StringIteratorPipe implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "JDBC";
+	private final @Getter String domain = "JDBC";
 	protected MixedQuerySender querySender = new MixedQuerySender();
 
 	protected class MixedQuerySender extends DirectQuerySender {

--- a/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Map;
 
+import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.HasPhysicalDestination;
@@ -27,15 +28,15 @@ import org.frankframework.core.IDataIterator;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeStartException;
 import org.frankframework.core.SenderException;
-import org.frankframework.dbms.IDbmsSupport;
+
 import org.frankframework.doc.ReferTo;
+import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.parameters.Parameter;
 import org.frankframework.pipes.StringIteratorPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.util.JdbcUtil;
-import org.frankframework.util.SpringUtils;
 
-import lombok.Getter;
+import org.frankframework.util.SpringUtils;
 
 
 /**

--- a/core/src/main/java/org/frankframework/jms/JMSFacade.java
+++ b/core/src/main/java/org/frankframework/jms/JMSFacade.java
@@ -89,7 +89,7 @@ public class JMSFacade extends JndiBase implements HasPhysicalDestination, IXAEn
 
 	public static final String JMS_MESSAGECLASS_KEY = "jms.messageClass.default";
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "JMS";
+	private final @Getter String domain = "JMS";
 	private final boolean createDestination = AppConstants.getInstance().getBoolean("jms.createDestination", false);
 	private final MessageClass messageClassDefault = AppConstants.getInstance().getOrDefault(JMS_MESSAGECLASS_KEY, MessageClass.AUTO);
 	private @Getter MessageClass messageClass = messageClassDefault;

--- a/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
+++ b/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
@@ -32,6 +32,24 @@ import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.xml.sax.SAXException;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.connection.ServerDescription;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import lombok.Getter;
+import lombok.Lombok;
+import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
@@ -53,24 +71,6 @@ import org.frankframework.stream.document.INodeBuilder;
 import org.frankframework.stream.document.ObjectBuilder;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.StringResolver;
-import org.xml.sax.SAXException;
-
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.InsertManyResult;
-import com.mongodb.client.result.InsertOneResult;
-import com.mongodb.client.result.UpdateResult;
-import com.mongodb.connection.ServerDescription;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import lombok.Getter;
-import lombok.Lombok;
-import lombok.Setter;
 
 /**
  * Sender to perform action on a MongoDB database.

--- a/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
+++ b/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
@@ -32,24 +32,6 @@ import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
-import org.xml.sax.SAXException;
-
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.result.DeleteResult;
-import com.mongodb.client.result.InsertManyResult;
-import com.mongodb.client.result.InsertOneResult;
-import com.mongodb.client.result.UpdateResult;
-import com.mongodb.connection.ServerDescription;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import lombok.Getter;
-import lombok.Lombok;
-import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
@@ -71,6 +53,24 @@ import org.frankframework.stream.document.INodeBuilder;
 import org.frankframework.stream.document.ObjectBuilder;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.StringResolver;
+import org.xml.sax.SAXException;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.result.UpdateResult;
+import com.mongodb.connection.ServerDescription;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import lombok.Getter;
+import lombok.Lombok;
+import lombok.Setter;
 
 /**
  * Sender to perform action on a MongoDB database.
@@ -85,7 +85,7 @@ import org.frankframework.util.StringResolver;
  */
 public class MongoDbSender extends SenderWithParametersBase implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Mongo";
+	private final @Getter String domain = "Mongo";
 	public static final String PARAM_DATABASE="database";
 	public static final String PARAM_COLLECTION="collection";
 	public static final String PARAM_FILTER="filter";

--- a/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
@@ -26,15 +26,6 @@ import javax.xml.validation.ValidatorHandler;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.xs.XSModel;
-import org.springframework.http.MediaType;
-import org.springframework.util.MimeType;
-import org.springframework.util.MimeTypeUtils;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.helpers.XMLFilterImpl;
-
-import jakarta.json.Json;
-import jakarta.json.JsonStructure;
-import lombok.Getter;
 import org.frankframework.align.Json2Xml;
 import org.frankframework.align.Xml2Json;
 import org.frankframework.align.XmlAligner;
@@ -61,6 +52,15 @@ import org.frankframework.validation.XmlValidatorException;
 import org.frankframework.xml.NamespaceRemovingFilter;
 import org.frankframework.xml.RootElementToSessionKeyFilter;
 import org.frankframework.xml.XmlWriter;
+import org.springframework.http.MediaType;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import jakarta.json.Json;
+import jakarta.json.JsonStructure;
+import lombok.Getter;
 
 /**
  *<code>Pipe</code> that validates the XML or JSON input message against a XML Schema and returns either XML or JSON.
@@ -69,7 +69,7 @@ import org.frankframework.xml.XmlWriter;
  */
 public class Json2XmlValidator extends XmlValidator implements HasPhysicalDestination {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "XML Schema";
+	private final @Getter String domain = "XML Schema";
 	public static final String INPUT_FORMAT_SESSION_KEY_PREFIX = "Json2XmlValidator.inputFormat ";
 
 	private @Getter boolean compactJsonArrays=true;

--- a/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
@@ -26,6 +26,15 @@ import javax.xml.validation.ValidatorHandler;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.xs.XSModel;
+import org.springframework.http.MediaType;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import jakarta.json.Json;
+import jakarta.json.JsonStructure;
+import lombok.Getter;
 import org.frankframework.align.Json2Xml;
 import org.frankframework.align.Xml2Json;
 import org.frankframework.align.XmlAligner;
@@ -52,15 +61,6 @@ import org.frankframework.validation.XmlValidatorException;
 import org.frankframework.xml.NamespaceRemovingFilter;
 import org.frankframework.xml.RootElementToSessionKeyFilter;
 import org.frankframework.xml.XmlWriter;
-import org.springframework.http.MediaType;
-import org.springframework.util.MimeType;
-import org.springframework.util.MimeTypeUtils;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.helpers.XMLFilterImpl;
-
-import jakarta.json.Json;
-import jakarta.json.JsonStructure;
-import lombok.Getter;
 
 /**
  *<code>Pipe</code> that validates the XML or JSON input message against a XML Schema and returns either XML or JSON.

--- a/core/src/main/java/org/frankframework/receivers/ExchangeMailListener.java
+++ b/core/src/main/java/org/frankframework/receivers/ExchangeMailListener.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016, 2019 Nationale-Nederlanden, 2020, 2022 WeAreFrank!
+   Copyright 2016, 2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 package org.frankframework.receivers;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.ReferTo;
+import org.frankframework.encryption.HasKeystore;
+import org.frankframework.encryption.HasTruststore;
 import org.frankframework.encryption.KeystoreType;
 import org.frankframework.filesystem.ExchangeAttachmentReference;
 import org.frankframework.filesystem.ExchangeFileSystem;
 import org.frankframework.filesystem.ExchangeMessageReference;
+import org.frankframework.filesystem.MailFileSystemBase;
 import org.frankframework.filesystem.MailListener;
 
 /**
@@ -96,7 +98,7 @@ public class ExchangeMailListener extends MailListener<ExchangeMessageReference,
 		getFileSystem().setAuthAlias(authAlias);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(MailFileSystemBase.class)
 	public void setBaseFolder(String baseFolder) {
 		getFileSystem().setBaseFolder(baseFolder);
 	}
@@ -106,7 +108,7 @@ public class ExchangeMailListener extends MailListener<ExchangeMessageReference,
 		getFileSystem().setFilter(filter);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(MailFileSystemBase.class)
 	public void setReplyAddressFields(String replyAddressFields) {
 		getFileSystem().setReplyAddressFields(replyAddressFields);
 	}
@@ -145,68 +147,68 @@ public class ExchangeMailListener extends MailListener<ExchangeMessageReference,
 	public void setMailboxObjectSeparator(String separator) {
 		getFileSystem().setMailboxObjectSeparator(separator);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystore(String keystore) {
 		getFileSystem().setKeystore(keystore);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreType(KeystoreType keystoreType) {
 		getFileSystem().setKeystoreType(keystoreType);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAuthAlias(String keystoreAuthAlias) {
 		getFileSystem().setKeystoreAuthAlias(keystoreAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystorePassword(String keystorePassword) {
 		getFileSystem().setKeystorePassword(keystorePassword);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeyManagerAlgorithm(String keyManagerAlgorithm) {
 		getFileSystem().setKeyManagerAlgorithm(keyManagerAlgorithm);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAlias(String keystoreAlias) {
 		getFileSystem().setKeystoreAlias(keystoreAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAliasAuthAlias(String keystoreAliasAuthAlias) {
 		getFileSystem().setKeystoreAliasAuthAlias(keystoreAliasAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAliasPassword(String keystoreAliasPassword) {
 		getFileSystem().setKeystoreAliasPassword(keystoreAliasPassword);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststore(String truststore) {
 		getFileSystem().setTruststore(truststore);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststoreType(KeystoreType truststoreType) {
 		getFileSystem().setTruststoreType(truststoreType);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststoreAuthAlias(String truststoreAuthAlias) {
 		getFileSystem().setTruststoreAuthAlias(truststoreAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststorePassword(String truststorePassword) {
 		getFileSystem().setTruststorePassword(truststorePassword);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTrustManagerAlgorithm(String trustManagerAlgorithm) {
 		getFileSystem().setTrustManagerAlgorithm(trustManagerAlgorithm);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setVerifyHostname(boolean verifyHostname) {
 		getFileSystem().setVerifyHostname(verifyHostname);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates) {
 		getFileSystem().setAllowSelfSignedCertificates(allowSelfSignedCertificates);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException) {
 		getFileSystem().setIgnoreCertificateExpiredException(ignoreCertificateExpiredException);
 	}

--- a/core/src/main/java/org/frankframework/receivers/JavaListener.java
+++ b/core/src/main/java/org/frankframework/receivers/JavaListener.java
@@ -65,7 +65,7 @@ import nl.nn.adapterframework.dispatcher.RequestProcessor;
 @Category("Basic")
 public class JavaListener<M> implements IPushingListener<M>, RequestProcessor, HasPhysicalDestination, ServiceClient {
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "JVM";
+	private final @Getter String domain = "JVM";
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/core/src/main/java/org/frankframework/scheduler/JobDef.java
+++ b/core/src/main/java/org/frankframework/scheduler/JobDef.java
@@ -16,23 +16,22 @@
 package org.frankframework.scheduler;
 
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.scheduler.job.IJob;
-import org.quartz.JobDetail;
-import org.springframework.context.ApplicationContext;
-
-import lombok.Getter;
-import lombok.Setter;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.IConfigurationAware;
 import org.frankframework.core.TransactionAttributes;
-
+import org.frankframework.scheduler.job.IJob;
 import org.frankframework.statistics.StatisticsKeeper;
 import org.frankframework.task.TimeoutGuard;
 import org.frankframework.util.Locker;
 import org.frankframework.util.MessageKeeper;
 import org.frankframework.util.MessageKeeper.MessageKeeperLevel;
+import org.quartz.JobDetail;
+import org.springframework.context.ApplicationContext;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Definition / configuration of scheduler jobs.
@@ -298,7 +297,7 @@ public abstract class JobDef extends TransactionAttributes implements IConfigura
 	private @Getter String cronExpression;
 	private @Getter long interval = -1;
 
-	private @Getter(onMethod = @__(@Override)) Locker locker = null;
+	private @Getter Locker locker = null;
 	private @Getter int numThreads = 1;
 	private int countThreads = 0;
 

--- a/core/src/main/java/org/frankframework/scheduler/JobDef.java
+++ b/core/src/main/java/org/frankframework/scheduler/JobDef.java
@@ -16,22 +16,23 @@
 package org.frankframework.scheduler;
 
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.configuration.Configuration;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.configuration.IbisManager;
-import org.frankframework.core.IConfigurationAware;
-import org.frankframework.core.TransactionAttributes;
 import org.frankframework.scheduler.job.IJob;
-import org.frankframework.statistics.StatisticsKeeper;
-import org.frankframework.task.TimeoutGuard;
-import org.frankframework.util.Locker;
-import org.frankframework.util.MessageKeeper;
-import org.frankframework.util.MessageKeeper.MessageKeeperLevel;
 import org.quartz.JobDetail;
 import org.springframework.context.ApplicationContext;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.frankframework.configuration.Configuration;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.IbisManager;
+import org.frankframework.core.IConfigurationAware;
+import org.frankframework.core.TransactionAttributes;
+
+import org.frankframework.statistics.StatisticsKeeper;
+import org.frankframework.task.TimeoutGuard;
+import org.frankframework.util.Locker;
+import org.frankframework.util.MessageKeeper;
+import org.frankframework.util.MessageKeeper.MessageKeeperLevel;
 
 /**
  * Definition / configuration of scheduler jobs.

--- a/core/src/main/java/org/frankframework/senders/ExchangeFolderSender.java
+++ b/core/src/main/java/org/frankframework/senders/ExchangeFolderSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019-2022 WeAreFrank!
+   Copyright 2019-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,10 +17,14 @@ package org.frankframework.senders;
 
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.doc.ReferTo;
+import org.frankframework.encryption.HasKeystore;
+import org.frankframework.encryption.HasTruststore;
 import org.frankframework.encryption.KeystoreType;
 import org.frankframework.filesystem.ExchangeFileSystem;
 import org.frankframework.filesystem.ExchangeMessageReference;
 import org.frankframework.filesystem.FileSystemSender;
+import org.frankframework.filesystem.MailFileSystemBase;
+
 /**
  * Implementation of a {@link FileSystemSender} that enables to manipulate messages in an Exchange folder.
  *
@@ -57,9 +61,9 @@ public class ExchangeFolderSender extends FileSystemSender<ExchangeMessageRefere
 		getFileSystem().setTenantId(tenantId);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
 	@Deprecated
 	@ConfigurationWarning("Authentication to Exchange Web Services with username and password will be disabled 2021-Q3. Please migrate to modern authentication using clientId and clientSecret. N.B. username no longer defaults to mailaddress")
+	@ReferTo(ExchangeFileSystem.class)
 	public void setUsername(String username) {
 		getFileSystem().setUsername(username);
 	}
@@ -76,7 +80,7 @@ public class ExchangeFolderSender extends FileSystemSender<ExchangeMessageRefere
 		getFileSystem().setAuthAlias(authAlias);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(MailFileSystemBase.class)
 	public void setBaseFolder(String baseFolder) {
 		getFileSystem().setBaseFolder(baseFolder);
 	}
@@ -86,7 +90,7 @@ public class ExchangeFolderSender extends FileSystemSender<ExchangeMessageRefere
 		getFileSystem().setFilter(filter);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(MailFileSystemBase.class)
 	public void setReplyAddressFields(String replyAddressFields) {
 		getFileSystem().setReplyAddressFields(replyAddressFields);
 	}
@@ -126,68 +130,68 @@ public class ExchangeFolderSender extends FileSystemSender<ExchangeMessageRefere
 		getFileSystem().setMailboxObjectSeparator(separator);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystore(String keystore) {
 		getFileSystem().setKeystore(keystore);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreType(KeystoreType keystoreType) {
 		getFileSystem().setKeystoreType(keystoreType);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAuthAlias(String keystoreAuthAlias) {
 		getFileSystem().setKeystoreAuthAlias(keystoreAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystorePassword(String keystorePassword) {
 		getFileSystem().setKeystorePassword(keystorePassword);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeyManagerAlgorithm(String keyManagerAlgorithm) {
 		getFileSystem().setKeyManagerAlgorithm(keyManagerAlgorithm);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAlias(String keystoreAlias) {
 		getFileSystem().setKeystoreAlias(keystoreAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAliasAuthAlias(String keystoreAliasAuthAlias) {
 		getFileSystem().setKeystoreAliasAuthAlias(keystoreAliasAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasKeystore.class)
 	public void setKeystoreAliasPassword(String keystoreAliasPassword) {
 		getFileSystem().setKeystoreAliasPassword(keystoreAliasPassword);
 	}
 
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststore(String truststore) {
 		getFileSystem().setTruststore(truststore);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststoreType(KeystoreType truststoreType) {
 		getFileSystem().setTruststoreType(truststoreType);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststoreAuthAlias(String truststoreAuthAlias) {
 		getFileSystem().setTruststoreAuthAlias(truststoreAuthAlias);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTruststorePassword(String truststorePassword) {
 		getFileSystem().setTruststorePassword(truststorePassword);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setTrustManagerAlgorithm(String trustManagerAlgorithm) {
 		getFileSystem().setTrustManagerAlgorithm(trustManagerAlgorithm);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setVerifyHostname(boolean verifyHostname) {
 		getFileSystem().setVerifyHostname(verifyHostname);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates) {
 		getFileSystem().setAllowSelfSignedCertificates(allowSelfSignedCertificates);
 	}
-	@ReferTo(ExchangeFileSystem.class)
+	@ReferTo(HasTruststore.class)
 	public void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException) {
 		getFileSystem().setIgnoreCertificateExpiredException(ignoreCertificateExpiredException);
 	}

--- a/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
@@ -65,7 +65,7 @@ public class IbisJavaSender extends SenderWithParametersBase implements HasPhysi
 	private static final String MULTIPART_RESPONSE_CONTENT_TYPE = "application/octet-stream";
 	private static final String MULTIPART_RESPONSE_CHARSET = "UTF-8";
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "JVM";
+	private final @Getter String domain = "JVM";
 
 	private @Getter String serviceName;
 	private @Getter String serviceNameSessionKey;

--- a/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
@@ -105,14 +105,14 @@ import org.frankframework.stream.ThreadLifeCycleEventListener;
 @Category("Basic")
 public class IbisLocalSender extends SenderWithParametersBase implements HasPhysicalDestination, IThreadCreator{
 
-	private final @Getter(onMethod = @__(@Override)) String domain = "Local";
+	private final @Getter String domain = "Local";
 
 	private Configuration configuration;
 	private @Getter String serviceName;
 	private @Getter String javaListener;
 	private @Getter String javaListenerSessionKey;
 	private @Getter boolean isolated=false;
-	private @Getter(onMethod = @__({@Override})) boolean synchronous=true;
+	private @Getter boolean synchronous=true;
 	private @Getter boolean checkDependency=true;
 	private @Getter int dependencyTimeOut=60;
 	private @Getter String returnedSessionKeys=""; // do not initialize with null, returned session keys must be set explicitly

--- a/core/src/main/java/org/frankframework/validation/XSD.java
+++ b/core/src/main/java/org/frankframework/validation/XSD.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -83,7 +82,7 @@ public abstract class XSD implements IXSD, Comparable<XSD> {
 	private final @Getter Set<String> importedNamespaces = new HashSet<>();
 	private @Getter String xsdTargetNamespace;
 	private @Getter String xsdDefaultNamespace;
-	private @Getter(onMethod_ = {@Nullable, @Override}) @Setter IXSD importParent;
+	private @Getter @Setter IXSD importParent;
 
 	protected XSD() {
 		super();

--- a/core/src/main/java/org/frankframework/validation/XSD.java
+++ b/core/src/main/java/org/frankframework/validation/XSD.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -82,7 +83,7 @@ public abstract class XSD implements IXSD, Comparable<XSD> {
 	private final @Getter Set<String> importedNamespaces = new HashSet<>();
 	private @Getter String xsdTargetNamespace;
 	private @Getter String xsdDefaultNamespace;
-	private @Getter @Setter IXSD importParent;
+	private @Setter IXSD importParent;
 
 	protected XSD() {
 		super();
@@ -438,4 +439,9 @@ public abstract class XSD implements IXSD, Comparable<XSD> {
 		}
 	}
 
+	@Nullable
+	@Override
+	public IXSD getImportParent() {
+		return importParent;
+	}
 }

--- a/core/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
+++ b/core/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class MockFileSystem<M extends MockFile> extends MockFolder implements IWritableFileSystem<M>, ApplicationContextAware {
-	private final @Getter(onMethod = @__(@Override)) String domain = "MockFilesystem";
+	private final @Getter String domain = "MockFilesystem";
 	protected Logger log = LogUtil.getLogger(this);
 
 	private boolean configured=false;

--- a/core/src/test/java/org/frankframework/testutil/mock/TransactionManagerMock.java
+++ b/core/src/test/java/org/frankframework/testutil/mock/TransactionManagerMock.java
@@ -45,8 +45,8 @@ public class TransactionManagerMock implements PlatformTransactionManager {
 	}
 
 	public abstract static class DummyTransactionStatus implements TransactionStatus {
-		private @Getter(onMethod = @__(@Override)) boolean rollbackOnly = false;
-		private @Getter(onMethod = @__(@Override)) boolean completed = false;
+		private @Getter boolean rollbackOnly = false;
+		private @Getter boolean completed = false;
 		public static DummyTransactionStatus newMock() {
 			return mock(DummyTransactionStatus.class, CALLS_REAL_METHODS);
 		}

--- a/messaging/src/main/java/org/frankframework/extensions/kafka/KafkaFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/kafka/KafkaFacade.java
@@ -22,21 +22,21 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.HasPhysicalDestination;
+import org.frankframework.core.IConfigurable;
 import org.springframework.context.ApplicationContext;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.HasPhysicalDestination;
-import org.frankframework.core.IConfigurable;
 
 @Log4j2
 public abstract class KafkaFacade implements HasPhysicalDestination, IConfigurable {
-	private final @Getter(onMethod = @__(@Override)) String domain = "KAFKA";
-	private final @Getter(onMethod = @__(@Override)) ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
-	private @Getter(onMethod = @__(@Override)) @Setter ApplicationContext applicationContext;
+	private final @Getter String domain = "KAFKA";
+	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
+	private @Getter @Setter ApplicationContext applicationContext;
 
 	private @Setter @Getter String name;
 	/** The bootstrap servers to connect to, as a comma separated list. */

--- a/messaging/src/main/java/org/frankframework/extensions/kafka/KafkaFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/kafka/KafkaFacade.java
@@ -22,15 +22,15 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.HasPhysicalDestination;
-import org.frankframework.core.IConfigurable;
 import org.springframework.context.ApplicationContext;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.HasPhysicalDestination;
+import org.frankframework.core.IConfigurable;
 
 @Log4j2
 public abstract class KafkaFacade implements HasPhysicalDestination, IConfigurable {

--- a/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
@@ -22,16 +22,16 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttSecurityException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.HasPhysicalDestination;
-import org.frankframework.core.IConfigurable;
-import org.frankframework.core.ListenerException;
-import org.frankframework.util.CredentialFactory;
 import org.springframework.context.ApplicationContext;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.HasPhysicalDestination;
+import org.frankframework.core.IConfigurable;
+import org.frankframework.core.ListenerException;
+import org.frankframework.util.CredentialFactory;
 
 @Log4j2
 public class MqttFacade implements HasPhysicalDestination, IConfigurable {

--- a/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
@@ -22,22 +22,22 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttSecurityException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
-import org.springframework.context.ApplicationContext;
-
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IConfigurable;
 import org.frankframework.core.ListenerException;
 import org.frankframework.util.CredentialFactory;
+import org.springframework.context.ApplicationContext;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class MqttFacade implements HasPhysicalDestination, IConfigurable {
-	private final @Getter(onMethod = @__(@Override)) String domain = "MQTT";
-	private @Getter(onMethod = @__(@Override)) ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
-	private @Getter(onMethod = @__(@Override)) @Setter ApplicationContext applicationContext;
+	private final @Getter String domain = "MQTT";
+	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
+	private @Getter @Setter ApplicationContext applicationContext;
 
 	private @Getter String name;
 	private @Getter int timeout = 3000;

--- a/pom.xml
+++ b/pom.xml
@@ -754,6 +754,18 @@
 							<version>1.18.30</version>
 						</dependency>
 					</dependencies>
+					<executions>
+						<execution>
+							<phase>generate-sources</phase>
+							<goals>
+								<goal>delombok</goal>
+							</goals>
+							<configuration>
+								<sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+								<addOutputDirectory>false</addOutputDirectory>
+							</configuration>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.glassfish.copyright</groupId>
@@ -1320,8 +1332,15 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.projectlombok</groupId>
+						<artifactId>lombok-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>
@@ -1353,7 +1372,6 @@
 						<version>1.0</version>
 						<inherited>false</inherited> <!-- Only run the Frank!Doc once and include all modules -->
 						<configuration>
-							<includeDeLombokSources>false</includeDeLombokSources>
 							<doclint>none</doclint>
 							<quiet>true</quiet>
 							<doclet>org.frankframework.frankdoc.doclet.DocletBuilder</doclet>

--- a/pom.xml
+++ b/pom.xml
@@ -746,18 +746,6 @@
 					<groupId>org.projectlombok</groupId>
 					<artifactId>lombok-maven-plugin</artifactId>
 					<version>1.18.20.0</version>
-					<executions>
-						<execution>
-							<phase>generate-sources</phase>
-							<goals>
-								<goal>delombok</goal>
-							</goals>
-							<configuration>
-								<sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
-								<addOutputDirectory>false</addOutputDirectory>
-							</configuration>
-						</execution>
-					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.glassfish.copyright</groupId>
@@ -1324,15 +1312,8 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.projectlombok</groupId>
-						<artifactId>lombok-maven-plugin</artifactId>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<configuration>
-							<sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>
@@ -1364,6 +1345,7 @@
 						<version>1.0</version>
 						<inherited>false</inherited> <!-- Only run the Frank!Doc once and include all modules -->
 						<configuration>
+							<includeDeLombokSources>false</includeDeLombokSources>
 							<doclint>none</doclint>
 							<quiet>true</quiet>
 							<doclet>org.frankframework.frankdoc.doclet.DocletBuilder</doclet>

--- a/pom.xml
+++ b/pom.xml
@@ -534,12 +534,6 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.junit.vintage</groupId>
-				<artifactId>junit-vintage-engine</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter</artifactId>
 				<version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>
@@ -746,6 +747,13 @@
 					<groupId>org.projectlombok</groupId>
 					<artifactId>lombok-maven-plugin</artifactId>
 					<version>1.18.20.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.glassfish.copyright</groupId>

--- a/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
@@ -20,9 +20,15 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.extensions.sap.ISapFunctionFacade;
 import org.frankframework.extensions.sap.SapException;
 import org.frankframework.extensions.sap.jco3.handlers.Handler;
+import org.frankframework.parameters.ParameterValue;
+import org.frankframework.parameters.ParameterValueList;
+import org.frankframework.stream.Message;
+import org.frankframework.util.LogUtil;
+import org.frankframework.util.XmlUtils;
 import org.springframework.context.ApplicationContext;
 
 import com.sap.conn.jco.JCoFunction;
@@ -32,12 +38,6 @@ import com.sap.conn.jco.JCoStructure;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.parameters.ParameterValue;
-import org.frankframework.parameters.ParameterValueList;
-import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
-import org.frankframework.util.XmlUtils;
 /**
  * Wrapper round SAP-functions, either SAP calling Ibis, or Ibis calling SAP.
  *
@@ -49,7 +49,7 @@ import org.frankframework.util.XmlUtils;
  * @since   5.0
  */
 public abstract class SapFunctionFacade implements ISapFunctionFacade {
-	private final @Getter(onMethod = @__(@Override)) String domain = "SAP";
+	private final @Getter String domain = "SAP";
 	protected static Logger log = LogUtil.getLogger(SapFunctionFacade.class);
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
@@ -20,15 +20,9 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.extensions.sap.ISapFunctionFacade;
 import org.frankframework.extensions.sap.SapException;
 import org.frankframework.extensions.sap.jco3.handlers.Handler;
-import org.frankframework.parameters.ParameterValue;
-import org.frankframework.parameters.ParameterValueList;
-import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
-import org.frankframework.util.XmlUtils;
 import org.springframework.context.ApplicationContext;
 
 import com.sap.conn.jco.JCoFunction;
@@ -38,6 +32,12 @@ import com.sap.conn.jco.JCoStructure;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.parameters.ParameterValue;
+import org.frankframework.parameters.ParameterValueList;
+import org.frankframework.stream.Message;
+import org.frankframework.util.LogUtil;
+import org.frankframework.util.XmlUtils;
 /**
  * Wrapper round SAP-functions, either SAP calling Ibis, or Ibis calling SAP.
  *

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -63,11 +63,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
Real fix was specifying the version of Lombok to the plugin.

Also removed the `onMethod`, which we need to discuss in a meeting, if we should keep it or not. 
There are 2 options to write those:
up to JDK7: `@Getter(onMethod=@__({@AnnotationsGoHere}))`
from JDK8: `@Getter(onMethod_={@AnnotationsGohere}) // note the underscore after onMethod.`

Fixed some side-findings: vintage-engine, missing `groupId` for maven-compiler-plugin.