### PR TITLE
Always use Maven Central first to find dependencies, secondly a special one

### DIFF
--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -312,6 +312,14 @@
 
 	<repositories>
 		<repository>
+			<id>central</id>
+			<name>Central Repository</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
 			<id>AsposeJavaAPI</id>
 			<name>Aspose Java Repository</name>
 			<url>https://repository.aspose.com/repo/</url>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -118,7 +118,7 @@
 					</snapshots>
 				</repository>
 				<repository>
-					<id>ibissource</id>
+					<id>frankframework</id>
 					<url>https://nexus.frankframework.org/content/groups/public</url>
 				</repository>
 			</repositories>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -110,6 +110,14 @@
 			</activation>
 			<repositories>
 				<repository>
+					<id>central</id>
+					<name>Central Repository</name>
+					<url>https://repo.maven.apache.org/maven2/</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+				<repository>
 					<id>ibissource</id>
 					<url>https://nexus.frankframework.org/content/groups/public</url>
 				</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1252,10 +1252,17 @@
 			</modules>
 			<repositories>
 				<repository>
+					<id>central</id>
+					<name>Central Repository</name>
+					<url>https://repo.maven.apache.org/maven2/</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
+				<repository>
 					<id>proprietary</id>
 					<url>https://nexus.frankframework.org/content/repositories/private/</url>
 					<snapshots>
-						<!-- Prevent Maven from attempting to download non existing /x.y-SNAPSHOT/maven-metadata.xml on this url for every module on every build -->
 						<enabled>false</enabled>
 					</snapshots>
 				</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1114,7 +1114,7 @@
 			</snapshots>
 		</repository>
 		<repository>
-			<id>ibissource</id>
+			<id>frankframework</id>
 			<url>https://nexus.frankframework.org/content/groups/public</url>
 		</repository>
 	</repositories>
@@ -1180,11 +1180,11 @@
 			<id>ibissource</id>
 			<distributionManagement>
 				<repository>
-					<id>ibissource</id>
+					<id>frankframework</id>
 					<url>https://nexus.frankframework.org/content/repositories/releases</url>
 				</repository>
 				<snapshotRepository>
-					<id>ibissource</id>
+					<id>frankframework</id>
 					<url>https://nexus.frankframework.org/content/repositories/snapshots</url>
 				</snapshotRepository>
 				<site>
@@ -1307,7 +1307,7 @@
 			</activation>
 			<pluginRepositories>
 				<pluginRepository>
-					<id>ibissource</id>
+					<id>frankframework</id>
 					<url>https://nexus.frankframework.org/content/groups/public</url>
 					<snapshots>
 						<enabled>true</enabled>


### PR DESCRIPTION
Without this change, it downloads Jackson libraries from our private repo 👎🏻 (in a specific module)
Defining a `<repositories>` entry overwrites the default Maven Central entry, so that one should be added first. It works in the defined order. 