### PR TITLE
Fix duplicated messages in exception forwards

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
@@ -493,6 +493,11 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 
 			} catch (Exception e) {
 				throwEvent(PIPE_EXCEPTION_MONITOR_EVENT);
+				PipeForward exceptionForward = findForward(PipeForward.EXCEPTION_FORWARD_NAME);
+				if (exceptionForward != null) {
+					log.warn("exception occured, forwarding to exception-forward ["+exceptionForward.getPath()+"], exception:", e);
+					return new PipeRunResult(exceptionForward, new ErrorMessageFormatter().format(null,e,this,input,session.getMessageId(),0));
+				}
 				throw new PipeRunException(this, "caught exception", e);
 			}
 

--- a/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
@@ -493,11 +493,6 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 
 			} catch (Exception e) {
 				throwEvent(PIPE_EXCEPTION_MONITOR_EVENT);
-				PipeForward exceptionForward = findForward(PipeForward.EXCEPTION_FORWARD_NAME);
-				if (exceptionForward != null) {
-					log.warn("exception occured, forwarding to exception-forward ["+exceptionForward.getPath()+"], exception:", e);
-					return new PipeRunResult(exceptionForward, new ErrorMessageFormatter().format(null,e,this,input,session.getMessageId(),0));
-				}
 				throw new PipeRunException(this, "caught exception", e);
 			}
 

--- a/core/src/main/java/nl/nn/adapterframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/nl/nn/adapterframework/processors/ExceptionHandlingPipeProcessor.java
@@ -18,6 +18,7 @@ package nl.nn.adapterframework.processors;
 import java.util.Date;
 import java.util.Map;
 
+import nl.nn.adapterframework.core.INamedObject;
 import nl.nn.adapterframework.core.IPipe;
 import nl.nn.adapterframework.core.PipeForward;
 import nl.nn.adapterframework.core.PipeLine;
@@ -45,8 +46,16 @@ public class ExceptionHandlingPipeProcessor extends PipeProcessorBase {
 					tsReceivedLong = tsReceivedDate.getTime();
 				}
 
+				Message errorMessage;
 				ErrorMessageFormatter emf = new ErrorMessageFormatter();
-				Message errorMessage = emf.format(e.getMessage(), e.getCause(), pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
+
+				if(e instanceof PipeRunException) {
+					INamedObject location = ((PipeRunException) e).getPipeInError();
+					errorMessage = emf.format(null, e.getCause(), location, message, pipeLineSession.getMessageId(), tsReceivedLong);
+				} else {
+					errorMessage = emf.format(null, e, pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
+				}
+
 				log.info("exception occurred, forwarding to exception-forward [{}], exception:\n", PipeForward.EXCEPTION_FORWARD_NAME, e);
 				return new PipeRunResult(pipe.getForwards().get(PipeForward.EXCEPTION_FORWARD_NAME), errorMessage);
 			}

--- a/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeProcessor.java
+++ b/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeProcessor.java
@@ -59,6 +59,7 @@ public class TransactionAttributePipeProcessor extends PipeProcessorBase {
 		boolean isTxCapable = hasTxCapableSender(pipe);
 		try {
 			if(isTxCapable && itx.isRollbackOnly()) {
+				log.trace("fail-fast exception: may not execute [{}] due to rollback-only state", pipe);
 				throw new PipeRunException(pipe, "unable to execute SQL statement, transaction has been marked as failed by an earlier sender");
 			}
 
@@ -66,11 +67,13 @@ public class TransactionAttributePipeProcessor extends PipeProcessorBase {
 
 		} catch (Error | RuntimeException | PipeRunException ex) {
 			if(isTxCapable) {
+				log.trace("marking pipeline [{}] as rollback-only due to pipe [{}] exception", pipeline, pipe);
 				itx.setRollbackOnly();
 			}
 			throw ex;
 		} catch (Exception e) {
 			if(isTxCapable) {
+				log.trace("marking pipeline [{}] as rollback-only due to pipe [{}] exception", pipeline, pipe);
 				itx.setRollbackOnly();
 			}
 			throw new PipeRunException(pipe, "Caught unknown checked exception", e);

--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -160,14 +160,15 @@
 		scope="prototype"
 		>
 		<property name="pipeProcessor">
+			<!-- allows a managed exception to be stored in the session -->
 			<bean
-				class="nl.nn.adapterframework.processors.ExceptionHandlingPipeProcessor"
+				class="nl.nn.adapterframework.processors.InputOutputPipeProcessor"
 				autowire="byName"
 				scope="prototype"
 				>
 				<property name="pipeProcessor">
 					<bean
-						class="nl.nn.adapterframework.processors.InputOutputPipeProcessor"
+						class="nl.nn.adapterframework.processors.ExceptionHandlingPipeProcessor"
 						autowire="byName"
 						scope="prototype"
 						>

--- a/core/src/test/java/nl/nn/adapterframework/http/HttpResponseMock.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/HttpResponseMock.java
@@ -49,13 +49,21 @@ import nl.nn.adapterframework.http.mime.MultipartEntity;
 
 public class HttpResponseMock extends Mockito implements Answer<HttpResponse> {
 	private String lineSeparator = System.getProperty("line.separator");
+	private final int statusCode;
+
+	public HttpResponseMock() {
+		this(200);
+	}
+	public HttpResponseMock(int statusCode) {
+		this.statusCode = statusCode;
+	}
 
 	private HttpResponse buildResponse(InputStream content) throws UnsupportedOperationException, IOException {
 		CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
 		StatusLine statusLine = mock(StatusLine.class);
 		HttpEntity httpEntity = mock(HttpEntity.class);
 
-		when(statusLine.getStatusCode()).thenReturn(200);
+		when(statusLine.getStatusCode()).thenReturn(statusCode);
 		when(httpResponse.getStatusLine()).thenReturn(statusLine);
 
 		when(httpEntity.getContent()).thenReturn(content);

--- a/test/src/main/configurations/TX/TransactionFailureInDbPipe.xml
+++ b/test/src/main/configurations/TX/TransactionFailureInDbPipe.xml
@@ -23,6 +23,7 @@
 				<exit path="ERROR" state="error"/>
 			</exits>
 
+			<!-- instead 1 record in the database -->
 			<pipe name="fixedInsert" className="nl.nn.adapterframework.pipes.SenderPipe">
 				<sender className="nl.nn.adapterframework.jdbc.FixedQuerySender" query="INSERT INTO IBISPROP (NAME,VALUE) VALUES ('LASTNAME',?)" queryType="insert">
 					<param name="value" value="test1" />
@@ -30,18 +31,21 @@
 				<forward name="success" path="fixedInsert2" />
 			</pipe>
 
+			<!-- attempt to insert 1 record in the database, should give an error because the column doesn't exist, should mark as rollbackOnly -->
 			<pipe name="fixedInsert2" className="nl.nn.adapterframework.pipes.SenderPipe">
 				<sender className="nl.nn.adapterframework.jdbc.FixedQuerySender" query="INSERT INTO IBISPROP (NAMEVALUE1) VALUES ('this-column-does-not-exist')" queryType="insert"/>
 				<forward name="success" path="fail"/>
 				<forward name="exception" path="fixedInsert3"/>
 			</pipe>
 
+			<!-- attempt to insert 1 record in the database, should give an error because the column doesn't exist, should fail but not change the tx status -->
 			<pipe name="fixedInsert3" className="nl.nn.adapterframework.pipes.SenderPipe" transactionAttribute="NotSupported">
 				<sender className="nl.nn.adapterframework.jdbc.FixedQuerySender" query="INSERT INTO IBISPROP (NAMEVALUE2) VALUES ('this-column-does-not-exist')" queryType="insert"/>
 				<forward name="success" path="fail"/>
 				<forward name="exception" path="This PutInSession should throw an exception but not trigger a rollback"/>
 			</pipe>
 
+			<!-- force an SenderException in a non-tx-captable Sender, should fail but not change the tx status -->
 			<pipe name="This PutInSession should throw an exception but not trigger a rollback"
 				className="nl.nn.adapterframework.pipes.PutInSession"
 				getInputFromFixedValue="tralala"
@@ -62,6 +66,7 @@
 				<forward name="success" path="EXIT"/>
 			</pipe>
 
+			<!-- force an SenderException in a tx-captable Sender, sql is correct but should not be allowed to execute due to rollbackOnly -->
 			<pipe name="fixedInsert4" className="nl.nn.adapterframework.pipes.SenderPipe">
 				<sender className="nl.nn.adapterframework.jdbc.FixedQuerySender" query="INSERT INTO IBISPROP (NAME,VALUE) VALUES ('SURNAME',?)" queryType="insert" />
 					<param name="value" value="test2" />

--- a/test/src/test/testtool/ClobAndBlob/scenario07/out.xml
+++ b/test/src/test/testtool/ClobAndBlob/scenario07/out.xml
@@ -1,5 +1,5 @@
-<errorMessage timestamp="Thu Feb 24 12:10:59 CET 2022" originator="IAF_ss9 7.8-SNAPSHOT" message="Adapter [ClobAndBlob] msgId [synthetic-message-id-a9fee1b8-45cd1ffc_18c35bfd289_-7f68]: Pipe [readBlobReadAsIfcompressed] caught exception: [nl.nn.adapterframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check: [nl.nn.adapterframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check">
-	<location class="nl.nn.adapterframework.core.Adapter" name="ClobAndBlob"/>
+<errorMessage timestamp="Thu Feb 24 12:10:59 CET 2022" originator="IAF_ss9 7.8-SNAPSHOT" message="SenderPipe [readBlobReadAsIfcompressed] msgId [IGNORE]: [nl.nn.adapterframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check">
+	<location class="nl.nn.adapterframework.pipes.SenderPipe" name="readBlobReadAsIfcompressed"/>
 	<details>IGNORE</details>
 	<originalMessage messageId="IGNORE" receivedTime="IGNORE">&lt;result/&gt;</originalMessage>
 </errorMessage>

--- a/test/src/test/testtool/Senders/scenario01/out.xml
+++ b/test/src/test/testtool/Senders/scenario01/out.xml
@@ -1,5 +1,5 @@
-<errorMessage timestamp="Mon Dec 04 18:20:24 CET 2023" originator="IAF_ss9 8.0-SNAPSHOT" message="Adapter [SendersExceptionInSenderWithExceptionForward] msgId [synthetic-message-id-a9fee1b8--28ad0d7c_18c35d5dec4_-7f68]: Pipe [Call ExceptionPipe] caught exception: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;">
-  <location class="nl.nn.adapterframework.core.Adapter" name="SendersExceptionInSenderWithExceptionForward"/>
+<errorMessage timestamp="IGNORE" originator="IAFIGNORE" message="SenderPipe [Call ExceptionPipe] msgId [IGNORE]: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;">
+  <location class="nl.nn.adapterframework.pipes.SenderPipe" name="Call ExceptionPipe"/>
   <details>IGNORE</details>
-  <originalMessage messageId="synthetic-message-id-a9fee1b8--28ad0d7c_18c35d5dec4_-7f68" receivedTime="Mon Dec 04 18:20:23 CET 2023">&lt;test/&gt;</originalMessage>
+  <originalMessage messageId="IGNORE" receivedTime="IGNORE">&lt;test/&gt;</originalMessage>
 </errorMessage>

--- a/test/src/test/testtool/UnzipPipeExceptionForwardTest/scenario01/out1.txt
+++ b/test/src/test/testtool/UnzipPipeExceptionForwardTest/scenario01/out1.txt
@@ -1,1 +1,1 @@
-Adapter [UnzipPipe] msgId [0a722fe4--2c744fc_183eb0a3993_-7aa3]: Pipe [unzipFile] cannot unzip: (EOFException) Unexpected end of ZLIB input stream: Unexpected end of ZLIB input stream
+UnzipPipe [unzipFile] msgId [synthetic-message-id-c0a80198--2a0ed479_18e6b5dd16f_-7c04]: Unexpected end of ZLIB input stream


### PR DESCRIPTION
Removed managed sender exceptions in #[5959](https://github.com/frankframework/frankframework/commit/55ef29d986106d278ee35e9596daa1d657c0b7e2#diff-3a1194e08b691760634fad4bc813cda839916b259d49eed0b58bebe3eec1cc26L497) but I have seem to have broken 2 individual problems.

- ErrorMessageFormatters where formatting the exception twice, see [UnzipPipeExceptionForwardTest/scenario01/out1.txt](https://github.com/frankframework/frankframework/pull/6497/files#diff-a7a022f73e74616e49a0109452fe06f5cd28da20fe60aaa8c0b2324ac2921847)
- InputOutputProcessor was no longer working when handling an exception.

This PR fixes the problems, though there are only integration-tests to prove this.
See the tests added in #5959 which remain been unmodified.


Also fixes CMIS exceptions accidently caught by sendMessageOrThrow