### PR TITLE
Clean up TransformerPool.getInstance()

### DIFF
--- a/core/src/main/java/org/frankframework/core/Resource.java
+++ b/core/src/main/java/org/frankframework/core/Resource.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019-2021 WeAreFrank!
+   Copyright 2019-2021, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -19,16 +19,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.xml.transform.Source;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.xerces.xni.parser.XMLInputSource;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.util.ClassLoaderUtils;
 import org.frankframework.util.XmlUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Reference to a resource, for instance on the classpath. Can be accessed multiple times.
@@ -47,15 +48,18 @@ public abstract class Resource implements IScopeProvider {
 		this.scopeProvider = scopeProvider;
 	}
 
-	public static Resource getResource(String resource) {
+	@Nullable
+	public static Resource getResource(@Nonnull String resource) {
 		return getResource(null, resource);
 	}
 
-	public static Resource getResource(IScopeProvider scopeProvider, String resource) {
+	@Nullable
+	public static Resource getResource(@Nullable IScopeProvider scopeProvider, @Nonnull String resource) {
 		return getResource(scopeProvider, resource, null);
 	}
 
-	public static Resource getResource(IScopeProvider scopeProvider, String resource, String allowedProtocols) {
+	@Nullable
+	public static Resource getResource(@Nullable IScopeProvider scopeProvider, @Nonnull String resource, String allowedProtocols) {
 		if(scopeProvider == null) {
 			scopeProvider = new GlobalScopeProvider(); // if no scope has been provided, assume to use the default 'global' scope.
 		}

--- a/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
@@ -106,7 +106,7 @@ public class ForEachChildElementPipe extends StringIteratorPipe implements IThre
 				if (streamingXslt && getXsltVersion() != DEFAULT_XSLT_VERSION) {
 					ConfigurationWarnings.add(this, log, "XsltProcessor xsltVersion ["+getXsltVersion()+"] currently does not support streaming XSLT, might lead to memory problems for large messages", SuppressKeys.XSLT_STREAMING_SUPRESS_KEY);
 				}
-				extractElementsTp=TransformerPool.getInstance(makeEncapsulatingXslt("root",getElementXPathExpression(), getXsltVersion(), getNamespaceDefs()), getXsltVersion());
+				extractElementsTp=TransformerPool.getInstance(makeEncapsulatingXslt("root",getElementXPathExpression(), getXsltVersion(), getNamespaceDefs()), getXsltVersion(), this);
 			}
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("elementXPathExpression ["+getElementXPathExpression()+"]",e);

--- a/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2019 Nationale-Nederlanden, 2020-2022 WeAreFrank!
+   Copyright 2013, 2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/ForEachChildElementPipe.java
@@ -26,13 +26,6 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.xml.sax.Attributes;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-
-import lombok.Getter;
-import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.configuration.ConfigurationWarnings;
@@ -66,6 +59,13 @@ import org.frankframework.xml.NodeSetFilter;
 import org.frankframework.xml.SaxException;
 import org.frankframework.xml.TransformerFilter;
 import org.frankframework.xml.XmlWriter;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Sends a message to a Sender for each child element of the input XML.
@@ -106,7 +106,7 @@ public class ForEachChildElementPipe extends StringIteratorPipe implements IThre
 				if (streamingXslt && getXsltVersion() != DEFAULT_XSLT_VERSION) {
 					ConfigurationWarnings.add(this, log, "XsltProcessor xsltVersion ["+getXsltVersion()+"] currently does not support streaming XSLT, might lead to memory problems for large messages", SuppressKeys.XSLT_STREAMING_SUPRESS_KEY);
 				}
-				extractElementsTp=TransformerPool.getInstance(makeEncapsulatingXslt("root",getElementXPathExpression(), getXsltVersion(), getNamespaceDefs()));
+				extractElementsTp=TransformerPool.getInstance(makeEncapsulatingXslt("root",getElementXPathExpression(), getXsltVersion(), getNamespaceDefs()), getXsltVersion());
 			}
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("elementXPathExpression ["+getElementXPathExpression()+"]",e);
@@ -140,10 +140,10 @@ public class ForEachChildElementPipe extends StringIteratorPipe implements IThre
 	}
 
 	protected String makeEncapsulatingXslt(String rootElementname, String xpathExpression, int xsltVersion, String namespaceDefs) {
-		String paramsString = "";
+		StringBuilder paramsString = new StringBuilder();
 		if (getParameterList() != null) {
 			for (Parameter param: getParameterList()) {
-				paramsString = paramsString + "<xsl:param name=\"" + param.getName() + "\"/>";
+				paramsString.append("<xsl:param name=\"").append(param.getName()).append("\"/>");
 			}
 		}
 		String namespaceClause = XmlUtils.getNamespaceClause(namespaceDefs);

--- a/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016 Nationale-Nederlanden, 2020-2022 WeAreFrank!
+   Copyright 2013, 2016 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
@@ -146,7 +146,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 		}
 		try {
 			if (StringUtils.isNotEmpty(getStopConditionXPathExpression())) {
-				stopConditionTp=TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null,getStopConditionXPathExpression(),OutputType.XML,false));
+				stopConditionTp=TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null,getStopConditionXPathExpression(),OutputType.XML,false), XmlUtils.DEFAULT_XSLT_VERSION);
 				stopConditionStatisticsKeeper =  new StatisticsKeeper("-> stop condition determination");
 			}
 		} catch (TransformerConfigurationException e) {
@@ -170,7 +170,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 	}
 
 	protected StopReason iterateOverInput(Message input, PipeLineSession session, Map<String,Object> threadContext, ItemCallback callback) throws SenderException, TimeoutException, IOException {
-		IDataIterator<I> it=null;
+		IDataIterator<I> it;
 		StopReason stopReason = null;
 		if (StringUtils.isNotEmpty(getItemNoSessionKey())) {
 			session.put(getItemNoSessionKey(),"0"); // prefill session variable, to have a value if iterator is empty

--- a/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/IteratingPipe.java
@@ -146,7 +146,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 		}
 		try {
 			if (StringUtils.isNotEmpty(getStopConditionXPathExpression())) {
-				stopConditionTp=TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null,getStopConditionXPathExpression(),OutputType.XML,false), XmlUtils.DEFAULT_XSLT_VERSION);
+				stopConditionTp=TransformerPool.getXPathTransformerPool(null,getStopConditionXPathExpression(),OutputType.XML);
 				stopConditionStatisticsKeeper =  new StatisticsKeeper("-> stop condition determination");
 			}
 		} catch (TransformerConfigurationException e) {

--- a/core/src/main/java/org/frankframework/pipes/XmlIf.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlIf.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2023 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/pipes/XmlIf.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlIf.java
@@ -77,7 +77,7 @@ public class XmlIf extends AbstractPipe {
 		super.configure();
 		if (StringUtils.isNotEmpty(getXpathExpression())) {
 			try {
-				tp = TransformerPool.getInstance(makeStylesheet(getXpathExpression(), getExpressionValue()), xsltVersion);
+				tp = TransformerPool.getInstance(makeStylesheet(getXpathExpression(), getExpressionValue()), xsltVersion, this);
 			} catch (TransformerConfigurationException e) {
 				throw new ConfigurationException("could not create transformer from xpathExpression ["+getXpathExpression()+"], target expressionValue ["+getExpressionValue()+"]",e);
 			}

--- a/core/src/main/java/org/frankframework/pipes/XmlIf.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlIf.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import javax.xml.transform.TransformerConfigurationException;
 
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeForward;
@@ -37,6 +35,8 @@ import org.frankframework.util.TransformerPool;
 import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.XmlEncodingUtils;
 import org.frankframework.util.XmlUtils;
+
+import lombok.Getter;
 
 /**
  * Selects an forward, based on XPath evaluation
@@ -77,7 +77,7 @@ public class XmlIf extends AbstractPipe {
 		super.configure();
 		if (StringUtils.isNotEmpty(getXpathExpression())) {
 			try {
-				tp = TransformerPool.getInstance(makeStylesheet(getXpathExpression(), getExpressionValue()));
+				tp = TransformerPool.getInstance(makeStylesheet(getXpathExpression(), getExpressionValue()), xsltVersion);
 			} catch (TransformerConfigurationException e) {
 				throw new ConfigurationException("could not create transformer from xpathExpression ["+getXpathExpression()+"], target expressionValue ["+getExpressionValue()+"]",e);
 			}

--- a/core/src/main/java/org/frankframework/pipes/XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlValidator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2015-2017 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2013, 2015-2017 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/pipes/XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlValidator.java
@@ -32,12 +32,6 @@ import javax.xml.validation.ValidatorHandler;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.xs.XSModel;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationContext;
-import org.xml.sax.helpers.XMLFilterImpl;
-
-import lombok.Getter;
-import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.HasSpecialDefaultValues;
@@ -74,6 +68,12 @@ import org.frankframework.validation.XercesXmlValidator;
 import org.frankframework.validation.XmlValidatorException;
 import org.frankframework.validation.xsd.ResourceXsd;
 import org.frankframework.xml.RootElementToSessionKeyFilter;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -148,7 +148,7 @@ public class XmlValidator extends ValidatorBase implements SchemasProvider, HasS
 				String extractNamespaceDefs = "soapenv=" + getSoapNamespace();
 				String extractBodyXPath     = "/soapenv:Envelope/soapenv:Body/*";
 				try {
-					transformerPoolExtractSoapBody = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(extractNamespaceDefs, extractBodyXPath, OutputType.XML));
+					transformerPoolExtractSoapBody = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(extractNamespaceDefs, extractBodyXPath, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
 				} catch (TransformerConfigurationException te) {
 					throw new ConfigurationException("got error creating transformer from getSoapBody", te);
 				}

--- a/core/src/main/java/org/frankframework/pipes/XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlValidator.java
@@ -148,7 +148,7 @@ public class XmlValidator extends ValidatorBase implements SchemasProvider, HasS
 				String extractNamespaceDefs = "soapenv=" + getSoapNamespace();
 				String extractBodyXPath     = "/soapenv:Envelope/soapenv:Body/*";
 				try {
-					transformerPoolExtractSoapBody = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(extractNamespaceDefs, extractBodyXPath, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+					transformerPoolExtractSoapBody = TransformerPool.getXPathTransformerPool(extractNamespaceDefs, extractBodyXPath, OutputType.XML);
 				} catch (TransformerConfigurationException te) {
 					throw new ConfigurationException("got error creating transformer from getSoapBody", te);
 				}

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -93,16 +93,16 @@ public class SoapWrapper {
 
 	private void init() throws ConfigurationException {
 		try {
-			extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false));
-			extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false));
-			extractHeaderSoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML));
-			extractHeaderSoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML));
-			extractFaultCount11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT));
-			extractFaultCount12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT));
-			extractFaultCode11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCODE_XPATH_SOAP11, TransformerPool.OutputType.TEXT));
-			extractFaultCode12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCODE_XPATH_SOAP12, TransformerPool.OutputType.TEXT));
-			extractFaultString11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTSTRING_XPATH_SOAP11, TransformerPool.OutputType.TEXT));
-			extractFaultString12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTSTRING_XPATH_SOAP12, TransformerPool.OutputType.TEXT));
+			extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractHeaderSoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractHeaderSoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultCount11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultCount12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultCode11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCODE_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultCode12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCODE_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultString11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTSTRING_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			extractFaultString12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTSTRING_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("cannot create SOAP transformer", e);
 		}

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -93,8 +93,8 @@ public class SoapWrapper {
 
 	private void init() throws ConfigurationException {
 		try {
-			extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, null, false));
-			extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, null, false));
+			extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false));
+			extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false));
 			extractHeaderSoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML));
 			extractHeaderSoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML));
 			extractFaultCount11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT));

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2015 Nationale-Nederlanden, 2020, 2022 WeAreFrank!
+   Copyright 2013, 2015 Nationale-Nederlanden, 2020, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/util/ClassLoaderUtils.java
+++ b/core/src/main/java/org/frankframework/util/ClassLoaderUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2023 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-
 import org.frankframework.configuration.IbisContext;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.core.IScopeProvider;
@@ -40,6 +40,7 @@ public abstract class ClassLoaderUtils {
 	 * @param resource name of the resource you are trying to fetch the URL from
 	 * @return URL of the resource or null if it can't be not found
 	 */
+	@Nullable
 	public static URL getResourceURL(String resource) {
 		return getResourceURL(null, resource);
 	}
@@ -53,7 +54,7 @@ public abstract class ClassLoaderUtils {
 	 *
 	 * @see IbisContext#init()
 	 */
-	public static URL getResourceURL(IScopeProvider scopeProvider, String resource) {
+	public static URL getResourceURL(@Nullable IScopeProvider scopeProvider, @Nonnull String resource) {
 		return getResourceURL(scopeProvider, resource, null);
 	}
 
@@ -63,8 +64,9 @@ public abstract class ClassLoaderUtils {
 	 * @param resource name of the resource you are trying to fetch the URL from
 	 * @return URL of the resource or null if it can't be not found
 	 */
-	public static URL getResourceURL(IScopeProvider scopeProvider, String resource, String allowedProtocols) {
-		ClassLoader classLoader = null;
+	@Nullable
+	public static URL getResourceURL(@Nullable IScopeProvider scopeProvider, @Nonnull String resource, @Nullable String allowedProtocols) {
+		ClassLoader classLoader;
 		if(scopeProvider == null) { // Used by ClassPath resources
 			classLoader = Thread.currentThread().getContextClassLoader();
 		} else {
@@ -125,11 +127,13 @@ public abstract class ClassLoaderUtils {
 		}
 	}
 
+	@Nonnull
 	public static List<String> getAllowedProtocols() {
 		return toList(DEFAULT_ALLOWED_PROTOCOLS);
 	}
 
-	private static List<String> toList(String protocolList) {
+	@Nonnull
+	private static List<String> toList(@Nullable String protocolList) {
 		if(StringUtils.isBlank(protocolList)) {
 			return Collections.emptyList();
 		}

--- a/core/src/main/java/org/frankframework/util/TransformerPool.java
+++ b/core/src/main/java/org/frankframework/util/TransformerPool.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016, 2019 Nationale-Nederlanden, 2020-2022 WeAreFrank!
+   Copyright 2013, 2016, 2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class TransformerPool {
 		}
 	}
 
-	private TransformerPool(Source source, String sysId, int xsltVersion, Source configSource, IScopeProvider scopeProvider) throws TransformerConfigurationException {
+	private TransformerPool(@Nonnull Source source, @Nullable String sysId, int xsltVersion, @Nonnull Source configSource, @Nullable IScopeProvider scopeProvider) throws TransformerConfigurationException {
 		super();
 		this.configSource = configSource;
 		try {
@@ -125,11 +125,11 @@ public class TransformerPool {
 		releaseTransformer(t);
 	}
 
-	private TransformerPool(Resource resource, int xsltVersion) throws TransformerConfigurationException, IOException, SAXException {
+	private TransformerPool(@Nonnull Resource resource, int xsltVersion) throws TransformerConfigurationException, IOException, SAXException {
 		this(resource.asSource(),resource.getSystemId(),xsltVersion,resource.asSource(), resource);
 	}
 
-	private TransformerPool(String xsltString, String sysId, int xsltVersion, IScopeProvider scopeProvider) throws TransformerConfigurationException {
+	private TransformerPool(@Nonnull String xsltString, @Nullable String sysId, int xsltVersion, @Nullable IScopeProvider scopeProvider) throws TransformerConfigurationException {
 		this(new StreamSource(new StringReader(xsltString)), sysId, xsltVersion,new StreamSource(new StringReader(xsltString)), scopeProvider);
 	}
 
@@ -138,7 +138,7 @@ public class TransformerPool {
 	 * load any resources from classpath. This should be used primarily for TransformerPools that evaluate
 	 * XPath expressions and can not be statically cached.
 	 */
-	public static TransformerPool getInstance(String xsltString, int xsltVersion) throws TransformerConfigurationException {
+	public static TransformerPool getInstance(@Nonnull String xsltString, int xsltVersion) throws TransformerConfigurationException {
 		return new TransformerPool(xsltString, null, xsltVersion, null);
 	}
 
@@ -153,7 +153,7 @@ public class TransformerPool {
 	 * @return A TransformerPool instance for the input stylesheet.
 	 * @throws TransformerConfigurationException
 	 */
-	public static TransformerPool getInstance(String xsltString, int xsltVersion, IScopeProvider scopeProvider) throws TransformerConfigurationException {
+	public static TransformerPool getInstance(@Nonnull String xsltString, int xsltVersion, @Nullable IScopeProvider scopeProvider) throws TransformerConfigurationException {
 		return new TransformerPool(xsltString, null, xsltVersion, scopeProvider);
 	}
 
@@ -162,7 +162,7 @@ public class TransformerPool {
 	 * Utility pools should never use configuration classloaders, instead always read from the classpath!
 	 * Utility pools should always be cached statically for re-use. The caller-code is responsible for this.
 	 */
-	public static TransformerPool getUtilityInstance(String xsltString, int xsltVersion) throws TransformerConfigurationException {
+	public static TransformerPool getUtilityInstance(@Nonnull String xsltString, int xsltVersion) throws TransformerConfigurationException {
 		return new TransformerPool(xsltString, null, xsltVersion, null) {
 			@Override
 			public void close() {
@@ -171,11 +171,11 @@ public class TransformerPool {
 		};
 	}
 
-	public static TransformerPool getInstance(Resource resource) throws TransformerConfigurationException, IOException {
+	public static TransformerPool getInstance(@Nonnull Resource resource) throws TransformerConfigurationException, IOException {
 		return getInstance(resource, 0);
 	}
 
-	public static TransformerPool getInstance(Resource resource, int xsltVersion) throws TransformerConfigurationException, IOException {
+	public static TransformerPool getInstance(@Nonnull Resource resource, int xsltVersion) throws TransformerConfigurationException, IOException {
 		try {
 			return new TransformerPool(resource, xsltVersion);
 		} catch (SAXException e) {
@@ -183,7 +183,7 @@ public class TransformerPool {
 		}
 	}
 
-	private void initTransformerPool(Source source, String sysId) throws TransformerConfigurationException {
+	private void initTransformerPool(@Nonnull Source source, @Nullable String sysId) throws TransformerConfigurationException {
 		if (StringUtils.isNotEmpty(sysId)) {
 			source.setSystemId(sysId);
 			log.debug("setting systemId to [{}]", sysId);
@@ -210,18 +210,21 @@ public class TransformerPool {
 		}
 	}
 
-	public static TransformerPool configureTransformer(IConfigurationAware scopeProvider, String namespaceDefs, String xPathExpression, String styleSheetName, OutputType outputType, boolean includeXmlDeclaration, ParameterList params, boolean mandatory) throws ConfigurationException {
+	@Nullable
+	public static TransformerPool configureTransformer(@Nullable IConfigurationAware scopeProvider, @Nullable String namespaceDefs, @Nullable String xPathExpression, @Nullable String styleSheetName, @Nonnull OutputType outputType, boolean includeXmlDeclaration, @Nullable ParameterList params, boolean mandatory) throws ConfigurationException {
 		if (mandatory || StringUtils.isNotEmpty(xPathExpression) || StringUtils.isNotEmpty(styleSheetName)) {
 			return configureTransformer(scopeProvider,namespaceDefs,xPathExpression,styleSheetName,outputType, includeXmlDeclaration, params);
 		}
 		return null;
 	}
 
-	public static TransformerPool configureTransformer(IConfigurationAware scopeProvider, String namespaceDefs, String xPathExpression, String styleSheetName, OutputType outputType, boolean includeXmlDeclaration, ParameterList params) throws ConfigurationException {
+	@Nonnull
+	public static TransformerPool configureTransformer(@Nullable IConfigurationAware scopeProvider, @Nullable String namespaceDefs, @Nullable String xPathExpression, @Nullable String styleSheetName, @Nullable OutputType outputType, boolean includeXmlDeclaration, @Nullable ParameterList params) throws ConfigurationException {
 		return configureTransformer0(scopeProvider,namespaceDefs,xPathExpression,styleSheetName,outputType,includeXmlDeclaration,params,0);
 	}
 
-	public static TransformerPool configureTransformer0(IConfigurationAware scopeProvider, String namespaceDefs, String xPathExpression, String styleSheetName, OutputType outputType, boolean includeXmlDeclaration, ParameterList params, int xsltVersion) throws ConfigurationException {
+	@Nonnull
+	public static TransformerPool configureTransformer0(@Nullable IConfigurationAware scopeProvider, @Nullable String namespaceDefs, @Nullable String xPathExpression, @Nullable String styleSheetName, @Nonnull OutputType outputType, boolean includeXmlDeclaration, @Nullable ParameterList params, int xsltVersion) throws ConfigurationException {
 		if (StringUtils.isNotEmpty(xPathExpression)) {
 			if (StringUtils.isNotEmpty(styleSheetName)) {
 				throw new ConfigurationException("cannot have both an xpathExpression and a styleSheetName specified");
@@ -237,44 +240,46 @@ public class TransformerPool {
 		throw new ConfigurationException("either xpathExpression or styleSheetName must be specified");
 	}
 
-	public static TransformerPool configureStyleSheetTransformer(IConfigurationAware scopeProvider, String styleSheetName, int xsltVersion) throws ConfigurationException {
-		TransformerPool result;
-		if (!StringUtils.isEmpty(styleSheetName)) {
-			Resource styleSheet=null;
-			try {
-				styleSheet = Resource.getResource(scopeProvider, styleSheetName);
-				if (styleSheet==null) {
-					throw new ConfigurationException("cannot find ["+ styleSheetName + "] in scope ["+scopeProvider+"]");
-				}
-				log.debug("configuring stylesheet [{}] resource [{}]", styleSheetName, styleSheet);
-				result = TransformerPool.getInstance(styleSheet, xsltVersion);
-
-				if (xsltVersion!=0) {
-					String xsltVersionInStylesheet = result.getConfigMap().get("version");
-					int detectedXsltVersion = XmlUtils.interpretXsltVersion(xsltVersionInStylesheet);
-					if (xsltVersion!=detectedXsltVersion) {
-						ConfigurationWarnings.add(scopeProvider, log, "configured xsltVersion ["+xsltVersion+"] does not match xslt version ["+detectedXsltVersion+"] declared in stylesheet ["+styleSheet.getSystemId()+"]");
-					}
-				}
-			} catch (IOException e) {
-				throw new ConfigurationException("cannot retrieve ["+ styleSheetName + "] resource ["+styleSheet+"]", e);
-			} catch (TransformerException e) {
-				throw new ConfigurationException("got error creating transformer from file [" + styleSheetName + "]", e);
-			}
-			if (XmlUtils.isAutoReload()) {
-				result.reloadResource=styleSheet;
-			}
-		} else {
+	@Nonnull
+	public static TransformerPool configureStyleSheetTransformer(@Nullable IConfigurationAware scopeProvider, @Nullable String styleSheetName, int xsltVersion) throws ConfigurationException {
+		if (StringUtils.isEmpty(styleSheetName)) {
 			throw new ConfigurationException("either xpathExpression or styleSheetName must be specified");
+		}
+		TransformerPool result;
+		Resource styleSheet=null;
+		try {
+			styleSheet = Resource.getResource(scopeProvider, styleSheetName);
+			if (styleSheet==null) {
+				throw new ConfigurationException("cannot find ["+ styleSheetName + "] in scope ["+scopeProvider+"]");
+			}
+			log.debug("configuring stylesheet [{}] resource [{}]", styleSheetName, styleSheet);
+			result = TransformerPool.getInstance(styleSheet, xsltVersion);
+
+			if (xsltVersion!=0) {
+				String xsltVersionInStylesheet = result.getConfigMap().get("version");
+				int detectedXsltVersion = XmlUtils.interpretXsltVersion(xsltVersionInStylesheet);
+				if (xsltVersion!=detectedXsltVersion) {
+					ConfigurationWarnings.add(scopeProvider, log, "configured xsltVersion ["+xsltVersion+"] does not match xslt version ["+detectedXsltVersion+"] declared in stylesheet ["+styleSheet.getSystemId()+"]");
+				}
+			}
+		} catch (IOException e) {
+			throw new ConfigurationException("cannot retrieve ["+ styleSheetName + "] resource ["+styleSheet+"]", e);
+		} catch (TransformerException e) {
+			throw new ConfigurationException("got error creating transformer from file [" + styleSheetName + "]", e);
+		}
+		if (XmlUtils.isAutoReload()) {
+			result.reloadResource=styleSheet;
 		}
 		return result;
 	}
 
-	public static TransformerPool getXPathTransformerPool(String namespaceDefs, String xPathExpression, @Nonnull OutputType outputType, boolean includeXmlDeclaration, ParameterList params) throws ConfigurationException {
+	@Nonnull
+	public static TransformerPool getXPathTransformerPool(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull OutputType outputType, boolean includeXmlDeclaration, @Nullable ParameterList params) throws ConfigurationException {
 		return getXPathTransformerPool(namespaceDefs, xPathExpression, outputType, includeXmlDeclaration, params, XmlUtils.DEFAULT_XSLT_VERSION);
 	}
 
-	private static TransformerPool getXPathTransformerPool(String namespaceDefs, String xPathExpression, OutputType outputType, boolean includeXmlDeclaration, ParameterList params, int xsltVersion) throws ConfigurationException {
+	@Nonnull
+	private static TransformerPool getXPathTransformerPool(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull OutputType outputType, boolean includeXmlDeclaration, @Nullable ParameterList params, int xsltVersion) throws ConfigurationException {
 		String xslt = XmlUtils.createXPathEvaluatorSource(namespaceDefs,xPathExpression, outputType, includeXmlDeclaration, params, true, StringUtils.isEmpty(namespaceDefs), null, xsltVersion);
 		log.debug("xpath [{}] resulted in xslt [{}]", xPathExpression, xslt);
 

--- a/core/src/main/java/org/frankframework/util/TransformerPool.java
+++ b/core/src/main/java/org/frankframework/util/TransformerPool.java
@@ -41,11 +41,6 @@ import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.SoftReferenceObjectPool;
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
-import org.xml.sax.ContentHandler;
-import org.xml.sax.SAXException;
-
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.core.IConfigurationAware;
@@ -58,6 +53,11 @@ import org.frankframework.stream.ThreadConnector;
 import org.frankframework.xml.ClassLoaderURIResolver;
 import org.frankframework.xml.NonResolvingURIResolver;
 import org.frankframework.xml.TransformerFilter;
+import org.w3c.dom.Document;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
 
 /**
  * Pool of transformers. As of IBIS 4.2.e the Templates object is used to
@@ -137,12 +137,6 @@ public class TransformerPool {
 
 	private TransformerPool(String xsltString, String sysId, int xsltVersion, IScopeProvider scopeProvider) throws TransformerConfigurationException {
 		this(new StreamSource(new StringReader(xsltString)), sysId, xsltVersion,new StreamSource(new StringReader(xsltString)), scopeProvider);
-	}
-
-	/** @deprecated Use Resource or UtilityInstance instead! This can/will cause memory leaks upon reloading configurations!!! */
-	@Deprecated
-	public static TransformerPool getInstance(String xsltString) throws TransformerConfigurationException {
-		return getInstance(xsltString, 0);
 	}
 
 	/** @deprecated Use Resource or UtilityInstance instead! This can/will cause memory leaks upon reloading configurations!!! */
@@ -272,7 +266,7 @@ public class TransformerPool {
 	}
 
 	public static TransformerPool getXPathTransformerPool(String namespaceDefs, String xPathExpression, @Nonnull OutputType outputType, boolean includeXmlDeclaration, ParameterList params) throws ConfigurationException {
-		return getXPathTransformerPool(namespaceDefs, xPathExpression, outputType, includeXmlDeclaration, params, 0);
+		return getXPathTransformerPool(namespaceDefs, xPathExpression, outputType, includeXmlDeclaration, params, XmlUtils.DEFAULT_XSLT_VERSION);
 	}
 
 	private static TransformerPool getXPathTransformerPool(String namespaceDefs, String xPathExpression, OutputType outputType, boolean includeXmlDeclaration, ParameterList params, int xsltVersion) throws ConfigurationException {
@@ -280,7 +274,7 @@ public class TransformerPool {
 		log.debug("xpath [{}] resulted in xslt [{}]", xPathExpression, xslt);
 
 		try {
-			return new TransformerPool(xslt, null, xsltVersion);
+			return new TransformerPool(xslt, null, xsltVersion == 0 ? XmlUtils.DEFAULT_XSLT_VERSION : xsltVersion);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("Cannot create TransformerPool for XPath expression ["+xPathExpression+"]", e);
 		}

--- a/core/src/main/java/org/frankframework/util/TransformerPool.java
+++ b/core/src/main/java/org/frankframework/util/TransformerPool.java
@@ -96,8 +96,7 @@ public class TransformerPool {
 		this.configSource = configSource;
 		try {
 			if (xsltVersion <= 0) {
-				configMap = getConfigMap();
-				String version = configMap.get("version");
+				String version = getConfigMap().get("version");
 				xsltVersion = XmlUtils.interpretXsltVersion(version);
 			}
 		} catch (TransformerException | IOException e) {
@@ -111,7 +110,7 @@ public class TransformerPool {
 		tFactory = XmlUtils.getTransformerFactory(xsltVersion, factoryErrorListener);
 		if (scopeProvider != null) {
 			classLoaderURIResolver = new ClassLoaderURIResolver(scopeProvider);
-			log.debug("created Transformerpool for sysId [{}] scopeProvider [{}]", sysId, scopeProvider);
+			log.debug("created TransformerPool for sysId [{}] scopeProvider [{}]", sysId, scopeProvider);
 			tFactory.setURIResolver(classLoaderURIResolver);
 		} else {
 			classLoaderURIResolver = new NonResolvingURIResolver();
@@ -282,7 +281,7 @@ public class TransformerPool {
 
 	public void open() {
 		if (pool == null) {
-			pool = new SoftReferenceObjectPool<>(new BasePooledObjectFactory<Transformer>() {
+			pool = new SoftReferenceObjectPool<>(new BasePooledObjectFactory<>() {
 
 				@Override
 				public Transformer create() throws Exception {

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -707,23 +707,7 @@ public class XmlUtils {
 	 */
 	@Nonnull
 	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod) {
-		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, false);
-	}
-
-	/**
-	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
-	 * The stylesheet output type will be determined by the outputMethod parameter.
-	 * The stylesheet XSLT version will be {@link #DEFAULT_XSLT_VERSION}.
-	 *
-	 * @param namespaceDefs Definitions of the namespaces in which to evaluate the XPath Expression.
-	 * @param xPathExpression The XPath Expression to evaluate
-	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}.
-	 * @param includeXmlDeclaration If true, include XML declaration in the resulting XSLT.
-	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
-	 */
-	@Nonnull
-	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration) {
-		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, includeXmlDeclaration, true);
+		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, false, true);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016-2019 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2013, 2016-2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ public class XmlUtils {
 		return result;
 	}
 
-	protected static String makeDetectXsltVersionXslt() {
+	private static String makeDetectXsltVersionXslt() {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
 			+ "<xsl:output method=\"text\"/>"
@@ -194,7 +194,7 @@ public class XmlUtils {
 	}
 
 
-	protected static String makeGetXsltConfigXslt() {
+	private static String makeGetXsltConfigXslt() {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
 			+ "<xsl:output method=\"text\"/>"
@@ -241,7 +241,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(()->createXPathEvaluatorSource(XPATH_GETROOTNODENAME),"GetRootNodeName",true, false, DEFAULT_XSLT_VERSION);
 	}
 
-	protected static String makeRemoveNamespacesXsltTemplates() {
+	private static String makeRemoveNamespacesXsltTemplates() {
 		// TODO: Wish to get rid of this as well but it's still embedded in another XSLT.
 		return
 		"<xsl:template match=\"*\">"
@@ -259,7 +259,7 @@ public class XmlUtils {
 		+ "</xsl:template>";
 	}
 
-	protected static String makeGetRootNamespaceXslt() {
+	private static String makeGetRootNamespaceXslt() {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
 			+ "<xsl:output method=\"text\"/>"
@@ -273,7 +273,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(XmlUtils::makeGetRootNamespaceXslt,"GetRootNamespace",true,false, 2);
 	}
 
-	protected static String makeAddRootNamespaceXslt(String namespace, boolean omitXmlDeclaration, boolean indent) {
+	private static String makeAddRootNamespaceXslt(String namespace, boolean omitXmlDeclaration, boolean indent) {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\" xmlns=\""+namespace+"\">"
 			+ "<xsl:output method=\"xml\" indent=\""+(indent?"yes":"no")+"\" omit-xml-declaration=\""+(omitXmlDeclaration?"yes":"no")+"\"/>"
@@ -309,7 +309,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(()->makeAddRootNamespaceXslt(namespace,omitXmlDeclaration,indent),"AddRootNamespace["+namespace+"]",omitXmlDeclaration,indent, 1);
 	}
 
-	protected static String makeChangeRootXslt(String root, boolean omitXmlDeclaration, boolean indent) {
+	private static String makeChangeRootXslt(String root, boolean omitXmlDeclaration, boolean indent) {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">"
 			+ "<xsl:output method=\"xml\" indent=\""+(indent?"yes":"no")+"\" omit-xml-declaration=\""+(omitXmlDeclaration?"yes":"no")+"\"/>"
@@ -328,7 +328,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(()->makeChangeRootXslt(root,omitXmlDeclaration,indent),"ChangeRoot["+root+"]",omitXmlDeclaration,indent, 1);
 	}
 
-	protected static String makeRemoveUnusedNamespacesXslt(boolean omitXmlDeclaration, boolean indent) {
+	private static String makeRemoveUnusedNamespacesXslt(boolean omitXmlDeclaration, boolean indent) {
 		return
 		"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">"
 			+ "<xsl:output method=\"xml\" indent=\""+(indent?"yes":"no")+"\" omit-xml-declaration=\""+(omitXmlDeclaration?"yes":"no")+"\"/>"
@@ -347,7 +347,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt(omitXmlDeclaration,indent),"RemoveUnusedNamespaces",omitXmlDeclaration,indent, 1);
 	}
 
-	protected static String makeRemoveUnusedNamespacesXslt2(boolean omitXmlDeclaration, boolean indent) {
+	private static String makeRemoveUnusedNamespacesXslt2(boolean omitXmlDeclaration, boolean indent) {
 		return "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
 				+ "<xsl:output method=\"xml\" indent=\""
 				+ (indent ? "yes" : "no")
@@ -388,7 +388,7 @@ public class XmlUtils {
 		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration,indent),"RemoveUnusedNamespacesXslt2",omitXmlDeclaration,indent, 2);
 	}
 
-	protected static String makeCopyOfSelectXslt(String xpath, boolean omitXmlDeclaration, boolean indent) {
+	private static String makeCopyOfSelectXslt(String xpath, boolean omitXmlDeclaration, boolean indent) {
 		return "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
 				+ "<xsl:output method=\"xml\" indent=\""
 				+ (indent ? "yes" : "no")
@@ -691,7 +691,7 @@ public class XmlUtils {
 	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
 	 */
 	@Nonnull
-	public static String createXPathEvaluatorSource(String xPathExpression) {
+	public static String createXPathEvaluatorSource(@Nonnull String xPathExpression) {
 		return createXPathEvaluatorSource(null, xPathExpression, TransformerPool.OutputType.TEXT);
 	}
 

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -157,11 +158,6 @@ public class XmlUtils {
 		return new GDate(s).getDate();
 	}
 
-	private static TransformerPool getUtilityTransformerPool(Supplier<String> xsltSupplier, String key, boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		//log.debug("utility transformer pool key ["+key+"] xslt ["+xslt+"]");
-		return getUtilityTransformerPool(xsltSupplier, key, omitXmlDeclaration, indent, 0);
-	}
-
 	private static TransformerPool getUtilityTransformerPool(Supplier<String> xsltSupplier, String key, boolean omitXmlDeclaration, boolean indent, int xsltVersion) throws ConfigurationException {
 		String fullKey=key+"-"+omitXmlDeclaration+"-"+indent;
 		TransformerPool result = utilityTPs.get(fullKey);
@@ -242,7 +238,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getGetRootNodeNameTransformerPool() throws ConfigurationException {
-		return getUtilityTransformerPool(()->createXPathEvaluatorSource(XPATH_GETROOTNODENAME, TransformerPool.OutputType.TEXT),"GetRootNodeName",true, false);
+		return getUtilityTransformerPool(()->createXPathEvaluatorSource(XPATH_GETROOTNODENAME),"GetRootNodeName",true, false, DEFAULT_XSLT_VERSION);
 	}
 
 	protected static String makeRemoveNamespacesXsltTemplates() {
@@ -274,7 +270,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getGetRootNamespaceTransformerPool() throws ConfigurationException {
-		return getUtilityTransformerPool(XmlUtils::makeGetRootNamespaceXslt,"GetRootNamespace",true,false);
+		return getUtilityTransformerPool(XmlUtils::makeGetRootNamespaceXslt,"GetRootNamespace",true,false, 2);
 	}
 
 	protected static String makeAddRootNamespaceXslt(String namespace, boolean omitXmlDeclaration, boolean indent) {
@@ -310,7 +306,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getAddRootNamespaceTransformerPool(String namespace, boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		return getUtilityTransformerPool(()->makeAddRootNamespaceXslt(namespace,omitXmlDeclaration,indent),"AddRootNamespace["+namespace+"]",omitXmlDeclaration,indent);
+		return getUtilityTransformerPool(()->makeAddRootNamespaceXslt(namespace,omitXmlDeclaration,indent),"AddRootNamespace["+namespace+"]",omitXmlDeclaration,indent, 1);
 	}
 
 	protected static String makeChangeRootXslt(String root, boolean omitXmlDeclaration, boolean indent) {
@@ -329,7 +325,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getChangeRootTransformerPool(String root, boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		return getUtilityTransformerPool(()->makeChangeRootXslt(root,omitXmlDeclaration,indent),"ChangeRoot["+root+"]",omitXmlDeclaration,indent);
+		return getUtilityTransformerPool(()->makeChangeRootXslt(root,omitXmlDeclaration,indent),"ChangeRoot["+root+"]",omitXmlDeclaration,indent, 1);
 	}
 
 	protected static String makeRemoveUnusedNamespacesXslt(boolean omitXmlDeclaration, boolean indent) {
@@ -348,7 +344,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getRemoveUnusedNamespacesTransformerPool(boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt(omitXmlDeclaration,indent),"RemoveUnusedNamespaces",omitXmlDeclaration,indent);
+		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt(omitXmlDeclaration,indent),"RemoveUnusedNamespaces",omitXmlDeclaration,indent, 1);
 	}
 
 	protected static String makeRemoveUnusedNamespacesXslt2(boolean omitXmlDeclaration, boolean indent) {
@@ -389,7 +385,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getRemoveUnusedNamespacesXslt2TransformerPool(boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration,indent),"RemoveUnusedNamespacesXslt2",omitXmlDeclaration,indent);
+		return getUtilityTransformerPool(()->makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration,indent),"RemoveUnusedNamespacesXslt2",omitXmlDeclaration,indent, 2);
 	}
 
 	protected static String makeCopyOfSelectXslt(String xpath, boolean omitXmlDeclaration, boolean indent) {
@@ -406,7 +402,7 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getCopyOfSelectTransformerPool(String xpath, boolean omitXmlDeclaration, boolean indent) throws ConfigurationException {
-		return getUtilityTransformerPool(()->makeCopyOfSelectXslt(xpath,omitXmlDeclaration,indent),"CopyOfSelect["+xpath+"]",omitXmlDeclaration,indent);
+		return getUtilityTransformerPool(()->makeCopyOfSelectXslt(xpath,omitXmlDeclaration,indent),"CopyOfSelect["+xpath+"]",omitXmlDeclaration,indent, 2);
 	}
 
 
@@ -686,34 +682,86 @@ public class XmlUtils {
 		return namespaceMap;
 	}
 
-	public static String createXPathEvaluatorSource(String XPathExpression) {
-		return createXPathEvaluatorSource(XPathExpression, TransformerPool.OutputType.TEXT);
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in.
+	 * The stylesheet will result in TEXT output.
+	 * The stylesheet XSLT version will be {@link #DEFAULT_XSLT_VERSION}.
+	 *
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
+	 */
+	@Nonnull
+	public static String createXPathEvaluatorSource(String xPathExpression) {
+		return createXPathEvaluatorSource(null, xPathExpression, TransformerPool.OutputType.TEXT);
 	}
 
-	public static String createXPathEvaluatorSource(String xPathExpression, TransformerPool.OutputType outputMethod) {
-		return createXPathEvaluatorSource(null, xPathExpression, outputMethod);
-	}
-
-	public static String createXPathEvaluatorSource(String namespaceDefs, String xPathExpression, TransformerPool.OutputType outputMethod) {
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
+	 * The stylesheet output type will be determined by the outputMethod parameter.
+	 * The stylesheet XSLT version will be {@link #DEFAULT_XSLT_VERSION}.
+	 *
+	 * @param namespaceDefs Definitions of the namespaces in which to evaluate the XPath Expression.
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}.
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
+	 */
+	@Nonnull
+	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod) {
 		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, false);
 	}
 
-	public static String createXPathEvaluatorSource(String namespaceDefs, String XPathExpression, TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration) {
-		return createXPathEvaluatorSource(namespaceDefs, XPathExpression, outputMethod, includeXmlDeclaration, null);
-	}
-
-	public static String createXPathEvaluatorSource(String namespaceDefs, String XPathExpression, TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, ParameterList params) {
-		return createXPathEvaluatorSource(namespaceDefs, XPathExpression, outputMethod, includeXmlDeclaration, params, true);
-	}
-
-	public static String createXPathEvaluatorSource(String namespaceDefs, String XPathExpression, TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, ParameterList params, boolean stripSpace) {
-		return createXPathEvaluatorSource(namespaceDefs, XPathExpression, outputMethod, includeXmlDeclaration, params, stripSpace, false, null, 0);
-	}
-
-	/*
-	 * version of createXPathEvaluator that allows to set outputMethod, and uses copy-of instead of value-of, and enables use of parameters.
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
+	 * The stylesheet output type will be determined by the outputMethod parameter.
+	 * The stylesheet XSLT version will be {@link #DEFAULT_XSLT_VERSION}.
+	 *
+	 * @param namespaceDefs Definitions of the namespaces in which to evaluate the XPath Expression.
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}.
+	 * @param includeXmlDeclaration If true, include XML declaration in the resulting XSLT.
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
 	 */
-	public static String createXPathEvaluatorSource(String namespaceDefs, String xpathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, ParameterList params, boolean stripSpace, boolean ignoreNamespaces, String separator, int xsltVersion) {
+	@Nonnull
+	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration) {
+		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, includeXmlDeclaration, true);
+	}
+
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
+	 * The stylesheet output type will be determined by the outputMethod parameter.
+	 * The stylesheet XSLT version will be {@link #DEFAULT_XSLT_VERSION}.
+	 *
+	 * @param namespaceDefs Definitions of the namespaces in which to evaluate the XPath Expression.
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}. If outputMethod is {@link TransformerPool.OutputType#XML} then
+	 *                     the resulting stylesheet will use the {@code copy-of} method instead of {@code value-of}.
+	 * @param includeXmlDeclaration If true, and outputMethod is {@link TransformerPool.OutputType#XML} then include XML declaration in the output after the XSLT is applied.
+	 * @param stripSpace If true then strip spaces in the output.
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
+	 */
+	@Nonnull
+	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, boolean stripSpace) {
+		return createXPathEvaluatorSource(namespaceDefs, xPathExpression, outputMethod, includeXmlDeclaration, null, stripSpace, false, null, DEFAULT_XSLT_VERSION);
+	}
+
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
+	 * The stylesheet output type will be determined by the outputMethod parameter.
+	 *
+	 * @param namespaceDefs Definitions of the namespaces in which to evaluate the XPath Expression.
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}. If outputMethod is {@link TransformerPool.OutputType#XML} then
+	 *                     the resulting stylesheet will use the {@code copy-of} method instead of {@code value-of}.
+	 * @param includeXmlDeclaration If true, and outputMethod is {@link TransformerPool.OutputType#XML} then include XML declaration in the output after the XSLT is applied.
+	 * @param params A {@link ParameterList} to evaluate while generating the stylesheet.
+	 * @param stripSpace If true then strip spaces in the output.
+	 * @param ignoreNamespaces If true then namespaces are ignored during the evaluation.
+	 * @param separator Separator between values if output method is {@link TransformerPool.OutputType#TEXT}.
+	 * @param xsltVersion Version of XSLT for which to generate the stylesheet. Can be 0, 1, or 2. If 0, then {@link #DEFAULT_XSLT_VERSION} is used.
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
+	 */
+	@Nonnull
+	public static String createXPathEvaluatorSource(@Nullable String namespaceDefs, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, @Nullable ParameterList params, boolean stripSpace, boolean ignoreNamespaces, String separator, int xsltVersion) {
 		String namespaceClause = getNamespaceClause(namespaceDefs);
 
 		final String copyMethod;
@@ -725,11 +773,27 @@ public class XmlUtils {
 
 		final String separatorString = separator != null ? " separator=\"" + separator + "\"" : "";
 
-		return createXPathEvaluatorSource(x -> "<xsl:"+copyMethod+" "+namespaceClause+" select=\"" + XmlEncodingUtils.encodeChars(xpathExpression) + "\"" + separatorString + "/>", xpathExpression, outputMethod, includeXmlDeclaration, params, stripSpace, ignoreNamespaces, xsltVersion);
+		return createXPathEvaluatorSource(ignored -> "<xsl:"+copyMethod+" "+namespaceClause+" select=\"" + XmlEncodingUtils.encodeChars(xPathExpression) + "\"" + separatorString + "/>", xPathExpression, outputMethod, includeXmlDeclaration, params, stripSpace, ignoreNamespaces, xsltVersion);
 	}
 
-	public static String createXPathEvaluatorSource(Function<String,String> xpathContainerSupplier, String xpathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, ParameterList params, boolean stripSpace, boolean ignoreNamespaces, int xsltVersion) {
-		if (StringUtils.isEmpty(xpathExpression)) {
+	/**
+	 * Create an XSLT stylesheet that can be used to evaluate the xpath expression passed in, in the given namespaces.
+	 * The stylesheet output type will be determined by the outputMethod parameter.
+	 *
+	 * @param xpathContainerSupplier A supplier function to transform the XPath expression to the required XSLT tags for generating the output that is desired.
+	 * @param xPathExpression The XPath Expression to evaluate
+	 * @param outputMethod Type of output as per {@link TransformerPool.OutputType}. If outputMethod is {@link TransformerPool.OutputType#XML} then
+	 *                     the resulting stylesheet will use the {@code copy-of} method instead of {@code value-of}.
+	 * @param includeXmlDeclaration If true, and outputMethod is {@link TransformerPool.OutputType#XML} then include XML declaration in the output after the XSLT is applied.
+	 * @param params A {@link ParameterList} to evaluate while generating the stylesheet.
+	 * @param stripSpace If true then strip spaces in the output.
+	 * @param ignoreNamespaces If true then namespaces are ignored during the evaluation.
+	 * @param xsltVersion Version of XSLT for which to generate the stylesheet. Can be 0, 1, or 2. If 0, then {@link #DEFAULT_XSLT_VERSION} is used.
+	 * @return An XSLT stylesheet generated to evaluate the XPath Expression
+	 */
+	@Nonnull
+	public static String createXPathEvaluatorSource(@Nonnull Function<String,String> xpathContainerSupplier, @Nonnull String xPathExpression, @Nonnull TransformerPool.OutputType outputMethod, boolean includeXmlDeclaration, @Nullable ParameterList params, boolean stripSpace, boolean ignoreNamespaces, int xsltVersion) {
+		if (StringUtils.isEmpty(xPathExpression)) {
 			throw new IllegalArgumentException("XPathExpression must be filled");
 		}
 
@@ -744,6 +808,9 @@ public class XmlUtils {
 		//xslt version 1 ignores namespaces by default, setting this to true will generate a different non-xslt1-parsable xslt: xslt1 'Can not convert #RTREEFRAG to a NodeList'
 		if(version == 1 && ignoreNamespaces) {
 			ignoreNamespaces = false;
+		}
+		if (outputMethod == TransformerPool.OutputType.TEXT && includeXmlDeclaration) {
+			includeXmlDeclaration = false;
 		}
 
 		String xsl =
@@ -764,12 +831,12 @@ public class XmlUtils {
 				"<xsl:template name=\"expression\">" +
 					"<xsl:param name=\"root\" />" +
 					"<xsl:for-each select=\"$root\">" +
-						xpathContainerSupplier.apply(xpathExpression) +
+						xpathContainerSupplier.apply(xPathExpression) +
 					"</xsl:for-each>" +
 				"</xsl:template>"
 			:
 			"<xsl:template match=\"/\">" +
-				xpathContainerSupplier.apply(xpathExpression) +
+				xpathContainerSupplier.apply(xPathExpression) +
 			"</xsl:template>" )+
 			"</xsl:stylesheet>";
 

--- a/core/src/test/java/org/frankframework/align/TestAlignNamespacesXml.java
+++ b/core/src/test/java/org/frankframework/align/TestAlignNamespacesXml.java
@@ -63,7 +63,7 @@ public class TestAlignNamespacesXml extends AlignTestBase {
 		+ template
 		+ "</xsl:stylesheet>";
 
-		TransformerPool tp = TransformerPool.getUtilityInstance(stylesheet, 2);
+		TransformerPool tp = TransformerPool.getInstance(stylesheet, 2, null);
 		tp.open();
 		String result = tp.transform(xmlString, null);
 		tp.close();

--- a/core/src/test/java/org/frankframework/align/TestAlignNamespacesXml.java
+++ b/core/src/test/java/org/frankframework/align/TestAlignNamespacesXml.java
@@ -63,7 +63,7 @@ public class TestAlignNamespacesXml extends AlignTestBase {
 		+ template
 		+ "</xsl:stylesheet>";
 
-		TransformerPool tp = TransformerPool.getInstance(stylesheet, 2);
+		TransformerPool tp = TransformerPool.getUtilityInstance(stylesheet, 2);
 		tp.open();
 		String result = tp.transform(xmlString, null);
 		tp.close();

--- a/core/src/test/java/org/frankframework/util/FunctionalTransformerPoolTestBase.java
+++ b/core/src/test/java/org/frankframework/util/FunctionalTransformerPoolTestBase.java
@@ -23,10 +23,4 @@ public class FunctionalTransformerPoolTestBase {
 	public void testTransformerPool(TransformerPool tp, String input, String expected) throws TransformerException, IOException, SAXException {
 		testTransformerPool(tp, input, expected, true, "String input");
 	}
-
-	public void testXslt(String xslt, String input, String expected, int xsltVersion) throws TransformerException, IOException, SAXException {
-		TransformerPool tp = TransformerPool.getUtilityInstance(xslt, xsltVersion);
-		testTransformerPool(tp, input, expected);
-	}
-
 }

--- a/core/src/test/java/org/frankframework/util/FunctionalTransformerPoolTestBase.java
+++ b/core/src/test/java/org/frankframework/util/FunctionalTransformerPoolTestBase.java
@@ -24,12 +24,9 @@ public class FunctionalTransformerPoolTestBase {
 		testTransformerPool(tp, input, expected, true, "String input");
 	}
 
-	public void testXslt(String xslt, String input, String expected) throws TransformerException, IOException, SAXException {
-		testXslt(xslt, input, expected, 0);
+	public void testXslt(String xslt, String input, String expected, int xsltVersion) throws TransformerException, IOException, SAXException {
+		TransformerPool tp = TransformerPool.getUtilityInstance(xslt, xsltVersion);
+		testTransformerPool(tp, input, expected);
 	}
 
-	public void testXslt(String xslt, String input, String expected, int xsltVersion) throws TransformerException, IOException, SAXException {
-		TransformerPool tp = TransformerPool.getInstance(xslt,xsltVersion);
-		testTransformerPool(tp,input,expected);
-	}
 }

--- a/core/src/test/java/org/frankframework/util/TransformerPoolTest.java
+++ b/core/src/test/java/org/frankframework/util/TransformerPoolTest.java
@@ -27,7 +27,7 @@ public class TransformerPoolTest {
 	@Test
 	public void plainXPath() throws Exception {
 		String xpathEvaluatorSource = XmlUtils.createXPathEvaluatorSource(xpath);
-		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource);
+		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource, XmlUtils.DEFAULT_XSLT_VERSION);
 		String result = transformerPool.transform(xml, null);
 		assertEquals(expectedXpath, result);
 	}
@@ -35,7 +35,7 @@ public class TransformerPoolTest {
 	@Test
 	public void plainXPathUsingMultiUseSource() throws Exception {
 		String xpathEvaluatorSource = XmlUtils.createXPathEvaluatorSource(xpath);
-		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource);
+		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource, XmlUtils.DEFAULT_XSLT_VERSION);
 		Source source = XmlUtils.stringToSource(xml);
 		String result = transformerPool.transform(source);
 		assertEquals(expectedXpath, result);

--- a/core/src/test/java/org/frankframework/util/TransformerPoolTest.java
+++ b/core/src/test/java/org/frankframework/util/TransformerPoolTest.java
@@ -26,16 +26,14 @@ public class TransformerPoolTest {
 
 	@Test
 	public void plainXPath() throws Exception {
-		String xpathEvaluatorSource = XmlUtils.createXPathEvaluatorSource(xpath);
-		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource, XmlUtils.DEFAULT_XSLT_VERSION);
+		TransformerPool transformerPool = TransformerPool.getXPathTransformerPool(xpath, XmlUtils.DEFAULT_XSLT_VERSION);
 		String result = transformerPool.transform(xml, null);
 		assertEquals(expectedXpath, result);
 	}
 
 	@Test
 	public void plainXPathUsingMultiUseSource() throws Exception {
-		String xpathEvaluatorSource = XmlUtils.createXPathEvaluatorSource(xpath);
-		TransformerPool transformerPool = TransformerPool.getInstance(xpathEvaluatorSource, XmlUtils.DEFAULT_XSLT_VERSION);
+		TransformerPool transformerPool = TransformerPool.getXPathTransformerPool(xpath, XmlUtils.DEFAULT_XSLT_VERSION);
 		Source source = XmlUtils.stringToSource(xml);
 		String result = transformerPool.transform(source);
 		assertEquals(expectedXpath, result);

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -48,27 +48,27 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	private static final TimeZone TEST_TZ = TimeZone.getTimeZone("UTC");
 
 	public void testGetRootNamespace(String input, String expected) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeGetRootNamespaceXslt(), input, expected);
+		testXslt(XmlUtils.makeGetRootNamespaceXslt(), input, expected, 2);
 		testTransformerPool(XmlUtils.getGetRootNamespaceTransformerPool(), input, expected);
 	}
 
 	public void testAddRootNamespace(String namespace, String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeAddRootNamespaceXslt(namespace, omitXmlDeclaration, indent), input, expected);
+		testXslt(XmlUtils.makeAddRootNamespaceXslt(namespace, omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getAddRootNamespaceTransformerPool(namespace, omitXmlDeclaration, indent), input, expected);
 	}
 
 	public void testChangeRoot(String root, String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeChangeRootXslt(root, omitXmlDeclaration, indent), input, expected);
+		testXslt(XmlUtils.makeChangeRootXslt(root, omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getChangeRootTransformerPool(root, omitXmlDeclaration, indent), input, expected);
 	}
 
 	public void testRemoveUnusedNamespaces(String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt(omitXmlDeclaration, indent), input, expected);
+		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt(omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getRemoveUnusedNamespacesTransformerPool(omitXmlDeclaration, indent), input, expected);
 	}
 
 	public void testRemoveUnusedNamespacesXslt2(String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException {
-		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration, indent),input,expected);
+		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration, indent),input,expected, 2);
 //		testTransformerPool(XmlUtils.getRemoveUnusedNamespacesXslt2TransformerPool(omitXmlDeclaration, indent),input,expected);
 	}
 

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -48,28 +48,24 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	private static final TimeZone TEST_TZ = TimeZone.getTimeZone("UTC");
 
 	public void testGetRootNamespace(String input, String expected) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeGetRootNamespaceXslt(), input, expected, 2);
 		testTransformerPool(XmlUtils.getGetRootNamespaceTransformerPool(), input, expected);
 	}
 
 	public void testAddRootNamespace(String namespace, String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeAddRootNamespaceXslt(namespace, omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getAddRootNamespaceTransformerPool(namespace, omitXmlDeclaration, indent), input, expected);
 	}
 
 	public void testChangeRoot(String root, String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeChangeRootXslt(root, omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getChangeRootTransformerPool(root, omitXmlDeclaration, indent), input, expected);
 	}
 
 	public void testRemoveUnusedNamespaces(String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
-		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt(omitXmlDeclaration, indent), input, expected, 1);
 		testTransformerPool(XmlUtils.getRemoveUnusedNamespacesTransformerPool(omitXmlDeclaration, indent), input, expected);
 	}
 
-	public void testRemoveUnusedNamespacesXslt2(String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException {
-		testXslt(XmlUtils.makeRemoveUnusedNamespacesXslt2(omitXmlDeclaration, indent),input,expected, 2);
-//		testTransformerPool(XmlUtils.getRemoveUnusedNamespacesXslt2TransformerPool(omitXmlDeclaration, indent),input,expected);
+	// TODO: Why is this test not executed anymore?
+	public void testRemoveUnusedNamespacesXslt2(String input, String expected, boolean omitXmlDeclaration, boolean indent) throws SAXException, TransformerException, IOException, ConfigurationException {
+		testTransformerPool(XmlUtils.getRemoveUnusedNamespacesXslt2TransformerPool(omitXmlDeclaration, indent),input,expected);
 	}
 
 

--- a/core/src/test/java/org/frankframework/util/XsltStreamingTest.java
+++ b/core/src/test/java/org/frankframework/util/XsltStreamingTest.java
@@ -141,7 +141,7 @@ public class XsltStreamingTest {
 		SwitchCounter sc = new SwitchCounter();
 
 		String xpath="/root/a";
-		TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null, xpath,OutputType.XML, false, null, false, false, null, 1));
+		TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null, xpath,OutputType.XML, false, null, false, false, null, 1), 1);
 
 		SAXResult result = new SAXResult();
 		SaxLogger resultfilter = new SaxLogger("out>", sc);

--- a/core/src/test/java/org/frankframework/util/XsltStreamingTest.java
+++ b/core/src/test/java/org/frankframework/util/XsltStreamingTest.java
@@ -141,19 +141,19 @@ public class XsltStreamingTest {
 		SwitchCounter sc = new SwitchCounter();
 
 		String xpath="/root/a";
-		TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(null, xpath,OutputType.XML, false, null, false, false, null, 1), 1);
+		TransformerPool tp = TransformerPool.getXPathTransformerPool(null, xpath, OutputType.XML, false, null, 1);
 
 		SAXResult result = new SAXResult();
 		SaxLogger resultfilter = new SaxLogger("out>", sc);
 		result.setHandler(resultfilter);
 
-		String input="<root>";
+		StringBuilder input= new StringBuilder("<root>");
 		for (int i=0;i<5;i++) {
-			input+="<a>"+i+"</a>"+"<b>opvulling</b>";
+			input.append("<a>").append(i).append("</a>").append("<b>opvulling</b>");
 		}
-		input+="</root>";
+		input.append("</root>");
 
-		ByteArrayInputStream bais = new ByteArrayInputStream(input.getBytes());
+		ByteArrayInputStream bais = new ByteArrayInputStream(input.toString().getBytes());
 		Source source = new StreamSource(new LoggingInputStream(bais, sc));
 
 		tp.transform(source, result);

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
@@ -182,7 +182,7 @@ public class BisJmsListener extends JmsListener {
 		}
 		try {
 			bisUtils = BisUtils.getInstance();
-			requestTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getRequestNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getRequestNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getRequestXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getRequestXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			requestTp = TransformerPool.getXPathTransformerPool(StringUtils.isNotEmpty(getRequestNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getRequestNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getRequestXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getRequestXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException(getLogPrefix() + "cannot create transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
@@ -22,8 +22,6 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.xml.sax.SAXException;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.ListenerException;
@@ -34,6 +32,7 @@ import org.frankframework.util.TransformerPool;
 import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.XmlException;
 import org.frankframework.util.XmlUtils;
+import org.xml.sax.SAXException;
 
 /**
  * Bis (Business Integration Services) extension of JmsListener.
@@ -183,7 +182,7 @@ public class BisJmsListener extends JmsListener {
 		}
 		try {
 			bisUtils = BisUtils.getInstance();
-			requestTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getRequestNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getRequestNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getRequestXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getRequestXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML));
+			requestTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getRequestNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getRequestNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getRequestXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getRequestXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException(getLogPrefix() + "cannot create transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import javax.xml.transform.TransformerConfigurationException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.Element;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeLineSession;
@@ -34,6 +32,7 @@ import org.frankframework.stream.Message;
 import org.frankframework.util.TransformerPool;
 import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.XmlUtils;
+import org.w3c.dom.Element;
 
 /**
  * Bis (Business Integration Services) extension of JmsSender.
@@ -96,9 +95,9 @@ public class BisJmsSender extends JmsSender {
 		}
 		try {
 			bisUtils = BisUtils.getInstance();
-			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorXPath() : bisUtils.getOldBisErrorXPath()), OutputType.TEXT));
-			responseTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getResponseNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getResponseNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getResponseXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getResponseXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML));
-			bisErrorListTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorListXPath() : bisUtils.getOldBisErrorListXPath()), OutputType.XML));
+			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorXPath() : bisUtils.getOldBisErrorXPath()), OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			responseTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getResponseNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getResponseNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getResponseXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getResponseXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisErrorListTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorListXPath() : bisUtils.getOldBisErrorListXPath()), OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException(getLogPrefix() + "cannot create transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
@@ -95,9 +95,9 @@ public class BisJmsSender extends JmsSender {
 		}
 		try {
 			bisUtils = BisUtils.getInstance();
-			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorXPath() : bisUtils.getOldBisErrorXPath()), OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			responseTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(StringUtils.isNotEmpty(getResponseNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getResponseNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getResponseXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getResponseXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
-			bisErrorListTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorListXPath() : bisUtils.getOldBisErrorListXPath()), OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisErrorTp = TransformerPool.getXPathTransformerPool(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorXPath() : bisUtils.getOldBisErrorXPath()), OutputType.TEXT);
+			responseTp = TransformerPool.getXPathTransformerPool(StringUtils.isNotEmpty(getResponseNamespaceDefs()) ? bisUtils.getSoapNamespaceDefs() + "\n" + getResponseNamespaceDefs() : bisUtils.getSoapNamespaceDefs(), StringUtils.isNotEmpty(getResponseXPath()) ? bisUtils.getSoapBodyXPath() + "/" + getResponseXPath() : bisUtils.getSoapBodyXPath() + "/*", OutputType.XML);
+			bisErrorListTp = TransformerPool.getXPathTransformerPool(bisUtils.getSoapNamespaceDefs() + "\n" + bisUtils.getBisNamespaceDefs(), (isResultInPayload() ? bisUtils.getBisErrorListXPath() : bisUtils.getOldBisErrorListXPath()), OutputType.XML);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException(getLogPrefix() + "cannot create transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
@@ -79,11 +79,11 @@ public class BisUtils {
 	private void init() throws ConfigurationException {
 		try {
 			// messageHeaderInSoapBody=true (old)
-			oldMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			oldMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			oldMessageHeaderConversationIdTp = TransformerPool.getXPathTransformerPool(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT);
+			oldMessageHeaderExternalRefToMessageIdTp = TransformerPool.getXPathTransformerPool(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT);
 			// messageHeaderInSoapBody=false
-			messageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			messageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			messageHeaderConversationIdTp = TransformerPool.getXPathTransformerPool(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT);
+			messageHeaderExternalRefToMessageIdTp = TransformerPool.getXPathTransformerPool(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("cannot create SOAP transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
@@ -23,10 +23,6 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.stream.Message;
 import org.frankframework.util.AppConstants;
@@ -39,6 +35,9 @@ import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.UUIDUtil;
 import org.frankframework.util.XmlBuilder;
 import org.frankframework.util.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
 /**
  * Some utilities for working with BIS.
@@ -80,11 +79,11 @@ public class BisUtils {
 	private void init() throws ConfigurationException {
 		try {
 			// messageHeaderInSoapBody=true (old)
-			oldMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT));
-			oldMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT));
+			oldMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			oldMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapBodyXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
 			// messageHeaderInSoapBody=false
-			messageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT));
-			messageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT));
+			messageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			messageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(soapNamespaceDefs + "\n" + bisNamespaceDefs, soapHeaderXPath + "/" + messageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException("cannot create SOAP transformer", e);
 		}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
@@ -235,7 +235,7 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 			if (StringUtils.isNotEmpty(getInputXPath())) {
 				String bodyMessageNd = StringUtils.isNotEmpty(getInputNamespaceDefs()) ? soapNamespaceDefs + "\n" + getInputNamespaceDefs() : soapNamespaceDefs;
 				String bodyMessageXe = StringUtils.isNotEmpty(getInputXPath()) ? soapBodyXPath + "/" + getInputXPath() : soapBodyXPath + "/*";
-				bodyMessageTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bodyMessageNd, bodyMessageXe, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+				bodyMessageTp = TransformerPool.getXPathTransformerPool(bodyMessageNd, bodyMessageXe, OutputType.XML);
 			}
 			String bisMessageHeaderNd = soapNamespaceDefs + "\n" + bisNamespaceDefs;
 			String bisMessageHeaderXe;
@@ -244,9 +244,9 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 			} else {
 				bisMessageHeaderXe = soapHeaderXPath + "/" + bisMessageHeaderXPath;
 			}
-			bisMessageHeaderTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisMessageHeaderNd, bisMessageHeaderXe, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
-			bisMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			bisMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisMessageHeaderTp = TransformerPool.getXPathTransformerPool(bisMessageHeaderNd, bisMessageHeaderXe, OutputType.XML);
+			bisMessageHeaderConversationIdTp = TransformerPool.getXPathTransformerPool(bisNamespaceDefs, bisMessageHeaderConversationIdXPath, OutputType.TEXT);
+			bisMessageHeaderExternalRefToMessageIdTp = TransformerPool.getXPathTransformerPool(bisNamespaceDefs, bisMessageHeaderExternalRefToMessageIdXPath, OutputType.TEXT);
 
 			String bisErrorNd = soapNamespaceDefs + "\n" + bisNamespaceDefs;
 			if (isBisResultInPayload()) {
@@ -255,7 +255,7 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 				bisErrorXe = soapBodyXPath + "/" + bisErrorXPath;
 			}
 			bisErrorXe = bisErrorXe + " or string-length(" + soapBodyXPath + "/" + soapErrorXPath + ")&gt;0";
-			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisErrorNd, bisErrorXe, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisErrorTp = TransformerPool.getXPathTransformerPool(bisErrorNd, bisErrorXe, OutputType.TEXT);
 			if (isAddOutputNamespace()) {
 				addOutputNamespaceTp = XmlUtils.getAddRootNamespaceTransformerPool(getOutputNamespace(), true, false);
 			}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
@@ -23,10 +23,6 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
-
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeLineSession;
@@ -43,6 +39,9 @@ import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.UUIDUtil;
 import org.frankframework.util.XmlBuilder;
 import org.frankframework.util.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
 /**
  * Pipe to wrap or unwrap a message conformable to the BIS (Business Integration Services) standard.
@@ -236,7 +235,7 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 			if (StringUtils.isNotEmpty(getInputXPath())) {
 				String bodyMessageNd = StringUtils.isNotEmpty(getInputNamespaceDefs()) ? soapNamespaceDefs + "\n" + getInputNamespaceDefs() : soapNamespaceDefs;
 				String bodyMessageXe = StringUtils.isNotEmpty(getInputXPath()) ? soapBodyXPath + "/" + getInputXPath() : soapBodyXPath + "/*";
-				bodyMessageTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bodyMessageNd, bodyMessageXe, OutputType.XML));
+				bodyMessageTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bodyMessageNd, bodyMessageXe, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
 			}
 			String bisMessageHeaderNd = soapNamespaceDefs + "\n" + bisNamespaceDefs;
 			String bisMessageHeaderXe;
@@ -245,9 +244,9 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 			} else {
 				bisMessageHeaderXe = soapHeaderXPath + "/" + bisMessageHeaderXPath;
 			}
-			bisMessageHeaderTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisMessageHeaderNd, bisMessageHeaderXe, OutputType.XML));
-			bisMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderConversationIdXPath, OutputType.TEXT));
-			bisMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderExternalRefToMessageIdXPath, OutputType.TEXT));
+			bisMessageHeaderTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisMessageHeaderNd, bisMessageHeaderXe, OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisMessageHeaderConversationIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderConversationIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			bisMessageHeaderExternalRefToMessageIdTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisNamespaceDefs, bisMessageHeaderExternalRefToMessageIdXPath, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
 
 			String bisErrorNd = soapNamespaceDefs + "\n" + bisNamespaceDefs;
 			if (isBisResultInPayload()) {
@@ -256,7 +255,7 @@ public class BisWrapperPipe extends SoapWrapperPipe {
 				bisErrorXe = soapBodyXPath + "/" + bisErrorXPath;
 			}
 			bisErrorXe = bisErrorXe + " or string-length(" + soapBodyXPath + "/" + soapErrorXPath + ")&gt;0";
-			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisErrorNd, bisErrorXe, OutputType.TEXT));
+			bisErrorTp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(bisErrorNd, bisErrorXe, OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
 			if (isAddOutputNamespace()) {
 				addOutputNamespaceTp = XmlUtils.getAddRootNamespaceTransformerPool(getOutputNamespace(), true, false);
 			}

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisWrapperPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2020 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2020, 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
@@ -24,10 +24,6 @@ import java.nio.file.Files;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.Getter;
-import lombok.Setter;
-
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.classloaders.DirectoryClassLoader;
@@ -48,8 +44,10 @@ import org.frankframework.util.Dir2Xml;
 import org.frankframework.util.FileUtils;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.TransformerPool;
-import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.XmlUtils;
+
+import lombok.Getter;
+import lombok.Setter;
 
 @Category("NN-Special")
 public class WsdlGeneratorPipe extends FixedForwardPipe {
@@ -205,10 +203,10 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 		inputValidator = createValidator(xsdFile, null, null, 1, 1, pipeLine);
 		pipeLine.setInputValidator(inputValidator);
 
-		String countRoot = null;
+		String countRoot;
 		try {
 			String countRootXPath = "count(*/*[local-name()='element'])";
-			TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(countRootXPath, OutputType.TEXT));
+			TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(countRootXPath), XmlUtils.DEFAULT_XSLT_VERSION);
 			Resource xsdResource = Resource.getResource(xsdFile.getPath());
 			countRoot = tp.transform(xsdResource.asSource());
 			if (StringUtils.isNotEmpty(countRoot)) {
@@ -237,7 +235,7 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 			if (StringUtils.isEmpty(namespace)) {
 				String xsdTargetNamespace = null;
 				try {
-					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource("*/@targetNamespace", OutputType.TEXT));
+					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource("*/@targetNamespace"), XmlUtils.DEFAULT_XSLT_VERSION);
 					xsdTargetNamespace = tp.transform(xsdResource.asSource());
 					if (StringUtils.isNotEmpty(xsdTargetNamespace)) {
 						log.debug("found target namespace [" + xsdTargetNamespace + "] in xsd file [" + xsdFile.getName() + "]");
@@ -264,10 +262,10 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 			}
 
 			if (StringUtils.isEmpty(root)) {
-				String xsdRoot = null;
+				String xsdRoot;
 				try {
 					String rootXPath = "*/*[local-name()='element'][" + rootPosition + "]/@name";
-					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(rootXPath, OutputType.TEXT));
+					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(rootXPath), XmlUtils.DEFAULT_XSLT_VERSION);
 					xsdRoot = tp.transform(xsdResource.asSource());
 					if (StringUtils.isNotEmpty(xsdRoot)) {
 						log.debug("found root element [" + xsdRoot + "] in xsd file [" + xsdFile.getName() + "]");

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
@@ -206,7 +206,7 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 		String countRoot;
 		try {
 			String countRootXPath = "count(*/*[local-name()='element'])";
-			TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(countRootXPath), XmlUtils.DEFAULT_XSLT_VERSION);
+			TransformerPool tp = TransformerPool.getXPathTransformerPool(countRootXPath, XmlUtils.DEFAULT_XSLT_VERSION);
 			Resource xsdResource = Resource.getResource(xsdFile.getPath());
 			countRoot = tp.transform(xsdResource.asSource());
 			if (StringUtils.isNotEmpty(countRoot)) {
@@ -233,9 +233,9 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 
 			Resource xsdResource = Resource.getResource(xsdFile.getPath());
 			if (StringUtils.isEmpty(namespace)) {
-				String xsdTargetNamespace = null;
+				String xsdTargetNamespace;
 				try {
-					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource("*/@targetNamespace"), XmlUtils.DEFAULT_XSLT_VERSION);
+					TransformerPool tp = TransformerPool.getXPathTransformerPool("*/@targetNamespace", XmlUtils.DEFAULT_XSLT_VERSION);
 					xsdTargetNamespace = tp.transform(xsdResource.asSource());
 					if (StringUtils.isNotEmpty(xsdTargetNamespace)) {
 						log.debug("found target namespace [" + xsdTargetNamespace + "] in xsd file [" + xsdFile.getName() + "]");
@@ -265,7 +265,7 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 				String xsdRoot;
 				try {
 					String rootXPath = "*/*[local-name()='element'][" + rootPosition + "]/@name";
-					TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(rootXPath), XmlUtils.DEFAULT_XSLT_VERSION);
+					TransformerPool tp = TransformerPool.getXPathTransformerPool(rootXPath, XmlUtils.DEFAULT_XSLT_VERSION);
 					xsdRoot = tp.transform(xsdResource.asSource());
 					if (StringUtils.isNotEmpty(xsdRoot)) {
 						log.debug("found root element [" + xsdRoot + "] in xsd file [" + xsdFile.getName() + "]");

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/nn-specials/src/main/java/org/frankframework/extensions/fxf/FxfWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/fxf/FxfWrapperPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016, 2020 Nationale-Nederlanden, 2020-2022 WeAreFrank!
+   Copyright 2013, 2016, 2020 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.frankframework.extensions.fxf;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.commons.lang3.StringUtils;
+import javax.xml.transform.TransformerConfigurationException;
 
-import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
@@ -35,6 +35,8 @@ import org.frankframework.util.SpringUtils;
 import org.frankframework.util.TransformerPool;
 import org.frankframework.util.TransformerPool.OutputType;
 import org.frankframework.util.XmlBuilder;
+
+import lombok.Getter;
 
 /**
  * FxF wrapper to be used with FxF3. When receiving files (direction=unwrap)
@@ -126,9 +128,17 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 			if(!new File(fxfDir).isDirectory()) {
 				throw new ConfigurationException("fxf.dir [" + fxfDir + "] doesn't exist or is not a directory");
 			}
-			transferFlowIdTp = TransformerPool.getXPathTransformerPool(null, TRANSFORMER_FLOW_ID_XPATH, OutputType.TEXT, false, getParameterList());
+			try {
+				transferFlowIdTp = TransformerPool.getXPathTransformerPool(null, TRANSFORMER_FLOW_ID_XPATH, OutputType.TEXT, false, getParameterList());
+			} catch (TransformerConfigurationException e) {
+				throw new ConfigurationException("Cannot create TransformerPool for XPath expression ["+TRANSFORMER_FLOW_ID_XPATH+"]", e);
+			}
 			String xpathFilename = isUseServerFilename() ? SERVER_FILENAME_XPATH : CLIENT_FILENAME_XPATH;
-			clientFilenameTp = TransformerPool.getXPathTransformerPool(null, xpathFilename, OutputType.TEXT, false, getParameterList());
+			try {
+				clientFilenameTp = TransformerPool.getXPathTransformerPool(null, xpathFilename, OutputType.TEXT, false, getParameterList());
+			} catch (TransformerConfigurationException e) {
+				throw new ConfigurationException("Cannot create TransformerPool for XPath expression ["+xpathFilename+"]", e);
+			}
 		}
 		if (StringUtils.isNotEmpty(getFlowOutFolder()) && !getFlowOutFolder().endsWith("/")) {
 			setFlowOutFolder(getFlowOutFolder()+"/");


### PR DESCRIPTION
There is one more change that I want to do which is to move all calls of `TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(..........))` to new overloaded methods `TransformerPool.getXPathTransformerPool(.....)`.

Then the remaining method `TransformerPool.getInstance(xslt, version)` can be made private or be deleted.