### PR TITLE
Fix duplicated messages in exception forwards

### DIFF
--- a/cmis/src/test/java/org/frankframework/extensions/cmis/CmisHttpInvokerTest.java
+++ b/cmis/src/test/java/org/frankframework/extensions/cmis/CmisHttpInvokerTest.java
@@ -1,5 +1,9 @@
 package org.frankframework.extensions.cmis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -9,6 +13,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.HashMap;
@@ -40,7 +45,7 @@ public class CmisHttpInvokerTest {
 		when(session.get(eq(SessionParameter.USER_AGENT), anyString())).thenReturn("Mockito mock-agent");
 	}
 
-	private CmisHttpInvoker createInvoker() {
+	private CmisHttpInvoker createInvoker(int statusCode) {
 		return new CmisHttpInvoker() {
 			@Override
 			protected CmisHttpSender createSender() {
@@ -50,7 +55,7 @@ public class CmisHttpInvokerTest {
 					CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
 
 					//Mock all requests
-					when(httpClient.execute(any(HttpHost.class), any(HttpRequestBase.class), any(HttpContext.class))).thenAnswer(new HttpResponseMock());
+					when(httpClient.execute(any(HttpHost.class), any(HttpRequestBase.class), any(HttpContext.class))).thenAnswer(new HttpResponseMock(statusCode));
 					when(sender.getHttpClient()).thenReturn(httpClient);
 
 					return sender;
@@ -75,8 +80,10 @@ public class CmisHttpInvokerTest {
 		};
 	}
 
-	private void assertResponse(String string, Response response) throws IOException {
-		String result = StreamUtil.streamToString(response.getStream());
+	private void assertResponse(String string, InputStream response) throws IOException {
+		assertResponse(string, StreamUtil.streamToString(response));
+	}
+	private void assertResponse(String string, String result) throws IOException {
 		String expected = TestFileUtils.getTestFile(string);
 		assertNotNull("cannot find test file", expected);
 
@@ -85,26 +92,32 @@ public class CmisHttpInvokerTest {
 
 	@Test
 	public void testGet() throws Exception {
-		CmisHttpInvoker invoker = createInvoker();
+		CmisHttpInvoker invoker = createInvoker(200);
 		UrlBuilder url = new UrlBuilder("https://dummy.url.com");
 		Response response = invoker.invokeGET(url, session);
 
-		assertResponse("/HttpInvokerResponse/simpleGet.txt", response);
+		assertNull(response.getErrorContent());
+		assertNotNull(response.getStream());
+		assertEquals(200, response.getResponseCode());
+		assertResponse("/HttpInvokerResponse/simpleGet.txt", response.getStream());
 	}
 
 	@Test
 	public void testPost() throws Exception {
-		CmisHttpInvoker invoker = createInvoker();
+		CmisHttpInvoker invoker = createInvoker(200);
 		UrlBuilder url = new UrlBuilder("https://dummy.url.com");
 		Output writer = createOutputFromFile("/HttpInvokerRequest/postMessage.txt");
 		Response response = invoker.invokePOST(url, "text/plain", writer, session);
 
-		assertResponse("/HttpInvokerResponse/simplePost.txt", response);
+		assertNull(response.getErrorContent());
+		assertNotNull(response.getStream());
+		assertEquals(200, response.getResponseCode());
+		assertResponse("/HttpInvokerResponse/simplePost.txt", response.getStream());
 	}
 
 	@Test
 	public void testPut() throws Exception {
-		CmisHttpInvoker invoker = createInvoker();
+		CmisHttpInvoker invoker = createInvoker(200);
 		UrlBuilder url = new UrlBuilder("https://dummy.url.com");
 		Output writer = createOutputFromFile("/HttpInvokerRequest/putMessage.txt");
 		Map<String, String> headers = new HashMap<>();
@@ -112,15 +125,33 @@ public class CmisHttpInvokerTest {
 
 		Response response = invoker.invokePUT(url, "text/plain", headers, writer, session);
 
-		assertResponse("/HttpInvokerResponse/simplePut.txt", response);
+		assertNull(response.getErrorContent());
+		assertNotNull(response.getStream());
+		assertEquals(200, response.getResponseCode());
+		assertResponse("/HttpInvokerResponse/simplePut.txt", response.getStream());
 	}
 
 	@Test
 	public void testDelete() throws Exception {
-		CmisHttpInvoker invoker = createInvoker();
+		CmisHttpInvoker invoker = createInvoker(200);
 		UrlBuilder url = new UrlBuilder("https://dummy.url.com");
 		Response response = invoker.invokeDELETE(url, session);
 
-		assertResponse("/HttpInvokerResponse/simpleDelete.txt", response);
+		assertNull(response.getErrorContent());
+		assertNotNull(response.getStream());
+		assertEquals(200, response.getResponseCode());
+		assertResponse("/HttpInvokerResponse/simpleDelete.txt", response.getStream());
+	}
+
+	@Test
+	public void testException() throws Exception {
+		CmisHttpInvoker invoker = createInvoker(400);
+		UrlBuilder url = new UrlBuilder("https://dummy.url.com");
+		Response response = invoker.invokeGET(url, session);
+		assertNotNull(response.getErrorContent());
+		assertNull(response.getStream());
+		assertEquals(400, response.getResponseCode());
+		assertTrue(response.getErrorContent().contains("HOST dummy.url.com"));
+		assertResponse("/HttpInvokerResponse/simpleGet.txt", response.getErrorContent());
 	}
 }

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -18,6 +18,7 @@ package org.frankframework.processors;
 import java.time.Instant;
 import java.util.Map;
 
+import org.frankframework.core.INamedObject;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeLine;
@@ -45,8 +46,16 @@ public class ExceptionHandlingPipeProcessor extends PipeProcessorBase {
 					tsReceivedLong = tsReceivedDate.toEpochMilli();
 				}
 
+				final Message errorMessage;
 				ErrorMessageFormatter emf = new ErrorMessageFormatter();
-				Message errorMessage = emf.format(e.getMessage(), e.getCause(), pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
+
+				if(e instanceof PipeRunException) {
+					INamedObject location = ((PipeRunException) e).getPipeInError();
+					errorMessage = emf.format(null, e.getCause(), location, message, pipeLineSession.getMessageId(), tsReceivedLong);
+				} else {
+					errorMessage = emf.format(null, e, pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
+				}
+
 				log.info("exception occured, forwarding to exception-forward [{}], exception:\n", PipeForward.EXCEPTION_FORWARD_NAME, e);
 				return new PipeRunResult(pipe.getForwards().get(PipeForward.EXCEPTION_FORWARD_NAME), errorMessage);
 			}

--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -154,14 +154,15 @@
 		scope="prototype"
 		>
 		<property name="pipeProcessor">
+			<!-- allows a managed exception to be stored in the session -->
 			<bean
-				class="org.frankframework.processors.ExceptionHandlingPipeProcessor"
+				class="org.frankframework.processors.InputOutputPipeProcessor"
 				autowire="byName"
 				scope="prototype"
 				>
 				<property name="pipeProcessor">
 					<bean
-						class="org.frankframework.processors.InputOutputPipeProcessor"
+						class="org.frankframework.processors.ExceptionHandlingPipeProcessor"
 						autowire="byName"
 						scope="prototype"
 						>

--- a/core/src/test/java/org/frankframework/http/HttpResponseMock.java
+++ b/core/src/test/java/org/frankframework/http/HttpResponseMock.java
@@ -48,14 +48,23 @@ import org.mockito.stubbing.Answer;
 import lombok.Getter;
 
 public class HttpResponseMock extends Mockito implements Answer<HttpResponse> {
+
 	private final String lineSeparator = System.getProperty("line.separator");
+	private final int statusCode;
+
+	public HttpResponseMock() {
+		this(200);
+	}
+	public HttpResponseMock(int statusCode) {
+		this.statusCode = statusCode;
+	}
 
 	private HttpResponse buildResponse(InputStream content) throws UnsupportedOperationException, IOException {
 		CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
 		StatusLine statusLine = mock(StatusLine.class);
 		HttpEntity httpEntity = mock(HttpEntity.class);
 
-		when(statusLine.getStatusCode()).thenReturn(200);
+		when(statusLine.getStatusCode()).thenReturn(statusCode);
 		when(httpResponse.getStatusLine()).thenReturn(statusLine);
 
 		when(httpEntity.getContent()).thenReturn(content);

--- a/test/src/test/testtool/ClobAndBlob/scenario07/out.xml
+++ b/test/src/test/testtool/ClobAndBlob/scenario07/out.xml
@@ -1,5 +1,5 @@
-<errorMessage timestamp="Thu Feb 24 12:10:59 CET 2022" originator="IAF_ss9 7.8-SNAPSHOT" message="Adapter [ClobAndBlob] msgId [synthetic-message-id-a9fee1b8-45cd1ffc_18c35bfd289_-7f68]: Pipe [readBlobReadAsIfcompressed] caught exception: [org.frankframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check: [org.frankframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check">
-	<location class="org.frankframework.core.Adapter" name="ClobAndBlob"/>
+<errorMessage timestamp="IGNORE" originator="IAFIGNORE" message="SenderPipe [readBlobReadAsIfcompressed] msgId [IGNORE]: [org.frankframework.jdbc.FixedQuerySender] [readBlobReadAsIfcompressed-sender] got exception executing a SELECT SQL command: (ZipException) incorrect header check">
+	<location class="org.frankframework.pipes.SenderPipe" name="readBlobReadAsIfcompressed"/>
 	<details>IGNORE</details>
 	<originalMessage messageId="IGNORE" receivedTime="IGNORE">&lt;result/&gt;</originalMessage>
 </errorMessage>

--- a/test/src/test/testtool/Senders/scenario01/out.xml
+++ b/test/src/test/testtool/Senders/scenario01/out.xml
@@ -1,5 +1,5 @@
-<errorMessage timestamp="Mon Dec 04 18:20:24 CET 2023" originator="IAF_ss9 8.0-SNAPSHOT" message="Adapter [SendersExceptionInSenderWithExceptionForward] msgId [synthetic-message-id-a9fee1b8--28ad0d7c_18c35d5dec4_-7f68]: Pipe [Call ExceptionPipe] caught exception: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;">
-  <location class="org.frankframework.core.Adapter" name="SendersExceptionInSenderWithExceptionForward"/>
-  <details>IGNORE</details>
-  <originalMessage messageId="synthetic-message-id-a9fee1b8--28ad0d7c_18c35d5dec4_-7f68" receivedTime="Mon Dec 04 18:20:23 CET 2023">&lt;test/&gt;</originalMessage>
+<errorMessage timestamp="IGNORE" originator="IAFIGNORE" message="SenderPipe [Call ExceptionPipe] msgId [IGNORE]: IbisLocalSender [Call ExceptionPipe-sender] exception calling JavaListener [ExceptionPipe]: Pipe [Generate exception] &lt;test/&gt;">
+	<location class="org.frankframework.pipes.SenderPipe" name="Call ExceptionPipe"/>
+	<details>IGNORE</details>
+	<originalMessage messageId="IGNORE" receivedTime="IGNORE">&lt;test/&gt;</originalMessage>
 </errorMessage>

--- a/test/src/test/testtool/UnzipPipeExceptionForwardTest/scenario01/out1.txt
+++ b/test/src/test/testtool/UnzipPipeExceptionForwardTest/scenario01/out1.txt
@@ -1,1 +1,1 @@
-Adapter [UnzipPipe] msgId [0a722fe4--2c744fc_183eb0a3993_-7aa3]: Pipe [unzipFile] cannot unzip: (EOFException) Unexpected end of ZLIB input stream: Unexpected end of ZLIB input stream
+UnzipPipe [unzipFile] msgId [synthetic-message-id-c0a80198--4d3d00bd_18e6bcf8d17_-7bfc]: Unexpected end of ZLIB input stream


### PR DESCRIPTION
Removed managed sender exceptions in #[5959](https://github.com/frankframework/frankframework/commit/55ef29d986106d278ee35e9596daa1d657c0b7e2#diff-3a1194e08b691760634fad4bc813cda839916b259d49eed0b58bebe3eec1cc26L497) but I have seem to have broken 2 individual problems.

- ErrorMessageFormatters where formatting the exception twice, see [UnzipPipeExceptionForwardTest/scenario01/out1.txt](https://github.com/frankframework/frankframework/pull/6497/files#diff-a7a022f73e74616e49a0109452fe06f5cd28da20fe60aaa8c0b2324ac2921847)
- InputOutputProcessor was no longer working when handling an exception.

This PR fixes the problems, though there are only integration-tests to prove this.
See the tests added in #5959 which remain been unmodified.


Also fixes CMIS exceptions accidently caught by sendMessageOrThrow