### PR TITLE
Manage AWS dependencies through BOM import in parent pom. Upgrade AWS deps

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -10,10 +10,6 @@
 	<artifactId>frankframework-aws</artifactId>
 	<name>Frank!Framework support for AWS</name>
 
-	<properties>
-		<software.amazon.awssdk.version>2.25.0</software.amazon.awssdk.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.frankframework</groupId>
@@ -30,13 +26,13 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>1.12.483</version>
+			<version>1.12.687</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-sqs-java-messaging-lib</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.3</version><!-- Stay at 2.0.x, due to jakarta package names in 2.1.x libs -->
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.geronimo.specs</groupId>
@@ -108,29 +104,4 @@
 		</dependency>
 	</dependencies>
 
-	<!-- ensure that all AWS SDK libraries use the same version -->
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>sqs</artifactId>
-				<version>${software.amazon.awssdk.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>auth</artifactId>
-				<version>${software.amazon.awssdk.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>utils</artifactId>
-				<version>${software.amazon.awssdk.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>cloudwatch</artifactId>
-				<version>${software.amazon.awssdk.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
 		<geronimo.jta.spec.version>1.1.1</geronimo.jta.spec.version>
 		<geronimo.j2ee.spec.version>1.0.1</geronimo.j2ee.spec.version>
 
+		<aws.java.sdk.version>2.25.17</aws.java.sdk.version>
+
 		<!-- Some test dependency versions -->
 		<mockito.version>5.11.0</mockito.version>
 		<junit.version>5.10.2</junit.version>
@@ -360,6 +362,14 @@
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>
 				<version>${log4j2.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws.java.sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Somehow the AWS libraries where not bumped by Dependabot, even though it is possible (S3 lib & SDK version). 