### PR TITLE
Fix log download & plain view

### DIFF
--- a/console/backend/src/main/java/org/frankframework/management/web/FileViewer.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/FileViewer.java
@@ -44,10 +44,10 @@ public class FileViewer extends FrankApiBase {
 	@Produces({"text/html", "text/plain", "application/xml", "application/zip", "application/octet-stream"})
 	@Relation("logging")
 	@Description("view or download a (log)file")
-	public Response getFileContent(@QueryParam("file") String file, @HeaderParam("Accept") String acceptHeader) {
+	public Response getFileContent(@QueryParam("file") String file, @QueryParam("accept") String acceptParam, @HeaderParam("Accept") String acceptHeader) {
 		RequestMessageBuilder builder = RequestMessageBuilder.create(this, BusTopic.FILE_VIEWER, BusAction.GET);
 		if (StringUtils.isEmpty(acceptHeader)) acceptHeader = "*/*";
-		String acceptType = acceptHeader.split(",")[0];
+		String acceptType = !StringUtils.isEmpty(acceptParam) ? acceptParam : acceptHeader.split(",")[0];
 		String wantedType = MediaType.valueOf(acceptType).getSubtype();
 		builder.addHeader("fileName", file);
 		builder.addHeader("resultType", wantedType);

--- a/console/backend/src/test/java/org/frankframework/management/web/TestFileViewer.java
+++ b/console/backend/src/test/java/org/frankframework/management/web/TestFileViewer.java
@@ -65,10 +65,34 @@ public class TestFileViewer extends FrankApiTestBase<FileViewer> {
 		assertFalse(resultString.contains("<br>"));
 	}
 
+	@Test
+	public void testDownloadFile() throws IOException {
+		URL fileUrl = TestFileViewer.class.getResource("/FileViewer/FileViewer.txt");
+		String filePath = fileUrl.getPath();
+		String fileName = FilenameUtils.getName(filePath);
+
+		doAnswer((i) -> {
+			RequestMessageBuilder inputMessage = i.getArgument(0);
+			inputMessage.addHeader(ResponseMessageBase.STATUS_KEY, 200);
+			inputMessage.setPayload(new FileInputStream(filePath));
+			Message<?> msg = inputMessage.build();
+			MessageHeaders headers = msg.getHeaders();
+			assertEquals("FILE_VIEWER", headers.get("topic"));
+			assertEquals("octet-stream", headers.get("meta-resultType"));
+			return msg;
+		}).when(jaxRsResource).sendSyncMessage(any(RequestMessageBuilder.class));
+
+		String requestUrl = "/file-viewer?file=" + fileName + "&accept=application/octet-stream"; // ignore accept header & use parameter
+		Response response = dispatcher.dispatchRequest(HttpMethod.GET, requestUrl, null, IbisRole.IbisTester, Map.of("Accept", MediaType.TEXT_PLAIN));
+		InputStream result = (InputStream) response.getEntity();
+
+		String resultString = StreamUtil.streamToString(result);
+		assertFalse(resultString.contains("<br>"));
+	}
+
 	private static Message<?> getDefaultAnswer(InvocationOnMock i, String filePath) throws FileNotFoundException {
 		RequestMessageBuilder inputMessage = i.getArgument(0);
 		inputMessage.addHeader(ResponseMessageBase.STATUS_KEY, 200);
-		inputMessage.addHeader(ResponseMessageBase.MIMETYPE_KEY, MediaType.TEXT_HTML);
 		inputMessage.setPayload(new FileInputStream(filePath));
 		Message<?> msg = inputMessage.build();
 		MessageHeaders headers = msg.getHeaders();

--- a/console/backend/src/test/java/org/frankframework/management/web/TestFileViewer.java
+++ b/console/backend/src/test/java/org/frankframework/management/web/TestFileViewer.java
@@ -2,6 +2,7 @@ package org.frankframework.management.web;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -43,6 +44,7 @@ public class TestFileViewer extends FrankApiTestBase<FileViewer> {
 		String requestUrl = "/file-viewer?file=" + fileName;
 		Response response = dispatcher.dispatchRequest(HttpMethod.GET, requestUrl, null, IbisRole.IbisTester, Map.of("Accept", MediaType.TEXT_HTML));
 		StreamingOutput result = (StreamingOutput) response.getEntity();
+		assertNotNull(result);
 
 		ByteArrayOutputStream boas = new ByteArrayOutputStream();
 		result.write(boas);
@@ -60,6 +62,7 @@ public class TestFileViewer extends FrankApiTestBase<FileViewer> {
 		String requestUrl = "/file-viewer?file=" + fileName;
 		Response response = dispatcher.dispatchRequest(HttpMethod.GET, requestUrl, null, IbisRole.IbisTester, Map.of("Accept", MediaType.TEXT_PLAIN));
 		InputStream result = (InputStream) response.getEntity();
+		assertNotNull(result);
 
 		String resultString = StreamUtil.streamToString(result);
 		assertFalse(resultString.contains("<br>"));
@@ -85,6 +88,7 @@ public class TestFileViewer extends FrankApiTestBase<FileViewer> {
 		String requestUrl = "/file-viewer?file=" + fileName + "&accept=application/octet-stream"; // ignore accept header & use parameter
 		Response response = dispatcher.dispatchRequest(HttpMethod.GET, requestUrl, null, IbisRole.IbisTester, Map.of("Accept", MediaType.TEXT_PLAIN));
 		InputStream result = (InputStream) response.getEntity();
+		assertNotNull(result);
 
 		String resultString = StreamUtil.streamToString(result);
 		assertFalse(resultString.contains("<br>"));

--- a/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.html
@@ -1,8 +1,8 @@
-<div
+<pre
   class="viewerContainer"
-  [innerHTML]="fileContents"
+  [innerText]="fileContents"
   [ngClass]="{ error }"
-></div>
+></pre>
 <div *ngIf="loading" class="text-center animated fadeInDown">
   <div>
     <div class="sk-spinner sk-spinner-wave">

--- a/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.scss
@@ -3,11 +3,15 @@
 }
 
 .viewerContainer {
-  padding: 10px;
+  margin: 0;
+  padding: 4px;
+  border: initial;
+  border-radius: initial;
+  overflow: auto;
   font-family: tahoma, verdana, arial, helvetica;
   font-size: 11px;
-  overflow: auto;
   color: #000;
+  white-space: pre-wrap;
 }
 
 .error {

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.html
@@ -103,7 +103,6 @@
         <div *ngIf="viewFile">
           <app-file-viewer
             [fileName]="viewFile"
-            contentType="text/html"
             style="
               width: 100%;
               min-height: 650px;

--- a/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/logging/logging.component.ts
@@ -64,7 +64,8 @@ export class LoggingComponent implements OnInit {
   }
 
   download(file: LoggingFile): void {
-    const url = `${this.appService.absoluteApiPath}file-viewer?file=${this.miscService.escapeURL(file.path)}`;
+    const contentType = 'application/octet-stream'; // always download instead of possibly display in new tab
+    const url = `${this.appService.absoluteApiPath}file-viewer?file=${this.miscService.escapeURL(file.path)}&accept=${contentType}`;
     window.open(url, '_blank');
   }
 


### PR DESCRIPTION
File Viewer now accepts `accept` url parameter which will overwrite `Accept` header to serve the right content-type
Also a fix for how files are displayed within the console (Fixes #6448)