### PR TITLE
Improve OpenAPI spec code

### DIFF
--- a/core/src/main/java/org/frankframework/http/openapi/OpenApiGenerator.java
+++ b/core/src/main/java/org/frankframework/http/openapi/OpenApiGenerator.java
@@ -1,0 +1,280 @@
+/*
+Copyright 2024 WeAreFrank!
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.frankframework.http.openapi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.xerces.xs.XSModel;
+import org.frankframework.align.XmlTypeToJsonSchemaConverter;
+import org.frankframework.core.IAdapter;
+import org.frankframework.core.PipeLine;
+import org.frankframework.core.PipeLineExit;
+import org.frankframework.http.rest.ApiDispatchConfig;
+import org.frankframework.http.rest.ApiListener;
+import org.frankframework.http.rest.ApiServiceDispatcher;
+import org.frankframework.http.rest.MediaTypes;
+import org.frankframework.parameters.Parameter;
+import org.frankframework.pipes.Json2XmlValidator;
+import org.frankframework.util.AppConstants;
+import org.frankframework.util.DateFormatUtils;
+import org.frankframework.util.HttpUtils;
+import org.springframework.util.MimeType;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class OpenApiGenerator {
+
+	public static JsonObject generateOpenApiJsonSchema(Collection<ApiDispatchConfig> clients, String endpoint, HttpServletRequest request) {
+		JsonObjectBuilder root = Json.createObjectBuilder();
+		root.add("openapi", "3.0.0");
+		String instanceName = AppConstants.getInstance().getProperty("instance.name");
+		String environment = AppConstants.getInstance().getString("dtap.stage", "LOC");
+		JsonObjectBuilder info = Json.createObjectBuilder();
+		info.add("title", instanceName);
+		info.add("description", "OpenApi auto-generated at " + DateFormatUtils.getTimeStamp() + " for " + instanceName + " (" + environment + ")");
+		info.add("version", "unknown");
+		root.add("info", info);
+		root.add("servers", mapServers(endpoint, request));
+
+		JsonObjectBuilder paths = Json.createObjectBuilder();
+		JsonObjectBuilder schemas = Json.createObjectBuilder();
+
+		for (ApiDispatchConfig config : clients) {
+			JsonObjectBuilder methods = Json.createObjectBuilder();
+			ApiListener listener = null;
+			for (ApiListener.HttpMethod method : config.getMethods()) {
+				JsonObjectBuilder methodBuilder = Json.createObjectBuilder();
+				listener = config.getApiListener(method);
+				if (listener != null && listener.getReceiver() != null) {
+					IAdapter adapter = listener.getReceiver().getAdapter();
+					if (StringUtils.isNotEmpty(adapter.getDescription())) {
+						methodBuilder.add("summary", adapter.getDescription());
+					}
+					if (StringUtils.isNotEmpty(listener.getOperationId())) {
+						methodBuilder.add("operationId", listener.getOperationId());
+					}
+					// GET and DELETE methods cannot have a requestBody according to the specs.
+					if (method != ApiListener.HttpMethod.GET && method != ApiListener.HttpMethod.DELETE) {
+						mapRequest(adapter, listener.getConsumes(), methodBuilder);
+					}
+					mapParamsInRequest(adapter, listener, methodBuilder);
+
+					methodBuilder.add("responses", mapResponses(adapter, listener.getContentType(), schemas));
+				}
+				methods.add(method.name().toLowerCase(), methodBuilder);
+			}
+			if (listener != null) {
+				paths.add(listener.getUriPattern(), methods);
+			}
+		}
+		root.add("paths", paths.build());
+		JsonObjectBuilder components = Json.createObjectBuilder();
+		components.add("schemas", schemas);
+		root.add("components", components);
+
+		return root.build();
+	}
+
+	private static JsonArrayBuilder mapServers(String url, HttpServletRequest request) {
+		JsonArrayBuilder serversArray = Json.createArrayBuilder();
+		String servletPath = AppConstants.getInstance().getString("servlet.ApiListenerServlet.urlMapping", "/api");
+
+		// Get load balancer url if exists
+		String loadBalancerUrl = AppConstants.getInstance().getProperty("loadBalancer.url", null);
+		if (StringUtils.isNotEmpty(loadBalancerUrl)) {
+			serversArray.add(Json.createObjectBuilder().add("url", loadBalancerUrl + servletPath).add("description", "load balancer"));
+		} else if (request != null) { // fall back to the request url
+			String requestUrl = HttpUtils.urlDecode(request.getRequestURL()
+					.toString()); // raw request -> schema+hostname+port/context-path/servlet-path/+request-uri
+			String requestPath = request.getPathInfo(); // -> the remaining path, starts with a /. Is automatically decoded by the web container!
+			String fullRequestUrl = requestUrl.substring(0, requestUrl.indexOf(requestPath));
+			serversArray.add(Json.createObjectBuilder().add("url", fullRequestUrl));
+		} else if (StringUtils.isNotBlank(url)) { // fall back to the request url
+			// TODO: validate if serverName property is set, including protocol and port
+			serversArray.add(Json.createObjectBuilder().add("url", url));
+		}
+
+		return serversArray;
+	}
+
+	private static void mapParamsInRequest(IAdapter adapter, ApiListener listener, JsonObjectBuilder methodBuilder) {
+		String uriPattern = listener.getUriPattern();
+		JsonArrayBuilder paramBuilder = Json.createArrayBuilder();
+		mapPathParameters(paramBuilder, uriPattern);
+		List<String> paramsFromHeaderAndCookie = mapHeaderAndParams(paramBuilder, listener);
+
+		// query params
+		Json2XmlValidator inputValidator = ApiServiceDispatcher.getJsonValidator(adapter.getPipeLine(), false);
+		if (inputValidator != null && !inputValidator.getParameterList().isEmpty()) {
+			for (Parameter parameter : inputValidator.getParameterList()) {
+				String parameterSessionKey = parameter.getSessionKey();
+				if (StringUtils.isNotEmpty(parameterSessionKey) && !parameterSessionKey.equals("headers") && !paramsFromHeaderAndCookie.contains(parameterSessionKey)) {
+					Parameter.ParameterType parameterType = parameter.getType() != null ? parameter.getType() : Parameter.ParameterType.STRING;
+					paramBuilder.add(addParameterToSchema(parameterSessionKey, "query", false, Json.createObjectBuilder()
+							.add("type", parameterType.toString().toLowerCase())));
+				}
+			}
+		}
+		JsonArray paramBuilderArray = paramBuilder.build();
+		if (!paramBuilderArray.isEmpty()) {
+			methodBuilder.add("parameters", paramBuilderArray);
+		}
+	}
+
+	private static List<String> mapHeaderAndParams(JsonArrayBuilder paramBuilder, ApiListener listener) {
+		List<String> paramsFromHeaderAndCookie = new ArrayList<>();
+		// header parameters
+		if (StringUtils.isNotEmpty(listener.getHeaderParams())) {
+			String[] params = listener.getHeaderParams().split(",");
+			for (String parameter : params) {
+				paramBuilder.add(addParameterToSchema(parameter, "header", false, Json.createObjectBuilder().add("type", "string")));
+				paramsFromHeaderAndCookie.add(parameter);
+			}
+		}
+		if (StringUtils.isNotEmpty(listener.getMessageIdHeader())) {
+			paramBuilder.add(addParameterToSchema(listener.getMessageIdHeader(), "header", false, Json.createObjectBuilder().add("type", "string")));
+		}
+
+		return paramsFromHeaderAndCookie;
+	}
+
+	private static void mapPathParameters(JsonArrayBuilder paramBuilder, String uriPattern) {
+		// path parameters
+		if (uriPattern.contains("{")) {
+			Pattern p = Pattern.compile("[^{/}]+(?=})");
+			Matcher m = p.matcher(uriPattern);
+			while (m.find()) {
+				paramBuilder.add(addParameterToSchema(m.group(), "path", true, Json.createObjectBuilder().add("type", "string")));
+			}
+		}
+	}
+
+	private static JsonObjectBuilder addParameterToSchema(String name, String in, boolean required, JsonObjectBuilder schema) {
+		JsonObjectBuilder param = Json.createObjectBuilder();
+		param.add("name", name);
+		param.add("in", in);
+		if (required) {
+			param.add("required", required);
+		}
+		param.add("schema", schema);
+		return param;
+	}
+
+	private static void mapRequest(IAdapter adapter, MediaTypes consumes, JsonObjectBuilder methodBuilder) {
+		PipeLine pipeline = adapter.getPipeLine();
+		Json2XmlValidator inputValidator = ApiServiceDispatcher.getJsonValidator(pipeline, false);
+		if (inputValidator != null && StringUtils.isNotEmpty(inputValidator.getRoot())) {
+			JsonObjectBuilder requestBodyContent = Json.createObjectBuilder();
+			JsonObjectBuilder schemaBuilder = Json.createObjectBuilder()
+					.add("schema", Json.createObjectBuilder().add("$ref", XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH + inputValidator.getRoot()));
+			requestBodyContent.add("content", Json.createObjectBuilder().add(mimeTypeToString(consumes.getMimeType()), schemaBuilder));
+			methodBuilder.add("requestBody", requestBodyContent);
+		}
+	}
+
+	//ContentType may have more parameters such as charset and formdata-boundary, strip those
+	private static String mimeTypeToString(MimeType mimeType) {
+		return mimeType.getType() + "/" + mimeType.getSubtype();
+	}
+
+	private static JsonObjectBuilder mapResponses(IAdapter adapter, MimeType contentType, JsonObjectBuilder schemas) {
+		JsonObjectBuilder responses = Json.createObjectBuilder();
+
+		PipeLine pipeline = adapter.getPipeLine();
+		Json2XmlValidator inputValidator = ApiServiceDispatcher.getJsonValidator(pipeline, false);
+		Json2XmlValidator outputValidator = ApiServiceDispatcher.getJsonValidator(pipeline, true);
+
+		JsonObjectBuilder schema = null;
+		String schemaReferenceElement = null;
+		List<XSModel> models = new ArrayList<>();
+		if (inputValidator != null) {
+			models.addAll(inputValidator.getXSModels());
+			schemaReferenceElement = inputValidator.getMessageRoot(true);
+		}
+		if (outputValidator != null) {
+			models.addAll(outputValidator.getXSModels());
+			schemaReferenceElement = outputValidator.getRoot();    // all non-empty exits should refer to this element
+		}
+
+		if (!models.isEmpty()) {
+			schema = Json.createObjectBuilder();
+		}
+		addComponentsToTheSchema(schemas, models);
+
+		Map<String, PipeLineExit> pipeLineExits = pipeline.getPipeLineExits();
+		for (String exitPath : pipeLineExits.keySet()) {
+			PipeLineExit ple = pipeLineExits.get(exitPath);
+			int exitCode = ple.getExitCode();
+			if (exitCode == 0) {
+				exitCode = 200;
+			}
+
+			JsonObjectBuilder exit = Json.createObjectBuilder();
+
+			Response.Status status = Response.Status.fromStatusCode(exitCode);
+			exit.add("description", status.getReasonPhrase());
+			if (!ple.isEmptyResult()) {
+				JsonObjectBuilder content = Json.createObjectBuilder();
+				if (StringUtils.isNotEmpty(schemaReferenceElement)) {
+					String reference;
+					if (StringUtils.isNotEmpty(ple.getResponseRoot()) && outputValidator == null) {
+						reference = ple.getResponseRoot();
+					} else {
+						List<String> references = List.of(schemaReferenceElement.split(","));
+						if (ple.isSuccessExit()) {
+							reference = references.get(0);
+						} else {
+							reference = references.get(references.size() - 1);
+						}
+					}
+					// JsonObjectBuilder add method consumes the schema
+					schema.add("schema", Json.createObjectBuilder().add("$ref", XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH + reference));
+					content.add(mimeTypeToString(contentType), schema);
+				}
+				exit.add("content", content);
+			}
+
+			responses.add("" + exitCode, exit);
+		}
+		return responses;
+	}
+
+	private static void addComponentsToTheSchema(JsonObjectBuilder schemas, List<XSModel> models) {
+		XmlTypeToJsonSchemaConverter converter = new XmlTypeToJsonSchemaConverter(models, true, XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH);
+		JsonObject jsonSchema = converter.getDefinitions();
+		if (jsonSchema != null) {
+			for (Map.Entry<String, JsonValue> entry : jsonSchema.entrySet()) {
+				schemas.add(entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+}

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -32,6 +32,16 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.nimbusds.jose.util.JSONObjectUtils;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonWriter;
+import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMultipart;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
@@ -58,17 +68,6 @@ import org.frankframework.util.StreamUtil;
 import org.frankframework.util.XmlBuilder;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeType;
-
-import com.nimbusds.jose.util.JSONObjectUtils;
-
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonWriter;
-import jakarta.json.JsonWriterFactory;
-import jakarta.json.stream.JsonGenerator;
-import jakarta.mail.BodyPart;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMultipart;
 
 /**
  *
@@ -168,7 +167,7 @@ public class ApiListenerServlet extends HttpServletBase {
 
 			/*
 			 * Generate an OpenApi json file for a set of ApiDispatchConfigs
-			 * @Deprecated This is here to support old url's
+			 * @Deprecated This is here to support old urls
 			 */
 			if(uri.endsWith("openapi.json")) {
 				generatePartialOpenApiSpec(uri, request, response);
@@ -189,7 +188,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			response.sendError(404, "OpenApi specification not found");
 			return;
 		}
-		JsonObject jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint);
+		JsonObject jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint, request);
 		returnJson(response, 200, jsonSchema);
 	}
 
@@ -200,12 +199,12 @@ public class ApiListenerServlet extends HttpServletBase {
 		if(specUri != null) {
 			ApiDispatchConfig apiConfig = dispatcher.findExactMatchingConfigForUri(specUri);
 			if(apiConfig != null) {
-				jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint);
+				jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint, request);
 			} else {
 				jsonSchema = null;
 			}
 		} else {
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(endpoint);
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(endpoint, request);
 		}
 		if (jsonSchema == null) {
 			response.sendError(404, "OpenApi specification not found");

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -188,7 +188,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			response.sendError(404, "OpenApi specification not found");
 			return;
 		}
-		JsonObject jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint, request);
+		JsonObject jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint);
 		returnJson(response, 200, jsonSchema);
 	}
 
@@ -199,12 +199,12 @@ public class ApiListenerServlet extends HttpServletBase {
 		if(specUri != null) {
 			ApiDispatchConfig apiConfig = dispatcher.findExactMatchingConfigForUri(specUri);
 			if(apiConfig != null) {
-				jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint, request);
+				jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, endpoint);
 			} else {
 				jsonSchema = null;
 			}
 		} else {
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(endpoint, request);
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(endpoint);
 		}
 		if (jsonSchema == null) {
 			response.sendError(404, "OpenApi specification not found");

--- a/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
@@ -18,7 +18,6 @@ package org.frankframework.http.rest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -26,7 +25,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
 
 import jakarta.json.JsonObject;
 import lombok.extern.log4j.Log4j2;
@@ -34,8 +32,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLine;
-import org.frankframework.pipes.Json2XmlValidator;
 import org.frankframework.http.openapi.OpenApiGenerator;
+import org.frankframework.pipes.Json2XmlValidator;
 
 /**
  * This class registers dispatches requests to the proper registered ApiListeners.
@@ -286,13 +284,13 @@ public class ApiServiceDispatcher {
 		return Collections.unmodifiableSortedMap(patternClients);
 	}
 
-	public JsonObject generateOpenApiJsonSchema(String endpoint, HttpServletRequest request) {
-		return OpenApiGenerator.generateOpenApiJsonSchema(getPatternClients().values(), endpoint, request);
+	public JsonObject generateOpenApiJsonSchema(String endpoint) {
+		return OpenApiGenerator.generateOpenApiJsonSchema(getPatternClients().values(), endpoint);
 	}
 
-	public JsonObject generateOpenApiJsonSchema(ApiDispatchConfig client, String endpoint, HttpServletRequest request) {
+	public JsonObject generateOpenApiJsonSchema(ApiDispatchConfig client, String endpoint) {
 		List<ApiDispatchConfig> clientList = List.of(client);
-		return OpenApiGenerator.generateOpenApiJsonSchema(clientList, endpoint, request);
+		return OpenApiGenerator.generateOpenApiJsonSchema(clientList, endpoint);
 	}
 
 	public static Json2XmlValidator getJsonValidator(PipeLine pipeline, boolean forOutputValidation) {
@@ -307,12 +305,11 @@ public class ApiServiceDispatcher {
 	}
 
 	public void clear() {
-		for (Iterator<String> it = patternClients.keySet().iterator(); it.hasNext();) {
-			String uriPattern = it.next();
+		for (String uriPattern : patternClients.keySet()) {
 			ApiDispatchConfig config = patternClients.remove(uriPattern);
-			if(config != null) config.clear();
+			if (config != null) config.clear();
 		}
-		if(!patternClients.isEmpty()) {
+		if (!patternClients.isEmpty()) {
 			log.warn("unable to gracefully unregister [{}] DispatchConfigs", patternClients.size());
 			patternClients.clear();
 		}

--- a/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiServiceDispatcher.java
@@ -16,44 +16,26 @@ limitations under the License.
 package org.frankframework.http.rest;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.ws.rs.core.Response.Status;
+import javax.servlet.http.HttpServletRequest;
 
+import jakarta.json.JsonObject;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.xerces.xs.XSModel;
-import org.frankframework.align.XmlTypeToJsonSchemaConverter;
-import org.frankframework.core.IAdapter;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLine;
-import org.frankframework.core.PipeLineExit;
-import org.frankframework.parameters.Parameter;
-import org.frankframework.parameters.Parameter.ParameterType;
 import org.frankframework.pipes.Json2XmlValidator;
-import org.frankframework.util.AppConstants;
-import org.frankframework.util.DateFormatUtils;
-import org.springframework.util.MimeType;
-
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonArrayBuilder;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
-import jakarta.json.JsonValue;
-import lombok.extern.log4j.Log4j2;
+import org.frankframework.http.openapi.OpenApiGenerator;
 
 /**
  * This class registers dispatches requests to the proper registered ApiListeners.
@@ -304,79 +286,13 @@ public class ApiServiceDispatcher {
 		return Collections.unmodifiableSortedMap(patternClients);
 	}
 
-	public JsonObject generateOpenApiJsonSchema(String endpoint) {
-		return generateOpenApiJsonSchema(getPatternClients().values(), endpoint);
+	public JsonObject generateOpenApiJsonSchema(String endpoint, HttpServletRequest request) {
+		return OpenApiGenerator.generateOpenApiJsonSchema(getPatternClients().values(), endpoint, request);
 	}
 
-	public JsonObject generateOpenApiJsonSchema(ApiDispatchConfig client, String endpoint) {
+	public JsonObject generateOpenApiJsonSchema(ApiDispatchConfig client, String endpoint, HttpServletRequest request) {
 		List<ApiDispatchConfig> clientList = List.of(client);
-		return generateOpenApiJsonSchema(clientList, endpoint);
-	}
-
-	protected JsonObject generateOpenApiJsonSchema(Collection<ApiDispatchConfig> clients, String endpoint) {
-		JsonObjectBuilder root = Json.createObjectBuilder();
-		root.add("openapi", "3.0.0");
-		String instanceName = AppConstants.getInstance().getProperty("instance.name");
-		String environment = AppConstants.getInstance().getString("dtap.stage", "LOC");
-		JsonObjectBuilder info = Json.createObjectBuilder();
-		info.add("title", instanceName);
-		info.add("description", "OpenApi auto-generated at "+ DateFormatUtils.getTimeStamp()+" for "+instanceName+" ("+environment+")");
-		info.add("version", "unknown");
-		root.add("info", info);
-		root.add("servers", mapServers(endpoint));
-
-		JsonObjectBuilder paths = Json.createObjectBuilder();
-		JsonObjectBuilder schemas = Json.createObjectBuilder();
-
-		for (ApiDispatchConfig config : clients) {
-			JsonObjectBuilder methods = Json.createObjectBuilder();
-			ApiListener listener = null;
-			for (ApiListener.HttpMethod method : config.getMethods()) {
-				JsonObjectBuilder methodBuilder = Json.createObjectBuilder();
-				listener = config.getApiListener(method);
-				if(listener != null && listener.getReceiver() != null) {
-					IAdapter adapter = listener.getReceiver().getAdapter();
-					if (StringUtils.isNotEmpty(adapter.getDescription())) {
-						methodBuilder.add("summary", adapter.getDescription());
-					}
-					if(StringUtils.isNotEmpty(listener.getOperationId())) {
-						methodBuilder.add("operationId", listener.getOperationId());
-					}
-					// GET and DELETE methods cannot have a requestBody according to the specs.
-					if(method != ApiListener.HttpMethod.GET && method != ApiListener.HttpMethod.DELETE) {
-						mapRequest(adapter, listener.getConsumes(), methodBuilder);
-					}
-					mapParamsInRequest(adapter, listener, methodBuilder);
-
-					methodBuilder.add("responses", mapResponses(adapter, listener.getContentType(), schemas));
-				}
-				methods.add(method.name().toLowerCase(), methodBuilder);
-			}
-			if(listener != null) {
-				paths.add(listener.getUriPattern(), methods);
-			}
-		}
-		root.add("paths", paths.build());
-		JsonObjectBuilder components = Json.createObjectBuilder();
-		components.add("schemas", schemas);
-		root.add("components", components);
-
-		return root.build();
-	}
-
-	private JsonArrayBuilder mapServers(String url) {
-		JsonArrayBuilder serversArray = Json.createArrayBuilder();
-		String servletPath = AppConstants.getInstance().getString("servlet.ApiListenerServlet.urlMapping", "/api");
-
-		// Get load balancer url if exists
-		String loadBalancerUrl = AppConstants.getInstance().getProperty("loadBalancer.url", null);
-		if(StringUtils.isNotEmpty(loadBalancerUrl)) {
-			serversArray.add(Json.createObjectBuilder().add("url", loadBalancerUrl + servletPath).add("description", "load balancer"));
-		} else if(StringUtils.isNotBlank(url)) { // fall back to the request url
-			serversArray.add(Json.createObjectBuilder().add("url", url));
-		}
-
-		return serversArray;
+		return OpenApiGenerator.generateOpenApiJsonSchema(clientList, endpoint, request);
 	}
 
 	public static Json2XmlValidator getJsonValidator(PipeLine pipeline, boolean forOutputValidation) {
@@ -388,156 +304,6 @@ public class ApiServiceDispatcher {
 			return (Json2XmlValidator) validator;
 		}
 		return null;
-	}
-
-	private void mapParamsInRequest(IAdapter adapter, ApiListener listener, JsonObjectBuilder methodBuilder) {
-		String uriPattern = listener.getUriPattern();
-		JsonArrayBuilder paramBuilder = Json.createArrayBuilder();
-		mapPathParameters(paramBuilder, uriPattern);
-		List<String> paramsFromHeaderAndCookie = mapHeaderAndParams(paramBuilder, listener);
-
-		// query params
-		Json2XmlValidator inputValidator = getJsonValidator(adapter.getPipeLine(), false);
-		if(inputValidator != null && !inputValidator.getParameterList().isEmpty()) {
-			for (Parameter parameter : inputValidator.getParameterList()) {
-				String parameterSessionkey = parameter.getSessionKey();
-				if(StringUtils.isNotEmpty(parameterSessionkey) && !parameterSessionkey.equals("headers") && !paramsFromHeaderAndCookie.contains(parameterSessionkey)) {
-					ParameterType parameterType = parameter.getType() != null ? parameter.getType() : ParameterType.STRING;
-					paramBuilder.add(addParameterToSchema(parameterSessionkey, "query", false, Json.createObjectBuilder().add("type", parameterType.toString().toLowerCase())));
-				}
-			}
-		}
-		JsonArray paramBuilderArray = paramBuilder.build();
-		if(!paramBuilderArray.isEmpty()) {
-			methodBuilder.add("parameters", paramBuilderArray);
-		}
-	}
-
-	private List<String> mapHeaderAndParams(JsonArrayBuilder paramBuilder, ApiListener listener) {
-		List<String> paramsFromHeaderAndCookie = new ArrayList<>();
-		// header parameters
-		if(StringUtils.isNotEmpty(listener.getHeaderParams())) {
-			String[] params = listener.getHeaderParams().split(",");
-			for (String parameter : params) {
-				paramBuilder.add(addParameterToSchema(parameter, "header", false, Json.createObjectBuilder().add("type", "string")));
-				paramsFromHeaderAndCookie.add(parameter);
-			}
-		}
-		if(StringUtils.isNotEmpty(listener.getMessageIdHeader())) {
-			paramBuilder.add(addParameterToSchema(listener.getMessageIdHeader(), "header", false, Json.createObjectBuilder().add("type", "string")));
-		}
-
-		return paramsFromHeaderAndCookie;
-	}
-
-	private void mapPathParameters(JsonArrayBuilder paramBuilder, String uriPattern) {
-		// path parameters
-		if(uriPattern.contains("{")) {
-			Pattern p = Pattern.compile("[^{/}]+(?=})");
-			Matcher m = p.matcher(uriPattern);
-			while(m.find()) {
-				paramBuilder.add(addParameterToSchema(m.group(), "path", true, Json.createObjectBuilder().add("type", "string")));
-			}
-		}
-	}
-
-	private JsonObjectBuilder addParameterToSchema(String name, String in, boolean required, JsonObjectBuilder schema) {
-		JsonObjectBuilder param = Json.createObjectBuilder();
-		param.add("name", name);
-		param.add("in", in);
-		if(required) {
-			param.add("required", required);
-		}
-		param.add("schema", schema);
-		return param;
-	}
-
-	private void mapRequest(IAdapter adapter, MediaTypes consumes, JsonObjectBuilder methodBuilder) {
-		PipeLine pipeline = adapter.getPipeLine();
-		Json2XmlValidator inputValidator = getJsonValidator(pipeline,false);
-		if(inputValidator != null && StringUtils.isNotEmpty(inputValidator.getRoot())) {
-			JsonObjectBuilder requestBodyContent = Json.createObjectBuilder();
-			JsonObjectBuilder schemaBuilder = Json.createObjectBuilder().add("schema", Json.createObjectBuilder().add("$ref", XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH+inputValidator.getRoot()));
-			requestBodyContent.add("content", Json.createObjectBuilder().add(mimeTypeToString(consumes.getMimeType()), schemaBuilder));
-			methodBuilder.add("requestBody", requestBodyContent);
-		}
-	}
-
-	//ContentType may have more parameters such as charset and formdata-boundry, strip those
-	private String mimeTypeToString(MimeType mimeType) {
-		return mimeType.getType() + "/" + mimeType.getSubtype();
-	}
-
-	private JsonObjectBuilder mapResponses(IAdapter adapter, MimeType contentType, JsonObjectBuilder schemas) {
-		JsonObjectBuilder responses = Json.createObjectBuilder();
-
-		PipeLine pipeline = adapter.getPipeLine();
-		Json2XmlValidator inputValidator = getJsonValidator(pipeline, false);
-		Json2XmlValidator outputValidator = getJsonValidator(pipeline, true);
-
-		JsonObjectBuilder schema = null;
-		String schemaReferenceElement = null;
-		List<XSModel> models = new ArrayList<>();
-		if(inputValidator != null) {
-			models.addAll(inputValidator.getXSModels());
-			schemaReferenceElement = inputValidator.getMessageRoot(true);
-		}
-		if(outputValidator != null) {
-			models.addAll(outputValidator.getXSModels());
-			schemaReferenceElement = outputValidator.getRoot();	// all non-empty exits should refer to this element
-		}
-
-		if(!models.isEmpty()) {
-			schema = Json.createObjectBuilder();
-		}
-		addComponentsToTheSchema(schemas, models);
-
-		Map<String, PipeLineExit> pipeLineExits = pipeline.getPipeLineExits();
-		for(String exitPath : pipeLineExits.keySet()) {
-			PipeLineExit ple = pipeLineExits.get(exitPath);
-			int exitCode = ple.getExitCode();
-			if(exitCode == 0) {
-				exitCode = 200;
-			}
-
-			JsonObjectBuilder exit = Json.createObjectBuilder();
-
-			Status status = Status.fromStatusCode(exitCode);
-			exit.add("description", status.getReasonPhrase());
-			if(!ple.isEmptyResult()) {
-				JsonObjectBuilder content = Json.createObjectBuilder();
-				if(StringUtils.isNotEmpty(schemaReferenceElement)){
-					String reference = null;
-					if(StringUtils.isNotEmpty(ple.getResponseRoot()) && outputValidator == null) {
-						reference = ple.getResponseRoot();
-					} else {
-						List<String> references = List.of(schemaReferenceElement.split(","));
-						if(ple.isSuccessExit()) {
-							reference = references.get(0);
-						} else {
-							reference = references.get(references.size()-1);
-						}
-					}
-					// JsonObjectBuilder add method consumes the schema
-					schema.add("schema", Json.createObjectBuilder().add("$ref", XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH+reference));
-					content.add(mimeTypeToString(contentType), schema);
-				}
-				exit.add("content", content);
-			}
-
-			responses.add(""+exitCode, exit);
-		}
-		return responses;
-	}
-
-	private void addComponentsToTheSchema(JsonObjectBuilder schemas, List<XSModel> models) {
-		XmlTypeToJsonSchemaConverter converter = new XmlTypeToJsonSchemaConverter(models, true, XmlTypeToJsonSchemaConverter.SCHEMA_DEFINITION_PATH);
-		JsonObject jsonSchema = converter.getDefinitions();
-		if(jsonSchema != null) {
-			for (Entry<String,JsonValue> entry: jsonSchema.entrySet()) {
-				schemas.add(entry.getKey(), entry.getValue());
-			}
-		}
 	}
 
 	public void clear() {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -107,9 +107,9 @@ public class WebServices extends BusEndpointBase {
 			if(apiConfig == null) {
 				throw new BusException("unable to find Dispatch configuration for uri");
 			}
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, uri);
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, null); // endpoint should be resolved from loadbalancer.url property
 		} else {
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(null); // endpoint should be resolved from loadbalancer.url property
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(null);
 		}
 
 		Map<String, Boolean> config = new HashMap<>();

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -107,9 +107,9 @@ public class WebServices extends BusEndpointBase {
 			if(apiConfig == null) {
 				throw new BusException("unable to find Dispatch configuration for uri");
 			}
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, uri, null);
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(apiConfig, uri);
 		} else {
-			jsonSchema = dispatcher.generateOpenApiJsonSchema(null, null);
+			jsonSchema = dispatcher.generateOpenApiJsonSchema(null); // endpoint should be resolved from loadbalancer.url property
 		}
 
 		Map<String, Boolean> config = new HashMap<>();

--- a/core/src/test/java/org/frankframework/http/openapi/OpenApiTest.java
+++ b/core/src/test/java/org/frankframework/http/openapi/OpenApiTest.java
@@ -1,29 +1,32 @@
-package org.frankframework.http.rest;
+package org.frankframework.http.openapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.http.rest.ApiServiceDispatcher;
 import org.frankframework.parameters.Parameter;
 import org.frankframework.testutil.MatchUtils;
 import org.frankframework.testutil.ParameterBuilder;
 import org.frankframework.testutil.TestFileUtils;
-import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-public class OpenApiTest extends OpenApiTestBase {
+class OpenApiTest extends OpenApiTestBase {
+
+	private final ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
 
 	@Test
 	void simpleEndpointGetTest() throws Exception {
-		String uri="/users";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/users";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri, "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -34,15 +37,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void simpleEndpointPostTest() throws Exception {
-		String uri="/simpleEndpointPostTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/simpleEndpointPostTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -53,15 +55,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testChoiceWithComplexType() throws Exception {
-		String uri="/transaction";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/transaction";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null)
-			.setInputValidator("transaction.xsd", "transaction", null, null)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("transaction.xsd", "transaction", null, null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -72,15 +73,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testChoiceWithSimpleType() throws Exception {
-		String uri="/options";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/options";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null)
-			.setInputValidator("Options.xsd", "Options", null, null)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("Options.xsd", "Options", null, null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -91,15 +91,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testMultipleChoices() throws Exception {
-		String uri="/multipleChoices";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/multipleChoices";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null)
-			.setInputValidator("multipleChoices.xsd", "EmbeddedChoice", null, null)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("multipleChoices.xsd", "EmbeddedChoice", null, null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -110,16 +109,15 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void simpleEndpointPostWithEmptyExitTest() throws Exception {
-		String uri="/simpleEndpointPostWithEmptyExitTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/simpleEndpointPostWithEmptyExitTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500, null, true)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500, null, true)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -130,15 +128,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void simpleEndpointWithOperationIdTest() throws Exception {
-		String uri="/simpleEndpointWithOperationIdTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/simpleEndpointWithOperationIdTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri, "get", "operationId")
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", null)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "get", "operationId")
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -149,22 +146,21 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void simpleEndpointQueryParamTest() throws Exception {
-		String uri="/simpleEndpointQueryParamTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/simpleEndpointQueryParamTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 		Parameter param = ParameterBuilder.create("parameter", "parameter").withSessionKey("parameter");
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri, "get", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "get", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
+				.addExit(200)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri, "post", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "post", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(2, dispatcher.findExactMatchingConfigForUri(uri).getMethods().size(), "more then 2 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -175,76 +171,74 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void pathParamQueryParamTest() throws Exception {
-		String uri="/pathParamQueryParamTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/pathParamQueryParamTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 		Parameter param = ParameterBuilder.create("parameter", "parameter").withSessionKey("parameter");
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri+"/{pattern}", "get", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
-			.addExit(200)
-			.addExit(500)
-			.addExit(403)
-			.build(true);
+				.setListener(uri + "/{pattern}", "get", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
+				.addExit(200)
+				.addExit(500)
+				.addExit(403)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri+"/{pattern}/sub/{path}", "post", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
-			.addExit(200)
-			.addExit(500)
-			.addExit(403)
-			.build(true);
+				.setListener(uri + "/{pattern}/sub/{path}", "post", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
+				.addExit(200)
+				.addExit(500)
+				.addExit(403)
+				.build(true);
 
 		assertEquals(2, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 2 registered pattern found!");
 		String expected = TestFileUtils.getTestFile("/OpenApi/envelopePathParamQueryParam.json");
 
-		String result = callOpenApi(uri+"/{pattern}");
+		String result = callOpenApi(uri + "/{pattern}");
 		MatchUtils.assertJsonEquals(expected, result);
 
-		String encodedResult = callOpenApi(uri+"/%7Bpattern%7D");
+		String encodedResult = callOpenApi(uri + "/%7Bpattern%7D");
 		MatchUtils.assertJsonEquals("Test should pass in escaped form!", expected, encodedResult);
 	}
 
 	@Test
 	void exitElementNamesTest() throws Exception {
-		String uri="/envelope";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/envelope";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 		Parameter param = ParameterBuilder.create("parameter", "parameter").withSessionKey("parameter");
 
 		String responseRoot = "EnvelopeResponse,EnvelopeError403,EnvelopeError500";
 		new AdapterBuilder("myAdapterName", "each exit have specific element name")
-			.setListener(uri, "get", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
-			.addExit(200,"EnvelopeResponse", false)
-			.addExit(500,"EnvelopeError500", false)
-			.addExit(403,"EnvelopeError403", false)
-			.build(true);
+				.setListener(uri, "get", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
+				.addExit(200, "EnvelopeResponse", false)
+				.addExit(500, "EnvelopeError500", false)
+				.addExit(403, "EnvelopeError403", false)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "200 code will retrieve the ref from first of response root")
-			.setListener(uri+"/test", "get", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
-			.addExit(200,null,false)
-			.addExit(500,"EnvelopeError500", false)
-			.addExit(403,"EnvelopeError403", false)
-			.build(true);
+				.setListener(uri + "/test", "get", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
+				.addExit(200, null, false)
+				.addExit(500, "EnvelopeError500", false)
+				.addExit(403, "EnvelopeError403", false)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "no element name responseRoot will be used as source for refs")
-			.setListener(uri+"/elementNames", "get", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
-			.addExit(200)
-			.addExit(500)
-			.addExit(403)
-			.build(true);
+				.setListener(uri + "/elementNames", "get", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
+				.addExit(200)
+				.addExit(500)
+				.addExit(403)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "403 empty exit")
-			.setListener(uri+"/{pattern}/sub/{path}", "post", null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
-			.addExit(200)
-			.addExit(500)
-			.addExit(403, null, true)
-			.build(true);
+				.setListener(uri + "/{pattern}/sub/{path}", "post", null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", responseRoot, param)
+				.addExit(200)
+				.addExit(500)
+				.addExit(403, null, true)
+				.build(true);
 
 		assertEquals(4, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 4 registered pattern found!");
 		String result = callOpenApi(uri);
@@ -255,31 +249,30 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void petStore() throws Exception {
-		String uriBase="/pets";
+		String uriBase = "/pets";
 		//Make sure all adapters have been registered on the dispatcher
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uriBase).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("listPets", "List all pets")
-			.setListener(uriBase, "get", null)
-			.setInputValidator("petstore.xsd", null, "Pets", null)
-			.addExit(200)
-			.addExit(500, "Error", false)
-			.build(true);
+				.setListener(uriBase, "get", null)
+				.setInputValidator("petstore.xsd", null, "Pets", null)
+				.addExit(200)
+				.addExit(500, "Error", false)
+				.build(true);
 
 		new AdapterBuilder("createPets", "Create a pet")
-			.setListener(uriBase, "post", null)
-			.setInputValidator("petstore.xsd", "Pet", "Pet", null)
-			.addExit(201, null, true)
-			.addExit(500, "Error", false)
-			.build(true);
+				.setListener(uriBase, "post", null)
+				.setInputValidator("petstore.xsd", "Pet", "Pet", null)
+				.addExit(201, null, true)
+				.addExit(500, "Error", false)
+				.build(true);
 
 		new AdapterBuilder("showPetById", "Info for a specific pet")
-			.setListener(uriBase+"/{petId}", "get", null)
-			.setInputValidator("petstore.xsd", null, "Pet", null)
-			.addExit(200)
-			.addExit(500, "Error", false)
-			.build(true);
+				.setListener(uriBase + "/{petId}", "get", null)
+				.setInputValidator("petstore.xsd", null, "Pet", null)
+				.addExit(200)
+				.addExit(500, "Error", false)
+				.build(true);
 
 		//getPets.start(getPets, postPet, getPet); //Async start
 
@@ -287,8 +280,8 @@ public class OpenApiTest extends OpenApiTestBase {
 
 		assertNotNull(dispatcher.findExactMatchingConfigForUri(uriBase), "unable to find DispatchConfig for uri [pets]");
 		assertEquals(2, dispatcher.findExactMatchingConfigForUri(uriBase).getMethods().size(), "not all listener uri [pets] are registered on the dispatcher");
-		assertNotNull(dispatcher.findExactMatchingConfigForUri(uriBase+"/a"), "unable to find DispatchConfig for uri [pets/a]");
-		assertEquals(1, dispatcher.findExactMatchingConfigForUri(uriBase+"/a").getMethods().size(), "listener uri [pets/a] not registered on dispatcher");
+		assertNotNull(dispatcher.findExactMatchingConfigForUri(uriBase + "/a"), "unable to find DispatchConfig for uri [pets/a]");
+		assertEquals(1, dispatcher.findExactMatchingConfigForUri(uriBase + "/a").getMethods().size(), "listener uri [pets/a] not registered on dispatcher");
 
 		String result = callOpenApi(uriBase);
 
@@ -298,26 +291,25 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void rootSchemaTest() throws Exception {
-		String uri="/";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"users", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "users", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"test", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "test", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(2, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 2 registered pattern found!");
-		String result = callOpenApi(uri+"users");
+		String result = callOpenApi(uri + "users");
 
 		String expected = TestFileUtils.getTestFile("/OpenApi/simpleRoot.json");
 		MatchUtils.assertJsonEquals(expected, result);
@@ -325,33 +317,32 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testSchemaGenerationWhenWildcardMatchersArePresent() throws Exception {
-		String uri="/";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"**", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "**", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"users", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "users", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"test", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "test", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(2, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 2 registered pattern found!");
-		String result = callOpenApi(uri+"users");
+		String result = callOpenApi(uri + "users");
 
 		String expected = TestFileUtils.getTestFile("/OpenApi/simpleRoot.json");
 		MatchUtils.assertJsonEquals(expected, result);
@@ -359,25 +350,24 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void twoEndpointsOneWithoutValidatorTest() throws Exception {
-		String uri="/path";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/path";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"/validator", "get", null)
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "/validator", "get", null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri+"/noValidator", "get", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri + "/noValidator", "get", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(2, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 2 registered pattern found!");
-		String result = callOpenApi(uri+"/validator");
+		String result = callOpenApi(uri + "/validator");
 
 		String expected = TestFileUtils.getTestFile("/OpenApi/noValidatorForOneEndpoint.json");
 		MatchUtils.assertJsonEquals(expected, result);
@@ -385,20 +375,19 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void parametersFromHeader() throws Exception {
-		String uri="/headerparams";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/headerparams";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "get", null, null)
-			.setHeaderParams("envelopeId, envelopeType")
-			.setInputValidator("simple.xsd", null, "user", null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri, "get", null, null)
+				.setHeaderParams("envelopeId, envelopeType")
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
-		MockHttpServletRequest request = createRequest("GET", uri+"/openapi.json");
+		MockHttpServletRequest request = createRequest("GET", uri + "/openapi.json");
 		request.addHeader("envelopeId", "dummy");
 		request.addHeader("envelopeType", "dummyType");
 
@@ -411,7 +400,6 @@ public class OpenApiTest extends OpenApiTestBase {
 //	@Test
 //	public void parametersFromCookie() throws Exception {
 //		String uri="/cookieparams";
-//		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
 //		assertEquals("there are still registered patterns! Threading issue?", 0, dispatcher.findAllMatchingConfigsForUri(uri).size());
 //
 //		new AdapterBuilder("myAdapterName", "description4simple-get")
@@ -438,7 +426,6 @@ public class OpenApiTest extends OpenApiTestBase {
 //	@Test
 //	public void parametersFromCookieAndHeader() throws Exception {
 //		String uri="/cookieplusheaderparams";
-//		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
 //		assertEquals("there are still registered patterns! Threading issue?", 0, dispatcher.findAllMatchingConfigsForUri(uri).size());
 //
 //		new AdapterBuilder("myAdapterName", "description4simple-get")
@@ -466,20 +453,19 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void validatorParamFromHeaderNotQuery() throws Exception {
-		String uri="/validatorParamFromHeaderNotQuery";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/validatorParamFromHeaderNotQuery";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 		Parameter param = ParameterBuilder.create("parameter", "parameter").withSessionKey("parameter");
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri, "get", null, null)
-			.setHeaderParams("parameter")
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
-			.addExit(200)
-			.build(true);
+				.setListener(uri, "get", null, null)
+				.setHeaderParams("parameter")
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", param)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findExactMatchingConfigForUri(uri).getMethods().size(), "more then 2 registered pattern found!");
-		MockHttpServletRequest request = createRequest("GET", uri+"/openapi.json");
+		MockHttpServletRequest request = createRequest("GET", uri + "/openapi.json");
 		request.addHeader("parameter", "dummy");
 
 		String result = service(request);
@@ -490,20 +476,18 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void messageIdHeaderTest() throws Exception {
-		String uri="/messageIdHeaderTest";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/messageIdHeaderTest";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "get envelope adapter description")
-			.setListener(uri, "get", null, null)
-			.setMessageIdHeader("x-message-id")
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", null)
-			.addExit(200)
-			.build(true);
-
+				.setListener(uri, "get", null, null)
+				.setMessageIdHeader("x-message-id")
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse", null)
+				.addExit(200)
+				.build(true);
 
 		assertEquals(1, dispatcher.findExactMatchingConfigForUri(uri).getMethods().size(), "more then 2 registered pattern found!");
-		MockHttpServletRequest request = createRequest("GET", uri+"/openapi.json");
+		MockHttpServletRequest request = createRequest("GET", uri + "/openapi.json");
 		request.addHeader("x-message-id", "dummy");
 
 		String result = service(request);
@@ -514,22 +498,21 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testHeaderParamIsnotAddedAsQueryParam() throws Exception {
-		String uri="/headerparams";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/headerparams";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 		Parameter p = ParameterBuilder.create("envelopeId", "envelopeType").withSessionKey("headers");
 		p.setXpathExpression("/headers/header[@name='envelopeId']");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "get", null, null)
-			.setHeaderParams("envelopeId, envelopeType")
-			.setInputValidator("simple.xsd", null, "user", p)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri, "get", null, null)
+				.setHeaderParams("envelopeId, envelopeType")
+				.setInputValidator("simple.xsd", null, "user", p)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
-		MockHttpServletRequest request = createRequest("GET", uri+"/openapi.json");
+		MockHttpServletRequest request = createRequest("GET", uri + "/openapi.json");
 		request.addHeader("envelopeId", "dummy");
 		request.addHeader("envelopeType", "dummyType");
 
@@ -541,16 +524,15 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testOutputValidator() throws Exception {
-		String uri="/outputValidator";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/outputValidator";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "get", null, null)
-			.setOutputValidator("simple.xsd", "user")
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri, "get", null, null)
+				.setOutputValidator("simple.xsd", "user")
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 
@@ -561,17 +543,16 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testInputOutputValidator() throws Exception {
-		String uri="/outputValidator";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/outputValidator";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "post", null, null)
-			.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse, EnvelopeError500", null)
-			.setOutputValidator("simple.xsd", "user")
-			.addExit(200)
-			.addExit(500, "EnvelopeError500", false)
-			.build(true);
+				.setListener(uri, "post", null, null)
+				.setInputValidator("envelope.xsd", "EnvelopeRequest", "EnvelopeResponse, EnvelopeError500", null)
+				.setOutputValidator("simple.xsd", "user")
+				.addExit(200)
+				.addExit(500, "EnvelopeError500", false)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 
@@ -582,15 +563,14 @@ public class OpenApiTest extends OpenApiTestBase {
 
 	@Test
 	void testWithoutValidator() throws Exception {
-		String uri="/noValidator";
-		ApiServiceDispatcher dispatcher = ApiServiceDispatcher.getInstance();
+		String uri = "/noValidator";
 		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
 
 		new AdapterBuilder("myAdapterName", "description4simple-get")
-			.setListener(uri, "get", null, null)
-			.addExit(200)
-			.addExit(500)
-			.build(true);
+				.setListener(uri, "get", null, null)
+				.addExit(200)
+				.addExit(500)
+				.build(true);
 
 		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
 


### PR DESCRIPTION
This is NOT a bug. Code is moved to new package and improved unit testing.

Explanation why it is not a bug:

**Situation 1**
http://localhost/iaf-test/api/openapi.json => still works fine in master (8.1-SNAPSHOT) and works in 7.8 & 7.9.

**Situation 2**
http://localhost/iaf-test/iaf/api/webservices/openapi.json?uri=/exception (or other `uri=` examples)
Needs the configured `loadBalancer.url` property, and otherwise it shows an empty array.
Does work as expected in: 7.9.1, 8.0.0, 8.1. 
Previously, in 7.9.0 and lower versions, it always uses the request and always shows a value for the server.  