### PR TITLE
Show toast on adapter reload

### DIFF
--- a/console/frontend/src/main/frontend/src/app/app.component.ts
+++ b/console/frontend/src/main/frontend/src/app/app.component.ts
@@ -581,10 +581,7 @@ export class AppComponent implements OnInit, OnDestroy {
   hasAdapterReloaded(adapter: Adapter): boolean {
     const oldAdapter =
       this.appService.adapters[`${adapter.configuration}/${adapter.name}`];
-    if (adapter.upSince > oldAdapter?.upSince) {
-      return true;
-    }
-    return false;
+    return adapter.upSince > oldAdapter?.upSince;
   }
 
   openInfoModel(): void {

--- a/console/frontend/src/main/frontend/src/app/services/poller.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/poller.service.ts
@@ -164,7 +164,10 @@ class PollerObject {
   }
 
   stop(): void {
-    if (!this.started()) return;
+    if (!this.started()) {
+      this.waiting = true;
+      return;
+    }
 
     this.ai.list = [];
     this.ai.avg = 0;

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.html
@@ -91,6 +91,11 @@
               >STUBBED</span
             >
             <span
+              *ngIf="isConfigAutoReloadable[selectedConfiguration]"
+              class="label label-warning"
+              >AUTORELOADABLE</span
+            >
+            <span
               *ngIf="isConfigReloading[selectedConfiguration]"
               class="label label-warning"
               >RELOADING</span

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -279,8 +279,10 @@ export class StatusComponent implements OnInit, OnDestroy {
         }
         if (ready) {
           //Remove poller once all states are STARTED
-          this.Poller.remove('server/configurations');
-          if (callback != null && typeof callback == 'function') callback();
+          window.setTimeout(() => {
+            this.Poller.remove('server/configurations');
+            if (callback != null && typeof callback == 'function') callback();
+          });
         }
       },
       true,

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -41,6 +41,7 @@ export class StatusComponent implements OnInit, OnDestroy {
   configurationFlowDiagram: string | null = null;
   isConfigStubbed: Record<string, boolean> = {};
   isConfigReloading: Record<string, boolean> = {};
+  isConfigAutoReloadable: Record<string, boolean> = {};
   msgBoxExpanded = false;
   adapterShowContent: Record<keyof typeof this.adapters, boolean> = {};
   loadFlowInline = true;
@@ -302,6 +303,7 @@ export class StatusComponent implements OnInit, OnDestroy {
     for (const index in this.appService.configurations) {
       const config = this.appService.configurations[index];
       this.isConfigStubbed[config.name] = config.stubbed;
+      this.isConfigAutoReloadable[config.name] = config.autoreload ?? false;
       this.isConfigReloading[config.name] =
         config.state == 'STARTING' || config.state == 'STOPPING'; //Assume reloading when in state STARTING (LOADING) or in state STOPPING (UNLOADING)
     }


### PR DESCRIPTION
Shows a toast when the `upSince` of one or multiple adapters have changed
<img width="277" alt="image" src="https://github.com/frankframework/frankframework/assets/4380412/8c693d48-978a-4d77-9b23-4cec75aadaa4">

Also a fix for manual config reload where poller in `startPollingForConfigurationStateChanges` didn't stop 