### PR TITLE
Use different defaults for Narayana JMS connection and session pools

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -148,11 +148,11 @@ transactionmanager.btm.journal.maxRetries=500
 
 ## JMS Connection Pool properties for Narayana
 # Maximum number of physical connections that you can create in this pool.
-transactionmanager.narayana.jms.connection.maxPoolSize=5
+transactionmanager.narayana.jms.connection.maxPoolSize=10
 # Amount of time a connection can be unused or idle until it can be discarded.
 transactionmanager.narayana.jms.connection.maxIdleTime=60
 # Maximum number of jms sessions per connection that can be created in the connection pool.
-transactionmanager.narayana.jms.connection.maxSessions=500
+transactionmanager.narayana.jms.connection.maxSessions=100
 # When set (in seconds), connections are validated, and either kept or removed from the pool, at this interval.
 transactionmanager.narayana.jms.connection.checkInterval=300
 # Max time to wait (in seconds) for a connection to become available if no connections are available from the pool


### PR DESCRIPTION
Backport of #6489

(cherry picked from commit cd9470318ccb766c41acd968c11091cd142b38e8) (cherry picked from commit 2520eba417687fbd302e9a7f44543464e0102483)