### PR TITLE
Make iaf-test (Spring) bootable

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -33,7 +33,6 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>${log4j2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/console/war/pom.xml
+++ b/console/war/pom.xml
@@ -107,7 +107,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>2.7.18</version>
 				<configuration>
-					<mainClass>org.frankframework.runner.StandaloneInitializer</mainClass>
+					<mainClass>org.frankframework.runner.ConsoleStandaloneInitializer</mainClass>
 					<layout>WAR</layout>
 				</configuration>
 				<executions>

--- a/console/war/src/main/java/org/frankframework/runner/ConsoleStandaloneInitializer.java
+++ b/console/war/src/main/java/org/frankframework/runner/ConsoleStandaloneInitializer.java
@@ -26,7 +26,7 @@ import org.springframework.boot.WebApplicationType;
  *
  * @author Niels Meijer
  */
-public class StandaloneInitializer {
+public class ConsoleStandaloneInitializer {
 
 	// Should start a XmlServletWebServerApplicationContext.
 	public static void main(String[] args) {

--- a/console/war/src/main/java/org/frankframework/runner/ConsoleWarInitializer.java
+++ b/console/war/src/main/java/org/frankframework/runner/ConsoleWarInitializer.java
@@ -29,7 +29,7 @@ import org.springframework.web.context.WebApplicationContext;
  *
  * @author Niels Meijer
  */
-public class WarInitializer extends SpringBootServletInitializer {
+public class ConsoleWarInitializer extends SpringBootServletInitializer {
 
 	@Configuration
 	public static class WarConfiguration {

--- a/core/src/main/java/org/frankframework/lifecycle/ApplicationServerConfigurer.java
+++ b/core/src/main/java/org/frankframework/lifecycle/ApplicationServerConfigurer.java
@@ -1,0 +1,77 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.lifecycle;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.cxf.jaxws.EndpointImpl;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.WebApplicationInitializer;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Programmatically load the Frank!Framework Web Environment.
+ * It's important this is loaded first, and before any programmatic listeners have been added.
+ * The EnvironmentContext will load servlets and filters.
+ *
+ * Uses the same order as well as delegation as the SpringBootServletInitializer used in the Frank!Console WAR.
+ *
+ * @author Niels Meijer
+ */
+@Log4j2
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ApplicationServerConfigurer implements WebApplicationInitializer {
+	private static final Logger APPLICATION_LOG = LogManager.getLogger("APPLICATION");
+
+	//Statics are defined here before independent of AppConstants, so that class does not need to be loaded yet.
+	public static final String APPLICATION_SERVER_TYPE_PROPERTY = "application.server.type";
+	public static final String APPLICATION_SERVER_CUSTOMIZATION_PROPERTY = "application.server.type.custom";
+
+	@Override
+	public void onStartup(ServletContext servletContext) throws ServletException {
+		System.setProperty(EndpointImpl.CHECK_PUBLISH_ENDPOINT_PERMISSON_PROPERTY_WITH_SECURITY_MANAGER, "false");
+
+		String serverInfo = servletContext.getServerInfo();
+		String autoDeterminedApplicationServerType = null;
+		if (StringUtils.containsIgnoreCase(serverInfo, "Tomcat")) {
+			autoDeterminedApplicationServerType = "TOMCAT";
+		} else if (StringUtils.containsIgnoreCase(serverInfo, "JBoss")) {
+			autoDeterminedApplicationServerType = "JBOSS";
+		} else if (StringUtils.containsIgnoreCase(serverInfo, "WildFly")) {
+			autoDeterminedApplicationServerType = "JBOSS";
+		} else {
+			autoDeterminedApplicationServerType = "TOMCAT";
+			APPLICATION_LOG.warn("Unknown server info [{}] default application server type could not be determined, TOMCAT will be used as default value", serverInfo);
+		}
+
+		//has it explicitly been set? if not, set the property
+		String serverType = System.getProperty(APPLICATION_SERVER_TYPE_PROPERTY);
+		String serverCustomization = System.getProperty(APPLICATION_SERVER_CUSTOMIZATION_PROPERTY,"");
+		if (autoDeterminedApplicationServerType.equals(serverType)) { //and is it the same as the automatically detected version?
+			log.info("property [{}] already has a default value [{}]", APPLICATION_SERVER_TYPE_PROPERTY, autoDeterminedApplicationServerType);
+		}
+		else if (StringUtils.isEmpty(serverType)) { //or has it not been set?
+			APPLICATION_LOG.info("Determined ApplicationServer [{}]{}", autoDeterminedApplicationServerType, (StringUtils.isNotEmpty(serverCustomization) ? " customization ["+serverCustomization+"]":""));
+			System.setProperty(APPLICATION_SERVER_TYPE_PROPERTY, autoDeterminedApplicationServerType);
+		}
+	}
+}

--- a/core/src/main/java/org/frankframework/lifecycle/FrankApplicationInitializer.java
+++ b/core/src/main/java/org/frankframework/lifecycle/FrankApplicationInitializer.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2023-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,6 +21,10 @@ import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
 import org.apache.logging.log4j.Logger;
+import org.frankframework.configuration.IbisContext;
+import org.frankframework.util.AppConstants;
+import org.frankframework.util.ClassUtils;
+import org.frankframework.util.LogUtil;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -28,11 +32,6 @@ import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import lombok.extern.log4j.Log4j2;
-import org.frankframework.configuration.IbisContext;
-import org.frankframework.util.AppConstants;
-import org.frankframework.util.ClassUtils;
-import org.frankframework.util.LogUtil;
-import org.frankframework.util.Misc;
 
 /**
  * Spring WebApplicationInitializer that should start after the {@link FrankEnvironmentInitializer} has been configured.
@@ -60,12 +59,6 @@ public class FrankApplicationInitializer implements WebApplicationInitializer {
 			appConstants.put("webapp.realpath", realPath);
 		} else {
 			log.warn("Could not determine webapp.realpath");
-		}
-		String projectBaseDir = Misc.getProjectBaseDir();
-		if (projectBaseDir != null) {
-			appConstants.put("project.basedir", projectBaseDir);
-		} else {
-			log.info("Could not determine project.basedir");
 		}
 
 		ApplicationContext parentContext = null;

--- a/core/src/main/java/org/frankframework/lifecycle/ServletManager.java
+++ b/core/src/main/java/org/frankframework/lifecycle/ServletManager.java
@@ -38,9 +38,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
+import org.springframework.web.context.ServletContextAware;
 
 import lombok.Setter;
 import org.frankframework.lifecycle.servlets.AuthenticationType;
@@ -81,10 +84,10 @@ import org.frankframework.util.StringUtil;
  * @author Niels Meijer
  *
  */
-public class ServletManager implements ApplicationContextAware, InitializingBean {
+public class ServletManager implements ApplicationContextAware, InitializingBean, ServletContextAware {
 
 	private ServletContext servletContext = null;
-	private final List<String> registeredRoles = new ArrayList<>();
+	private final List<String> registeredRoles = new ArrayList<>(ServletAuthenticatorBase.DEFAULT_IBIS_ROLES); //Add the default IBIS roles
 	private final Logger log = LogUtil.getLogger(this);
 	private final Map<String, ServletConfiguration> servlets = new HashMap<>();
 	private final Map<String, IAuthenticator> authenticators = new HashMap<>();
@@ -99,15 +102,19 @@ public class ServletManager implements ApplicationContextAware, InitializingBean
 		return Collections.unmodifiableList(registeredRoles);
 	}
 
-	public ServletManager(ServletContext servletContext) {
+	@Override
+	@Autowired
+	@Lazy
+	public void setServletContext(ServletContext servletContext) {
 		this.servletContext = servletContext;
-
-		//Add the default IBIS roles
-		registeredRoles.addAll(ServletAuthenticatorBase.DEFAULT_IBIS_ROLES);
 	}
 
 	@Override // After initialization but before other servlets are wired
 	public void afterPropertiesSet() throws Exception {
+		if(servletContext == null) {
+			throw new IllegalStateException("not ServletContext configured");
+		}
+
 		Environment env = applicationContext.getEnvironment();
 		SecuritySettings.setupDefaultSecuritySettings(env);
 		allowUnsecureOptionsRequest = env.getProperty(ServletAuthenticatorBase.ALLOW_OPTIONS_REQUESTS_KEY, boolean.class, false);

--- a/core/src/main/java/org/frankframework/lifecycle/ServletManager.java
+++ b/core/src/main/java/org/frankframework/lifecycle/ServletManager.java
@@ -102,6 +102,10 @@ public class ServletManager implements ApplicationContextAware, InitializingBean
 		return Collections.unmodifiableList(registeredRoles);
 	}
 
+	/*
+	 * Maybe a bit overkill to use ServletContextAware and Autowired but this ensures that the 
+	 * ServletContext is always set, when running traditional WAR as well as via Spring Boot.
+	 */
 	@Override
 	@Autowired
 	@Lazy

--- a/core/src/main/java/org/frankframework/lifecycle/servlets/ApplicationServerConfigurer.java
+++ b/core/src/main/java/org/frankframework/lifecycle/servlets/ApplicationServerConfigurer.java
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package org.frankframework.lifecycle;
+package org.frankframework.lifecycle.servlets;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -29,11 +29,8 @@ import org.springframework.web.WebApplicationInitializer;
 import lombok.extern.log4j.Log4j2;
 
 /**
- * Programmatically load the Frank!Framework Web Environment.
- * It's important this is loaded first, and before any programmatic listeners have been added.
- * The EnvironmentContext will load servlets and filters.
- *
- * Uses the same order as well as delegation as the SpringBootServletInitializer used in the Frank!Console WAR.
+ * It's important this is loaded first, and before any programmatic listeners have been added to determine the Application Server type.
+ * We should technically use different profiles for this, but for now, it overwites the default Spring Context
  *
  * @author Niels Meijer
  */

--- a/core/src/main/java/org/frankframework/lifecycle/servlets/HttpSecurityConfigurer.java
+++ b/core/src/main/java/org/frankframework/lifecycle/servlets/HttpSecurityConfigurer.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,13 +15,11 @@
 */
 package org.frankframework.lifecycle.servlets;
 
-import java.util.EnumSet;
 import java.util.Map;
 
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration.Dynamic;
 import javax.servlet.ServletContext;
 
+import org.frankframework.lifecycle.ServletManager;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,11 +32,9 @@ import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.filter.DelegatingFilterProxy;
 
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
-import org.frankframework.lifecycle.ServletManager;
 
 @Log4j2
 @Order(Ordered.LOWEST_PRECEDENCE)
@@ -60,11 +56,6 @@ public class HttpSecurityConfigurer implements WebSecurityConfigurer<WebSecurity
 		if(!(beanFactory instanceof ConfigurableListableBeanFactory)) {
 			throw new IllegalStateException("beanFactory not set or not instanceof ConfigurableListableBeanFactory");
 		}
-
-		// Add the SpringSecurity filter to enable authentication
-		Dynamic filter = servletContext.addFilter("springSecurityFilterChain", DelegatingFilterProxy.class);
-		filter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
-		servletContext.log("registered SpringSecurityFilter");
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/lifecycle/servlets/SecurityFilterChainConfigurer.java
+++ b/core/src/main/java/org/frankframework/lifecycle/servlets/SecurityFilterChainConfigurer.java
@@ -1,0 +1,45 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.lifecycle.servlets;
+
+import java.util.EnumSet;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration.Dynamic;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.WebApplicationInitializer;
+import org.springframework.web.filter.DelegatingFilterProxy;
+
+/**
+ * Add the SpringSecurity filter to enable authentication.
+ * Has a high precedence so it's loaded before the EnvironmentInitializer starts.
+ * 
+ * @author Niels Meijer
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SecurityFilterChainConfigurer implements WebApplicationInitializer {
+
+	@Override
+	public void onStartup(ServletContext servletContext) throws ServletException {
+		Dynamic filter = servletContext.addFilter("springSecurityFilterChain", DelegatingFilterProxy.class);
+		filter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
+		servletContext.log("registered SpringSecurityFilter");
+	}
+}

--- a/core/src/main/java/org/frankframework/util/AppConstants.java
+++ b/core/src/main/java/org/frankframework/util/AppConstants.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.lifecycle.ApplicationServerConfigurer;
 
 /**
  * Singleton class that has the constant values for this application. <br/>
@@ -43,8 +44,8 @@ public final class AppConstants extends PropertyLoader {
 
 	private static final String APP_CONSTANTS_PROPERTIES_FILE = "AppConstants.properties";
 	private static final String ADDITIONAL_PROPERTIES_FILE_KEY = "ADDITIONAL.PROPERTIES.FILE";
-	public static final String APPLICATION_SERVER_TYPE_PROPERTY = "application.server.type";
-	public static final String APPLICATION_SERVER_CUSTOMIZATION_PROPERTY = "application.server.type.custom";
+	public static final String APPLICATION_SERVER_TYPE_PROPERTY = ApplicationServerConfigurer.APPLICATION_SERVER_TYPE_PROPERTY;
+	public static final String APPLICATION_SERVER_CUSTOMIZATION_PROPERTY = ApplicationServerConfigurer.APPLICATION_SERVER_CUSTOMIZATION_PROPERTY;
 	public static final String ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY = ADDITIONAL_PROPERTIES_FILE_KEY+".SUFFIX";
 
 	private static final Properties additionalProperties = new Properties();

--- a/core/src/main/java/org/frankframework/util/AppConstants.java
+++ b/core/src/main/java/org/frankframework/util/AppConstants.java
@@ -26,7 +26,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.frankframework.lifecycle.ApplicationServerConfigurer;
+import org.frankframework.lifecycle.servlets.ApplicationServerConfigurer;
 
 /**
  * Singleton class that has the constant values for this application. <br/>

--- a/core/src/main/java/org/frankframework/util/Misc.java
+++ b/core/src/main/java/org/frankframework/util/Misc.java
@@ -34,17 +34,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.Logger;
+import org.frankframework.core.IMessageBrowser.HideMethod;
+import org.xml.sax.InputSource;
+
 import jakarta.json.Json;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonStructure;
 import jakarta.json.JsonWriter;
 import jakarta.json.JsonWriterFactory;
 import jakarta.json.stream.JsonGenerator;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-import org.apache.logging.log4j.Logger;
-import org.frankframework.core.IMessageBrowser.HideMethod;
-import org.xml.sax.InputSource;
 
 
 /**
@@ -346,24 +347,6 @@ public class Misc {
 			log.warn("unable to parse build-output-directory using charset [{}]", StreamUtil.DEFAULT_INPUT_STREAM_ENCODING, e);
 			return null;
 		}
-	}
-
-	public static String getProjectBaseDir() {
-		String buildOutputDirectory = getBuildOutputDirectory();
-		if (buildOutputDirectory != null) {
-			// classic java project: {project.basedir}/WebContent/WEB-INF/classes
-			// maven project: {project.basedir}/target/classes
-			File dir = new File(buildOutputDirectory);
-			while (dir != null) {
-				String name = dir.getName();
-				if ("WebContent".equalsIgnoreCase(name)
-						|| "target".equalsIgnoreCase(name)) {
-					return dir.getParent();
-				}
-				dir = dir.getParentFile();
-			}
-		}
-		return null;
 	}
 
 	public static <T> void addToSortedListUnique(List<T> list, T item) {

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerTest.java
@@ -230,7 +230,7 @@ public class ApiListenerTest {
 
 	@Test
 	public void testGetPhysicalDestinationNameWith1Endpoint() throws Exception {
-		ServletManager manager = spy(new ServletManager(null));
+		ServletManager manager = spy(new ServletManager());
 		Servlet servlet = mock(Servlet.class);
 		when(servlet.getName()).thenReturn(ApiListenerServlet.class.getSimpleName());
 		when(servlet.getUrlMapping()).thenReturn("aapje/*");
@@ -248,7 +248,7 @@ public class ApiListenerTest {
 
 	@Test
 	public void testGetPhysicalDestinationNameWith2Endpoints() throws Exception {
-		ServletManager manager = spy(new ServletManager(null));
+		ServletManager manager = spy(new ServletManager());
 		Servlet servlet = mock(Servlet.class);
 		when(servlet.getName()).thenReturn(ApiListenerServlet.class.getSimpleName());
 		when(servlet.getUrlMapping()).thenReturn("aap/*,/noot/*");

--- a/core/src/test/java/org/frankframework/lifecycle/ServletManagerTest.java
+++ b/core/src/test/java/org/frankframework/lifecycle/ServletManagerTest.java
@@ -59,7 +59,8 @@ public class ServletManagerTest {
 				return dynamic.get(servletName);
 			}
 		};
-		manager = new ServletManager(context);
+		manager = new ServletManager();
+		manager.setServletContext(context);
 
 		ApplicationContext applicationContext = mock(ApplicationContext.class);
 		MockEnvironment environment = new MockEnvironment();

--- a/core/src/test/java/org/frankframework/testutil/mock/ServletManagerMock.java
+++ b/core/src/test/java/org/frankframework/testutil/mock/ServletManagerMock.java
@@ -5,7 +5,7 @@ import org.frankframework.lifecycle.ServletManager;
 public class ServletManagerMock extends ServletManager {
 
 	public ServletManagerMock() {
-		super(null);
+		super();
 	}
 
 	@Override

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -103,7 +103,7 @@
 
 	<profiles>
 		<profile>
-			<id>ibissource</id>
+			<id>frankframework</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/Debugger.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/Debugger.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2018 Nationale-Nederlanden, 2020-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/runner/LadybugWarInitializer.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/runner/LadybugWarInitializer.java
@@ -37,10 +37,12 @@ import org.springframework.web.context.WebApplicationContext;
 /**
  * Spring Boot entrypoint when running as a normal WAR application.
  *
+ * Has an order of 500 because it should start after the EnvironmentContext and before the ApplicationContext.
+ * 
  * @author Niels Meijer
  */
 @Order(500)
-public class TestToolWarInitializer extends SpringBootServletInitializer {
+public class LadybugWarInitializer extends SpringBootServletInitializer {
 	private static final Logger APPLICATION_LOG = LogUtil.getLogger("APPLICATION");
 
 	@Configuration

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/runner/TestToolWarInitializer.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/runner/TestToolWarInitializer.java
@@ -40,7 +40,7 @@ import org.springframework.web.context.WebApplicationContext;
  * @author Niels Meijer
  */
 @Order(500)
-public class WarInitializer extends SpringBootServletInitializer {
+public class TestToolWarInitializer extends SpringBootServletInitializer {
 	private static final Logger APPLICATION_LOG = LogUtil.getLogger("APPLICATION");
 
 	@Configuration
@@ -72,15 +72,18 @@ public class WarInitializer extends SpringBootServletInitializer {
 
 	@Override
 	protected WebApplicationContext run(SpringApplication application) {
+		AppConstants properties = AppConstants.getInstance(); //Deep clone of the AppConstants
+		String file = properties.getProperty("ibistesttool.springConfigFile", "springIbisTestTool.xml");
+
+		application.setAllowBeanDefinitionOverriding(true);//Only allow this (by default) for this context. application.propeties may be overwritten..
 		Set<String> set = new HashSet<>();
-		set.add(getConfigFile());
+		set.add(getConfigFile(file));
 		application.setSources(set);
-		application.setDefaultProperties(AppConstants.getInstance());
+		application.setDefaultProperties(properties);
 		return super.run(application);
 	}
 
-	private String getConfigFile() {
-		String file = AppConstants.getInstance().getProperty("ibistesttool.springConfigFile", "springIbisTestTool.xml");
+	private String getConfigFile(String file) {
 		ClassLoader classLoader = this.getClass().getClassLoader();
 		URL fileURL = classLoader.getResource(file);
 		if(fileURL == null) {

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/runner/TestToolWarInitializer.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/runner/TestToolWarInitializer.java
@@ -72,10 +72,11 @@ public class TestToolWarInitializer extends SpringBootServletInitializer {
 
 	@Override
 	protected WebApplicationContext run(SpringApplication application) {
-		AppConstants properties = AppConstants.getInstance(); //Deep clone of the AppConstants
+		AppConstants properties = AppConstants.getInstance();
 		String file = properties.getProperty("ibistesttool.springConfigFile", "springIbisTestTool.xml");
 
-		application.setAllowBeanDefinitionOverriding(true);//Only allow this (by default) for this context. application.propeties may be overwritten..
+		//Only allow this (by default) for this context, application.propeties may be overwritten.
+		application.setAllowBeanDefinitionOverriding(true);
 		Set<String> set = new HashSet<>();
 		set.add(getConfigFile(file));
 		application.setSources(set);

--- a/ladybug/src/main/resources/application.properties
+++ b/ladybug/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.main.allow-bean-definition-overriding=true

--- a/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
+++ b/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
@@ -35,9 +35,9 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.IbisContext;
 import org.frankframework.core.Adapter;
+import org.frankframework.larva.LarvaTool;
 import org.frankframework.lifecycle.FrankApplicationInitializer;
 import org.frankframework.stream.Message;
-import org.frankframework.larva.LarvaTool;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.DateFormatUtils;
 import org.frankframework.util.LogUtil;
@@ -162,9 +162,6 @@ public class IbisTester {
 		AppConstants.removeInstance();
 		appConstants = AppConstants.getInstance();
 		webAppPath = getWebContentDirectory();
-		String projectBaseDir = Misc.getProjectBaseDir();
-		appConstants.put("project.basedir", projectBaseDir);
-		debug("***set property with name [project.basedir] and value [" + projectBaseDir + "]***");
 
 		System.setProperty("jdbc.migrator.active", "true");
 		// appConstants.put("validators.disabled", "true");

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/JeeAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/JeeAuthenticator.java
@@ -93,7 +93,7 @@ public class JeeAuthenticator extends ServletAuthenticatorBase {
 	// Reads the web.xml file 'security-roles'
 	private MappableAttributesRetriever getWebXmlSecurityRoles() {
 		DelegatedMappableAttributesRetriever attributeRetriever = new DelegatedMappableAttributesRetriever();
-		try {
+		try {// If no web.xml is present this (default) authenticator will fail (and prevent the application from starting up.
 			MappableAttributesRetriever webXml = SpringUtils.createBean(getApplicationContext(), WebXmlMappableAttributesRetriever.class);
 			attributeRetriever.addMappableAttributes(webXml.getMappableAttributes());
 		} catch (BeanCreationException | BeanInstantiationException | NoSuchBeanDefinitionException e) {

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/JeeAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/JeeAuthenticator.java
@@ -19,6 +19,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
@@ -90,8 +93,12 @@ public class JeeAuthenticator extends ServletAuthenticatorBase {
 	// Reads the web.xml file 'security-roles'
 	private MappableAttributesRetriever getWebXmlSecurityRoles() {
 		DelegatedMappableAttributesRetriever attributeRetriever = new DelegatedMappableAttributesRetriever();
-		MappableAttributesRetriever webXml = SpringUtils.createBean(getApplicationContext(), WebXmlMappableAttributesRetriever.class);
-		attributeRetriever.addMappableAttributes(webXml.getMappableAttributes());
+		try {
+			MappableAttributesRetriever webXml = SpringUtils.createBean(getApplicationContext(), WebXmlMappableAttributesRetriever.class);
+			attributeRetriever.addMappableAttributes(webXml.getMappableAttributes());
+		} catch (BeanCreationException | BeanInstantiationException | NoSuchBeanDefinitionException e) {
+			log.info("unable to read web.xml file, caught exception: {}", e::getMessage);
+		}
 		attributeRetriever.addMappableAttributes(new HashSet<>(getSecurityRoles()));
 		return attributeRetriever;
 	}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -269,10 +269,10 @@
 		In newer versions of Eclipse (at least version 20181214-0600 onwards) this seems to have been resolved.
 		-->
 		<profile>
-			<id>m2e</id>
+			<id>spring-boot</id>
 			<activation>
 				<property>
-					<name>m2e.version</name>
+					<name>m2e.version</name><!-- automatically enables it on Eclipse -->
 				</property>
 			</activation>
 			<dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -278,6 +278,11 @@
 			<dependencies>
 				<dependency>
 					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-filesystem</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
 					<artifactId>frankframework-larva</artifactId>
 					<scope>runtime</scope>
 				</dependency>
@@ -294,6 +299,31 @@
 				<dependency>
 					<groupId>org.frankframework</groupId>
 					<artifactId>frankframework-console-backend</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-akamai</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-cmis</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-aws</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-messaging</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-batch</artifactId>
 					<scope>runtime</scope>
 				</dependency>
 			</dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -288,11 +288,6 @@
 				</dependency>
 				<dependency>
 					<groupId>org.frankframework</groupId>
-					<artifactId>frankframework-ladybug</artifactId>
-					<scope>runtime</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.frankframework</groupId>
 					<artifactId>frankframework-console-frontend</artifactId>
 					<scope>runtime</scope>
 				</dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -48,6 +48,40 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- provided dependencies will be added to the executable (Spring) WAR -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<version>${spring.boot.version}</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-autoconfigure</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<version>${spring.boot.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-loader</artifactId>
+			<version>${spring.boot.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -250,6 +284,16 @@
 				<dependency>
 					<groupId>org.frankframework</groupId>
 					<artifactId>frankframework-ladybug</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-console-frontend</artifactId>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.frankframework</groupId>
+					<artifactId>frankframework-console-backend</artifactId>
 					<scope>runtime</scope>
 				</dependency>
 			</dependencies>

--- a/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
+++ b/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
@@ -63,6 +63,7 @@ public class IafTestInitializer {
 		System.setProperty("application.security.http.authentication", "false");
 		System.setProperty("application.security.http.transportGuarantee", "none");
 		System.setProperty("dtap.stage", "LOC");
+		System.setProperty("active.jms", "false");
 		System.setProperty("log.dir", getLogDir(projectDir));
 		System.setProperty(ApplicationServerConfigurer.APPLICATION_SERVER_TYPE_PROPERTY, "IBISTEST");
 

--- a/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
+++ b/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
@@ -22,9 +22,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.frankframework.lifecycle.ApplicationServerConfigurer;
 import org.frankframework.lifecycle.FrankApplicationInitializer;
 import org.frankframework.lifecycle.SpringContextScope;
+import org.frankframework.lifecycle.servlets.ApplicationServerConfigurer;
 import org.frankframework.util.AppConstants;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
@@ -52,13 +52,16 @@ public class IafTestInitializer {
 
 	// Should start a XmlServletWebServerApplicationContext.
 	public static void main(String[] args) throws IOException {
-		String logDir = getLogDir();
+		String currentDir = System.getProperty("user.dir");
+		Path projectPath = Path.of(currentDir).toAbsolutePath();
+
+		String logDir = getLogDir(projectPath);
 
 		System.setProperty("application.security.http.authentication", "false");
 		System.setProperty("application.security.http.transportGuarantee", "none");
 		System.setProperty("dtap.stage", "LOC");
 		System.setProperty("log.dir", logDir);
-		System.setProperty(ApplicationServerConfigurer.APPLICATION_SERVER_TYPE_PROPERTY, "TOMCAT");
+		System.setProperty(ApplicationServerConfigurer.APPLICATION_SERVER_TYPE_PROPERTY, "IBISTEST");
 
 		SpringApplication app = new SpringApplication();
 		app.addInitializers(new ConfigureAppConstants());
@@ -71,10 +74,8 @@ public class IafTestInitializer {
 		app.run(args);
 	}
 
-	private static String getLogDir() throws IOException {
-		String currentDir = System.getProperty("user.dir");
-		Path absPath = Path.of(currentDir).toAbsolutePath();
-		Path targetPath = absPath.resolve("target");
+	private static String getLogDir(Path projectPath) throws IOException {
+		Path targetPath = projectPath.resolve("target");
 		if(Files.exists(targetPath) && Files.isDirectory(targetPath)) {
 			Path logDir = targetPath.resolve("logs");
 			if(!Files.exists(logDir)) {

--- a/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
+++ b/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
@@ -125,7 +125,7 @@ public class IafTestInitializer {
 			if(!Files.exists(logDir)) {
 				Files.createDirectory(logDir);
 			}
-			return logDir.toAbsolutePath().toString();
+			return logDir.toAbsolutePath().toString().replace("\\", "/"); // Slashes are required for the larva tool...
 		}
 		throw new IOException("unable to determine log directory");
 	}

--- a/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
+++ b/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
@@ -24,7 +24,10 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 
+import org.apache.logging.log4j.LogManager;
 import org.frankframework.lifecycle.FrankApplicationInitializer;
 import org.frankframework.lifecycle.SpringContextScope;
 import org.frankframework.lifecycle.servlets.ApplicationServerConfigurer;
@@ -43,7 +46,14 @@ import org.springframework.core.env.PropertiesPropertySource;
  */
 public class IafTestInitializer {
 
-	public static class ApplicationInitializer extends FrankApplicationInitializer implements ServletContextInitializer {}
+	public static class ApplicationInitializerWrapper implements ServletContextInitializer {
+		@Override
+		public void onStartup(ServletContext servletContext) throws ServletException {
+			FrankApplicationInitializer init = new FrankApplicationInitializer();
+			init.onStartup(servletContext);
+			LogManager.getLogger("APPLICATION").info("Started Frank!Application");
+		}
+	}
 
 	public static class ConfigureAppConstants implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
@@ -71,7 +81,7 @@ public class IafTestInitializer {
 		app.addInitializers(new ConfigureAppConstants());
 		app.setWebApplicationType(WebApplicationType.SERVLET);
 		Set<String> set = new HashSet<>();
-		app.addPrimarySources(List.of(ApplicationInitializer.class));
+		app.addPrimarySources(List.of(ApplicationInitializerWrapper.class));
 		set.add(SpringContextScope.ENVIRONMENT.getContextFile());
 		set.add("TestFrankContext.xml");
 		app.setSources(set);

--- a/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
+++ b/test/src/main/java/org/frankframework/runner/IafTestInitializer.java
@@ -1,0 +1,88 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.runner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.frankframework.lifecycle.ApplicationServerConfigurer;
+import org.frankframework.lifecycle.FrankApplicationInitializer;
+import org.frankframework.lifecycle.SpringContextScope;
+import org.frankframework.util.AppConstants;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertiesPropertySource;
+
+/**
+ * Spring Boot entrypoint or main class defined in the pom.xml when packaging using the 'spring-boot:repackage' goal.
+ *
+ * @author Niels Meijer
+ */
+public class IafTestInitializer {
+
+	public static class ApplicationInitializer extends FrankApplicationInitializer implements ServletContextInitializer {}
+
+	public static class ConfigureAppConstants implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext applicationContext) {
+			applicationContext.getEnvironment().getPropertySources().addFirst(new PropertiesPropertySource(SpringContextScope.ENVIRONMENT.getFriendlyName(), AppConstants.getInstance()));
+		}
+	}
+
+	// Should start a XmlServletWebServerApplicationContext.
+	public static void main(String[] args) throws IOException {
+		String logDir = getLogDir();
+
+		System.setProperty("application.security.http.authentication", "false");
+		System.setProperty("application.security.http.transportGuarantee", "none");
+		System.setProperty("dtap.stage", "LOC");
+		System.setProperty("log.dir", logDir);
+		System.setProperty(ApplicationServerConfigurer.APPLICATION_SERVER_TYPE_PROPERTY, "TOMCAT");
+
+		SpringApplication app = new SpringApplication();
+		app.addInitializers(new ConfigureAppConstants());
+		app.setWebApplicationType(WebApplicationType.SERVLET);
+		Set<String> set = new HashSet<>();
+		app.addPrimarySources(List.of(ApplicationInitializer.class));
+		set.add(SpringContextScope.ENVIRONMENT.getContextFile());
+		set.add("TestFrankContext.xml");
+		app.setSources(set);
+		app.run(args);
+	}
+
+	private static String getLogDir() throws IOException {
+		String currentDir = System.getProperty("user.dir");
+		Path absPath = Path.of(currentDir).toAbsolutePath();
+		Path targetPath = absPath.resolve("target");
+		if(Files.exists(targetPath) && Files.isDirectory(targetPath)) {
+			Path logDir = targetPath.resolve("logs");
+			if(!Files.exists(logDir)) {
+				Files.createDirectory(logDir);
+			}
+			return logDir.toAbsolutePath().toString();
+		}
+		throw new IOException("unable to determine log directory");
+	}
+
+}

--- a/test/src/main/resources/StageSpecifics_LOC.properties
+++ b/test/src/main/resources/StageSpecifics_LOC.properties
@@ -39,8 +39,8 @@ scenariosroot1.directory=src/test/testtool
 scenariosroot1.description=Eclipse Maven project
 scenariosroot1.m2e.pom.properties=../META-INF/maven/org.frankframework/frankframework-test/pom.properties
 
-scenariosroot2.directory=../../TestTool
-scenariosroot2.description=Eclipse classic project
+scenariosroot2.directory=../../../test/TestTool
+scenariosroot2.description=Spring Boot project
 
 scenariosroot3.directory=../testtool
 scenariosroot3.description=testtool directory on server

--- a/test/src/main/resources/TestFrankContext.xml
+++ b/test/src/main/resources/TestFrankContext.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+	">
+
+	<context:property-placeholder location="classpath:application.properties"/>
+
+	<bean id="tomcat" class="org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory">
+		<property name="port" value="${server.port}"/>
+		<property name="contextPath" value="/iaf-test"/>
+	</bean>
+
+</beans>

--- a/test/src/main/resources/application.properties
+++ b/test/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+# Spring Application log settings
+logging.level.root=WARN
+logging.level.org.frankframework=DEBUG
+logging.level.org.springframework=WARN
+logging.level.org.apache.coyote=WARN
+logging.level.org.apache.tomcat=WARN
+logging.level.org.apache.catalina=INFO
+logging.level.org.apache.jasper=WARN
+logging.level.org.apache.naming=WARN
+
+logging.level.org.springframework.jndi=WARN
+logging.level.org.springframework.integration.http=WARN
+logging.level.org.springframework.core.convert=WARN
+
+logging.level.com.microsoft.sqlserver=WARN
+
+# Application defaults
+spring.jmx.enabled=false
+server.port=80


### PR DESCRIPTION
I move a lot around to clean up the code as well as use it independently.
Spring automatically finds the `WebApplicationInitializer`s when running in a traditional WAR environment.
When using Spring Boot these implementations are ignored (!).

They will need to be either manually added as `PrimarySource` on the `SpringApplication` or defined in a bean config somewhere. Spring Boot listens to the `ServletContextInitializer` interface instead, which a traditional WAR environment does not find. At some point we need to make our 'runnables' a bit more generic so they can implement both interfaces, for now I've opted to not do that due to them being in the spring-boot-starter dependency, which is not part of our default classpath.