### PR TITLE
Use different defaults for Narayana JMS connection and session pools

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -160,7 +160,7 @@ transactionmanager.narayana.jms.connection.maxPoolSize=10
 # Amount of time a connection can be unused or idle until it can be discarded.
 transactionmanager.narayana.jms.connection.maxIdleTime=60
 # Maximum number of jms sessions per connection that can be created in the connection pool.
-transactionmanager.narayana.jms.connection.maxSessions=80
+transactionmanager.narayana.jms.connection.maxSessions=100
 # When set (in seconds), connections are validated, and either kept or removed from the pool, at this interval.
 transactionmanager.narayana.jms.connection.checkInterval=300
 # Max time to wait (in seconds) for a connection to become available if no connections are available from the pool

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -156,11 +156,11 @@ transactionmanager.btm.journal.maxRetries=500
 
 ## JMS Connection Pool properties for Narayana
 # Maximum number of physical connections that you can create in this pool.
-transactionmanager.narayana.jms.connection.maxPoolSize=5
+transactionmanager.narayana.jms.connection.maxPoolSize=10
 # Amount of time a connection can be unused or idle until it can be discarded.
 transactionmanager.narayana.jms.connection.maxIdleTime=60
 # Maximum number of jms sessions per connection that can be created in the connection pool.
-transactionmanager.narayana.jms.connection.maxSessions=500
+transactionmanager.narayana.jms.connection.maxSessions=80
 # When set (in seconds), connections are validated, and either kept or removed from the pool, at this interval.
 transactionmanager.narayana.jms.connection.checkInterval=300
 # Max time to wait (in seconds) for a connection to become available if no connections are available from the pool


### PR DESCRIPTION
[IBM uses a default of 100 sessions per connection](https://www.ibm.com/docs/en/datapower-gateway/10.0.1?topic=commands-sessions-per-connection).
I've read somewhere that by default Tibco supports up to 250 sessions, so in order to be safe we shouldn't cross this limit.

The article also says the following, but I've yet to decipher what it actually means.
You define 5 total connections and 20 sessions per connection. With three active connections, a new session request generates the establishment of a fourth connection.