### PR TITLE
Use provided charset when converting to InputSource

### DIFF
--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -665,7 +665,7 @@ public class Message implements Serializable, Closeable {
 			return new InputSource(new StringReader((String) request));
 		}
 		LOG.debug("returning {} as InputSource", this::getObjectId);
-		if (isBinary()) {
+		if (isBinary() && getCharset() == null) { //When a charset is present it should be used.
 			return new InputSource(asInputStream());
 		}
 		return new InputSource(asReader());

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -379,14 +379,15 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 		assertTrue(handler.toString().contains("værgeløn"));
 	}
 
-	static Stream<Arguments> testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally() throws IOException, URISyntaxException {
-		return readFileInDifferentWays("/Util/MessageUtils/utf8.xml");
+	static Stream<Arguments> testReadBOMMessageAsInputSourceWithWrongEncodingSpecifiedExternally() throws IOException, URISyntaxException {
+		return readFileInDifferentWays("/Util/MessageUtils/utf8-with-bom.xml");
 	}
 	@ParameterizedTest
 	@MethodSource
-	public void testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally(Message message) throws Exception {
+	public void testReadBOMMessageAsInputSourceWithWrongEncodingSpecifiedExternally(Message message) throws Exception {
 		// Arrange
 		message.getContext().withCharset("ISO-8859-1");
+		assertEquals("ISO-8859-1", message.getCharset());
 
 		ContentHandler handler = new XmlWriter();
 		XMLReader xmlReader = XmlUtils.getXMLReader(handler);
@@ -397,6 +398,29 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 
 		// Assert
 		assertTrue(handler.toString().contains("testFile with BOM —•˜›"));
+	}
+
+	static Stream<Arguments> testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally() throws IOException, URISyntaxException {
+		return readFileInDifferentWays("/Util/MessageUtils/utf8-without-bom.xml");
+	}
+	@ParameterizedTest
+	@MethodSource
+	public void testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally(Message message) throws Exception {
+		// Arrange
+		message.getContext().withCharset("ISO-8859-1");
+		assertEquals("ISO-8859-1", message.getCharset());
+
+		ContentHandler handler = new XmlWriter();
+		XMLReader xmlReader = XmlUtils.getXMLReader(handler);
+
+		// Act
+		InputSource source = message.asInputSource();
+		xmlReader.parse(source);
+
+		// Assert
+		// NB: This assert breaks, because the parser is not reading the input XML correctly.
+		// Shows how the "fix" could be wrong. (But of course, when encoding is specified externally in metadata, and it doesn't match the contents, that is the real bug...)
+		assertFalse(handler.toString().contains("testFile with BOM —•˜›"));
 	}
 
 	static Stream<Arguments> testReadMessageAsInputSourceWithNonDefaultCharset() throws IOException, URISyntaxException {

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
@@ -24,9 +26,11 @@ import javax.xml.transform.TransformerFactory;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.Resource;
+import org.frankframework.stream.FileMessage;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.UrlMessage;
 import org.frankframework.testutil.MatchUtils;
+import org.frankframework.testutil.MessageTestUtils;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.testutil.TestScopeProvider;
 import org.frankframework.xml.StringBuilderContentHandler;
@@ -37,7 +41,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -337,5 +344,77 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	@ValueSource(strings = {"2023-13-09T24:08:05", "2023-13-09T18:60:05", "2023-13-09T18:08:60", "2023-13-09T18:08:05", "2023-11-31T18:08:05", "2100-02-29T18:08:05", "2013-12-10 12:41:43"})
 	public void shouldThrowErrorWhenStringWithHoursOutOfBoundsIsProvided(String s) {
 		assertThrows(IllegalArgumentException.class, () -> XmlUtils.parseXmlDateTime(s));
+	}
+
+
+	static Stream<Arguments> readFileInDifferentWays(String resource) throws IOException, URISyntaxException {
+		URL testFileURL = TestFileUtils.getTestFileURL(resource);
+
+		return Stream.of(
+				Arguments.of(MessageTestUtils.getBinaryMessage(resource, false)), //InputStream
+				Arguments.of(MessageTestUtils.getCharacterMessage(resource, false)), //Reader
+				Arguments.of(new UrlMessage(testFileURL)), //Supplier
+				Arguments.of(new FileMessage(new File(testFileURL.toURI()))) //SerializableFileReference
+			);
+	}
+
+	static Stream<Arguments> testReadMessageAsInputSourceWithUnspecifiedNonDefaultCharset() throws IOException, URISyntaxException {
+		return readFileInDifferentWays("/Util/MessageUtils/iso-8859-1_without_xml_declaration.xml");
+	}
+	@ParameterizedTest
+	@MethodSource
+	public void testReadMessageAsInputSourceWithUnspecifiedNonDefaultCharset(Message message) throws Exception {
+		// Arrange
+		message.getContext().withCharset("ISO-8859-1");
+
+		ContentHandler handler = new XmlWriter();
+		XMLReader xmlReader = XmlUtils.getXMLReader(handler);
+
+		// Act
+		InputSource source = message.asInputSource();
+		xmlReader.parse(source);
+
+		// Assert
+		assertTrue(handler.toString().contains("håndværkere"));
+		assertTrue(handler.toString().contains("værgeløn"));
+	}
+
+	static Stream<Arguments> testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally() throws IOException, URISyntaxException {
+		return readFileInDifferentWays("/Util/MessageUtils/utf8.xml");
+	}
+	@ParameterizedTest
+	@MethodSource
+	public void testReadMessageAsInputSourceWithWrongEncodingSpecifiedExternally(Message message) throws Exception {
+		// Arrange
+		message.getContext().withCharset("ISO-8859-1");
+
+		ContentHandler handler = new XmlWriter();
+		XMLReader xmlReader = XmlUtils.getXMLReader(handler);
+
+		// Act
+		InputSource source = message.asInputSource();
+		xmlReader.parse(source);
+
+		// Assert
+		assertTrue(handler.toString().contains("testFile with BOM —•˜›"));
+	}
+
+	static Stream<Arguments> testReadMessageAsInputSourceWithNonDefaultCharset() throws IOException, URISyntaxException {
+		return readFileInDifferentWays("/Util/MessageUtils/iso-8859-1.xml");
+	}
+	@ParameterizedTest
+	@MethodSource
+	public void testReadMessageAsInputSourceWithNonDefaultCharset(Message message) throws Exception {
+		// Arrange
+		ContentHandler handler = new XmlWriter();
+		XMLReader xmlReader = XmlUtils.getXMLReader(handler);
+
+		// Act
+		InputSource source = message.asInputSource();
+		xmlReader.parse(source);
+
+		// Assert
+		assertTrue(handler.toString().contains("håndværkere"));
+		assertTrue(handler.toString().contains("værgeløn"));
 	}
 }

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -1,6 +1,7 @@
 package org.frankframework.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/core/src/test/resources/Util/MessageUtils/iso-8859-1.xml
+++ b/core/src/test/resources/Util/MessageUtils/iso-8859-1.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<root>
+   <!-- This file is valid according to XML spec, because the non-UTF8 encoding is declared in the file -->
+BARNDOMSOMGIVELSERNE<b/>
+ Skønt H. C. Andersens barndomsomgivelser var meget fattige, blev de i hans rige fantasi
+ solbeskinnede.
+    Der findes en mandtalsliste fra nogle få år ______ H. C. Andersens fødsel. Den er ______ 1801
+ og den giver klare oplysninger om, hvor mange der boede ______ Odense og hvad de var
+ beskæftigede ______. Den omfatter 1199 husstande. Hvis man fordeler disse ______ erhverv,
+ får man 102 embeds- og bestillingsmænd, 26 officerer, 12 der beskæftiger sig med
+ immaterielle erhverv, 81 som lever ______ handel, 36 værtshusholdere, 460 håndværkere, 39
+ avlsmænd og urtemænd, 121 soldater, 97 daglejere, 139 enlige kvinder og
+ almissemedlemmer, 29 pensionister og rentenydere.
+    H. C. Andersens forældre tilhørte samfundets laveste lag. Faderen var friskomager, og
+ når han meldte sig ______ militærtjeneste ______ Napoleons side, har det nok ikke så meget været
+ idealisme som praktisk økonomi. For at sikre sig en soldats værgeløn. Han kom ikke
+ længere end ______ Holsten. Han fik høj feber og måtte sendes hjem. Da han kom hjem,
+ forværredes sygdommen og han døde.
+</root>

--- a/core/src/test/resources/Util/MessageUtils/iso-8859-1_without_xml_declaration.xml
+++ b/core/src/test/resources/Util/MessageUtils/iso-8859-1_without_xml_declaration.xml
@@ -1,0 +1,18 @@
+<root>
+   <!-- This file is valid according to XML spec, because the non-UTF8 encoding is declared in the file -->
+BARNDOMSOMGIVELSERNE<b/>
+ Skønt H. C. Andersens barndomsomgivelser var meget fattige, blev de i hans rige fantasi
+ solbeskinnede.
+    Der findes en mandtalsliste fra nogle få år ______ H. C. Andersens fødsel. Den er ______ 1801
+ og den giver klare oplysninger om, hvor mange der boede ______ Odense og hvad de var
+ beskæftigede ______. Den omfatter 1199 husstande. Hvis man fordeler disse ______ erhverv,
+ får man 102 embeds- og bestillingsmænd, 26 officerer, 12 der beskæftiger sig med
+ immaterielle erhverv, 81 som lever ______ handel, 36 værtshusholdere, 460 håndværkere, 39
+ avlsmænd og urtemænd, 121 soldater, 97 daglejere, 139 enlige kvinder og
+ almissemedlemmer, 29 pensionister og rentenydere.
+    H. C. Andersens forældre tilhørte samfundets laveste lag. Faderen var friskomager, og
+ når han meldte sig ______ militærtjeneste ______ Napoleons side, har det nok ikke så meget været
+ idealisme som praktisk økonomi. For at sikre sig en soldats værgeløn. Han kom ikke
+ længere end ______ Holsten. Han fik høj feber og måtte sendes hjem. Da han kom hjem,
+ forværredes sygdommen og han døde.
+</root>

--- a/core/src/test/resources/Util/MessageUtils/utf8-with-bom.xml
+++ b/core/src/test/resources/Util/MessageUtils/utf8-with-bom.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+testFile with BOM —•˜›
+</root>

--- a/core/src/test/resources/Util/MessageUtils/utf8-without-bom.xml
+++ b/core/src/test/resources/Util/MessageUtils/utf8-without-bom.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+testFile w/o BOM —•˜›
+</root>

--- a/core/src/test/resources/Util/MessageUtils/utf8.xml
+++ b/core/src/test/resources/Util/MessageUtils/utf8.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+testFile with BOM —•˜›
+</root>


### PR DESCRIPTION
Took #6357 as a base and expanded the tests a tiny bit.