### PR TITLE
Do not add the Content-Type header when it already exists (v2)

### DIFF
--- a/core/src/main/java/org/frankframework/http/HttpSessionBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSessionBase.java
@@ -78,6 +78,7 @@ import org.frankframework.http.authentication.HttpAuthenticationException;
 import org.frankframework.http.authentication.OAuthAccessTokenManager;
 import org.frankframework.http.authentication.OAuthAuthenticationScheme;
 import org.frankframework.http.authentication.OAuthPreferringAuthenticationStrategy;
+import org.frankframework.http.authentication.OAuthAccessTokenManager.AuthenticationType;
 import org.frankframework.lifecycle.ConfigurableLifecycle;
 import org.frankframework.util.ClassUtils;
 import org.frankframework.util.CredentialFactory;
@@ -149,11 +150,11 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	private @Getter @Setter ApplicationContext applicationContext;
 
 	/* CONNECTION POOL */
-	private @Getter int timeout = 10000;
+	private @Getter int timeout = 10_000;
 	private @Getter int maxConnections = 10;
 	private @Getter int maxExecuteRetries = 1;
 	private @Getter boolean staleChecking=true;
-	private @Getter int staleTimeout = 5000; // [ms]
+	private @Getter int staleTimeout = 5+000; // [ms]
 	private @Getter int connectionTimeToLive = 900; // [s]
 	private @Getter int connectionIdleTimeout = 10; // [s]
 	private final HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
@@ -172,6 +173,7 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	private @Getter String clientId;
 	private @Getter String clientSecret;
 	private @Getter String scope;
+
 	private @Getter boolean authenticatedTokenRequest;
 
 	/* PROXY */
@@ -362,7 +364,7 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 		connectionManager.setDefaultMaxPerRoute(getMaxConnections());
 
 		if (isStaleChecking()) {
-			log.info("set up connectionManager, setting stale checking ["+isStaleChecking()+"]");
+			log.info("set up connectionManager, setting stale checking [true]");
 			connectionManager.setValidateAfterInactivity(getStaleTimeout());
 		}
 
@@ -416,7 +418,8 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 			requestConfigBuilder.setAuthenticationEnabled(true);
 
 			if (preferredAuthenticationScheme == AuthenticationScheme.OAUTH) {
-				OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getTokenEndpoint(), getScope(), client_cf, user_cf==null, isAuthenticatedTokenRequest(), this, getTokenExpiry());
+				AuthenticationType authType = isAuthenticatedTokenRequest() ? AuthenticationType.AUTHENTICATION_HEADER : AuthenticationType.REQUEST_PARAMETER;
+				OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getTokenEndpoint(), getScope(), client_cf, user_cf==null, authType, this, getTokenExpiry());
 				defaultHttpClientContext.setAttribute(OAuthAuthenticationScheme.ACCESSTOKEN_MANAGER_KEY, accessTokenManager);
 				httpClientBuilder.setTargetAuthenticationStrategy(new OAuthPreferringAuthenticationStrategy());
 			}

--- a/core/src/main/java/org/frankframework/http/authentication/OAuthAccessTokenManager.java
+++ b/core/src/main/java/org/frankframework/http/authentication/OAuthAccessTokenManager.java
@@ -16,9 +16,9 @@
 package org.frankframework.http.authentication;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -33,11 +33,19 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.http.HttpSessionBase;
+import org.frankframework.task.TimeoutGuard;
+import org.frankframework.util.CredentialFactory;
+import org.frankframework.util.DateFormatUtils;
+import org.frankframework.util.LogUtil;
+import org.frankframework.util.StreamUtil;
+import org.frankframework.util.StringUtil;
 
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationGrant;
@@ -56,29 +64,25 @@ import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 
-import org.frankframework.http.HttpSessionBase;
-import org.frankframework.task.TimeoutGuard;
-import org.frankframework.util.CredentialFactory;
-import org.frankframework.util.DateFormatUtils;
-import org.frankframework.util.LogUtil;
-import org.frankframework.util.StreamUtil;
-import org.frankframework.util.StringUtil;
-
 public class OAuthAccessTokenManager {
 	protected Logger log = LogUtil.getLogger(this);
 
 	private URI tokenEndpoint;
 	private final Scope scope;
 	private final CredentialFactory clientCredentialFactory;
-	private final boolean useClientCredentialsGrant;
+	private final boolean useClientCredentials;
 	private final HttpSessionBase httpSession;
 	private final int expiryMs;
-	private final boolean authenticatedTokenRequest; // if set true, clientId and clientSecret will be added as Basic Authentication header, instead of as request parameters
+	private final AuthenticationType authenticationType;
 
 	private AccessToken accessToken;
 	private long accessTokenRefreshTime;
 
-	public OAuthAccessTokenManager(String tokenEndpoint, String scope, CredentialFactory clientCF, boolean useClientCredentialsGrant, boolean authenticatedTokenRequest, HttpSessionBase httpSession, int expiry) throws HttpAuthenticationException {
+	public enum AuthenticationType {
+		AUTHENTICATION_HEADER, REQUEST_PARAMETER
+	}
+
+	public OAuthAccessTokenManager(String tokenEndpoint, String scope, CredentialFactory clientCF, boolean useClientCredentials, AuthenticationType authType, HttpSessionBase httpSession, int expiry) throws HttpAuthenticationException {
 		try {
 			this.tokenEndpoint = new URI(tokenEndpoint);
 		} catch (URISyntaxException e) {
@@ -87,8 +91,8 @@ public class OAuthAccessTokenManager {
 
 		this.scope = StringUtils.isNotEmpty(scope) ? Scope.parse(scope) : null;
 		this.clientCredentialFactory = clientCF;
-		this.useClientCredentialsGrant = useClientCredentialsGrant;
-		this.authenticatedTokenRequest = authenticatedTokenRequest;
+		this.useClientCredentials = useClientCredentials;
+		this.authenticationType = authType;
 		this.httpSession = httpSession;
 		this.expiryMs = expiry * 1000;
 	}
@@ -124,9 +128,9 @@ public class OAuthAccessTokenManager {
 	protected TokenRequest createRequest(Credentials credentials) {
 		AuthorizationGrant grant;
 
-		if (useClientCredentialsGrant) {
+		if (useClientCredentials) { //Client authentication is required
 			grant = new ClientCredentialsGrant();
-		} else {
+		} else { //Client authentication required only for confidential clients
 			String username = credentials.getUserPrincipal().getName();
 			Secret password = new Secret(credentials.getPassword());
 			grant = new ResourceOwnerPasswordCredentialsGrant(username, password);
@@ -136,6 +140,8 @@ public class OAuthAccessTokenManager {
 		ClientID clientID = new ClientID(clientCredentialFactory.getUsername());
 		Secret clientSecret = new Secret(clientCredentialFactory.getPassword());
 		ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
+
+		// ClientSecretPost
 
 		return new TokenRequest(tokenEndpoint, clientAuth, grant, scope);
 	}
@@ -170,9 +176,10 @@ public class OAuthAccessTokenManager {
 	// convert the Nimbus HTTPRequest into an Apache HttpClient HttpRequest
 	protected HttpRequestBase convertToApacheHttpRequest(HTTPRequest httpRequest) throws HttpAuthenticationException {
 		HttpRequestBase apacheHttpRequest;
-		String query = httpRequest.getQuery();
-		if (!authenticatedTokenRequest) {
-			List<NameValuePair> clientInfo= new LinkedList<>();
+		String query = httpRequest.getQuery(); //This is the POST BODY, don't ask me why they called it QUERY...
+
+		if(authenticationType == AuthenticationType.REQUEST_PARAMETER) {
+			List<NameValuePair> clientInfo = new LinkedList<>();
 			clientInfo.add(new BasicNameValuePair("client_id", clientCredentialFactory.getUsername()));
 			clientInfo.add(new BasicNameValuePair("client_secret", clientCredentialFactory.getPassword()));
 			query = StringUtil.concatStrings(query, "&", URLEncodedUtils.format(clientInfo, "UTF-8"));
@@ -182,14 +189,10 @@ public class OAuthAccessTokenManager {
 				String url = StringUtil.concatStrings(httpRequest.getURL().toExternalForm(), "?", query);
 				apacheHttpRequest = new HttpGet(url);
 				break;
-			case POST:
+			case POST: //authenticationType.HEADER is always POST
 				apacheHttpRequest = new HttpPost(httpRequest.getURL().toExternalForm());
-				apacheHttpRequest.addHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8");
-				try {
-					((HttpPost)apacheHttpRequest).setEntity(new StringEntity(query));
-				} catch (UnsupportedEncodingException e) {
-					throw new HttpAuthenticationException("Could not create TokenRequest", e);
-				}
+				ContentType contentType = ContentType.APPLICATION_FORM_URLENCODED.withCharset(StandardCharsets.UTF_8);
+				((HttpPost)apacheHttpRequest).setEntity(new StringEntity(query, contentType));
 
 				break;
 			default:

--- a/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
@@ -163,6 +163,23 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 	}
 
 	@Test
+	void testOAuthAuthenticatedTokenRequest() throws Exception {
+		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPath);
+		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
+		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
+		sender.setClientId(MockTokenServer.CLIENT_ID);
+		sender.setClientSecret(MockTokenServer.CLIENT_SECRET);
+		sender.setAuthenticatedTokenRequest(true);
+
+		sender.configure();
+		sender.open();
+
+		result = sendMessage();
+		assertEquals("200", session.getString(RESULT_STATUS_CODE_SESSIONKEY));
+		assertNotNull(result.asString());
+	}
+
+	@Test
 	void testOAuthAuthenticationUnchallenged() throws Exception {
 		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPathUnchallenged);
 		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);

--- a/core/src/test/java/org/frankframework/http/authentication/OAuthAccessTokenManagerRequestTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/OAuthAccessTokenManagerRequestTest.java
@@ -3,11 +3,14 @@ package org.frankframework.http.authentication;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Base64;
+
 import org.apache.http.Header;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.frankframework.http.authentication.OAuthAccessTokenManager.AuthenticationType;
 import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.StreamUtil;
 import org.junit.jupiter.api.Test;
@@ -17,94 +20,92 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 
 public class OAuthAccessTokenManagerRequestTest {
 
-	String scope = "email";
-	String clientId = "fakeClientId";
-	String clientSecret = "fakeClientSecret";
-	String tokenEndpoint = "http://fakeTokenEndpoint";
+	private String scope = "email";
+	private String clientId = "fakeClientId";
+	private String clientSecret = "fakeClientSecret";
+	private String tokenEndpoint = "http://fakeTokenEndpoint";
+	private String base64 = "Basic " + Base64.getEncoder().encodeToString((clientId+":"+clientSecret).getBytes());
 
-	CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
+	private Credentials credentials = new UsernamePasswordCredentials("fakeCredentialUserName", "fakeCredentialPassword");
+	private CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
 	private TestableOAuthAccessTokenManager tokenManager;
 
 
 	@Test
 	void testRetrieveAccessTokenWithClientCredentialsGrantInRequestParameters() throws Exception {
-		Credentials credentials = new UsernamePasswordCredentials("fakeCredentialUserName", "fakeCredentialPassword");
+		tokenManager = new TestableOAuthAccessTokenManager(true, AuthenticationType.REQUEST_PARAMETER);
 
-		tokenManager = new TestableOAuthAccessTokenManager(true, false);
-
-		TokenRequest tokenRequest =  tokenManager.createRequest(credentials);
+		TokenRequest tokenRequest = tokenManager.createRequest(credentials);
 
 		HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
 		assertEquals("POST", httpRequest.getMethod().name());
 		assertEquals("grant_type=client_credentials&scope=email", httpRequest.getQuery());
-		assertEquals("{Authorization=[Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
+		assertEquals("{Authorization=["+base64+"], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
 
 		HttpPost apacheRequest = (HttpPost)tokenManager.convertToApacheHttpRequest(httpRequest);
 		assertEquals("POST", apacheRequest.getMethod());
-		assertHeaderPresent(apacheRequest, "Authorization","Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=");
-		assertEquals("[Content-Type: text/plain; charset=ISO-8859-1,Content-Length: 95,Chunked: false]", apacheRequest.getEntity().toString());
+		assertHeaderPresent(apacheRequest, "Authorization",base64);
+		assertHeaderPresent(apacheRequest, "Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 		assertEquals("grant_type=client_credentials&scope=email&client_id=fakeClientId&client_secret=fakeClientSecret", StreamUtil.streamToString(apacheRequest.getEntity().getContent(), "\n", "UTF-8"));
+		assertEquals("[Content-Type: application/x-www-form-urlencoded; charset=UTF-8,Content-Length: 95,Chunked: false]", apacheRequest.getEntity().toString());
 	}
 
 	@Test
 	void testRetrieveAccessTokenWithClientCredentialsGrantInBasicAuthentication() throws Exception {
-		Credentials credentials = new UsernamePasswordCredentials("fakeCredentialUserName", "fakeCredentialPassword");
+		tokenManager = new TestableOAuthAccessTokenManager(true, AuthenticationType.AUTHENTICATION_HEADER);
 
-		tokenManager = new TestableOAuthAccessTokenManager(true, true);
-
-		TokenRequest tokenRequest =  tokenManager.createRequest(credentials);
+		TokenRequest tokenRequest = tokenManager.createRequest(credentials);
 
 		HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
 		assertEquals("POST", httpRequest.getMethod().name());
 		assertEquals("grant_type=client_credentials&scope=email", httpRequest.getQuery());
-		assertEquals("{Authorization=[Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
+		assertEquals("{Authorization=["+base64+"], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
 
 		HttpPost apacheRequest = (HttpPost)tokenManager.convertToApacheHttpRequest(httpRequest);
 		assertEquals("POST", apacheRequest.getMethod());
-		assertHeaderPresent(apacheRequest, "Authorization","Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=");
-		assertEquals("[Content-Type: text/plain; charset=ISO-8859-1,Content-Length: 41,Chunked: false]", apacheRequest.getEntity().toString());
+		assertHeaderPresent(apacheRequest, "Authorization",base64);
+		assertHeaderPresent(apacheRequest, "Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 		assertEquals("grant_type=client_credentials&scope=email", StreamUtil.streamToString(apacheRequest.getEntity().getContent(), "\n", "UTF-8"));
+		assertEquals("[Content-Type: application/x-www-form-urlencoded; charset=UTF-8,Content-Length: 41,Chunked: false]", apacheRequest.getEntity().toString());
 	}
 
 	@Test
 	void testRetrieveAccessTokenWithResourceOwnerPasswordGrantUsingRequestParameters() throws Exception {
-		Credentials credentials = new UsernamePasswordCredentials("fakeCredentialUserName", "fakeCredentialPassword");
+		tokenManager = new TestableOAuthAccessTokenManager(false, AuthenticationType.REQUEST_PARAMETER);
 
-		tokenManager = new TestableOAuthAccessTokenManager(false, false);
-
-		TokenRequest tokenRequest =  tokenManager.createRequest(credentials);
+		TokenRequest tokenRequest = tokenManager.createRequest(credentials);
 
 		HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
 		assertEquals("POST", httpRequest.getMethod().name());
 		assertEquals("password=fakeCredentialPassword&grant_type=password&username=fakeCredentialUserName&scope=email", httpRequest.getQuery());
-		assertEquals("{Authorization=[Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
+		assertEquals("{Authorization=["+base64+"], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
 
 		HttpPost apacheRequest = (HttpPost)tokenManager.convertToApacheHttpRequest(httpRequest);
 		assertEquals("POST", apacheRequest.getMethod());
-		assertHeaderPresent(apacheRequest, "Authorization","Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=");
+		assertHeaderPresent(apacheRequest, "Authorization",base64);
+		assertHeaderPresent(apacheRequest, "Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 		assertEquals("password=fakeCredentialPassword&grant_type=password&username=fakeCredentialUserName&scope=email&client_id=fakeClientId&client_secret=fakeClientSecret", StreamUtil.streamToString(apacheRequest.getEntity().getContent(), "\n", "UTF-8"));
-		assertEquals("[Content-Type: text/plain; charset=ISO-8859-1,Content-Length: 149,Chunked: false]", apacheRequest.getEntity().toString());
+		assertEquals("[Content-Type: application/x-www-form-urlencoded; charset=UTF-8,Content-Length: 149,Chunked: false]", apacheRequest.getEntity().toString());
 	}
 
 	@Test
 	void testRetrieveAccessTokenWithResourceOwnerPasswordGrantUsingBasicAuthentication() throws Exception {
-		Credentials credentials = new UsernamePasswordCredentials("fakeCredentialUserName", "fakeCredentialPassword");
+		tokenManager = new TestableOAuthAccessTokenManager(false, AuthenticationType.AUTHENTICATION_HEADER);
 
-		tokenManager = new TestableOAuthAccessTokenManager(false, true);
-
-		TokenRequest tokenRequest =  tokenManager.createRequest(credentials);
+		TokenRequest tokenRequest = tokenManager.createRequest(credentials);
 
 		HTTPRequest httpRequest = tokenRequest.toHTTPRequest();
 		assertEquals("POST", httpRequest.getMethod().name());
 		assertEquals("password=fakeCredentialPassword&grant_type=password&username=fakeCredentialUserName&scope=email", httpRequest.getQuery());
-		assertEquals("{Authorization=[Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
+		assertEquals("{Authorization=["+base64+"], Content-Type=[application/x-www-form-urlencoded; charset=UTF-8]}", httpRequest.getHeaderMap().toString());
 
 		HttpPost apacheRequest = (HttpPost)tokenManager.convertToApacheHttpRequest(httpRequest);
 		assertEquals("POST", apacheRequest.getMethod());
-		assertHeaderPresent(apacheRequest, "Authorization","Basic ZmFrZUNsaWVudElkOmZha2VDbGllbnRTZWNyZXQ=");
+		assertHeaderPresent(apacheRequest, "Authorization",base64);
+		assertHeaderPresent(apacheRequest, "Content-Type","application/x-www-form-urlencoded; charset=UTF-8");
 		assertEquals("password=fakeCredentialPassword&grant_type=password&username=fakeCredentialUserName&scope=email", StreamUtil.streamToString(apacheRequest.getEntity().getContent(), "\n", "UTF-8"));
-		assertEquals("[Content-Type: text/plain; charset=ISO-8859-1,Content-Length: 95,Chunked: false]", apacheRequest.getEntity().toString());
+		assertEquals("[Content-Type: application/x-www-form-urlencoded; charset=UTF-8,Content-Length: 95,Chunked: false]", apacheRequest.getEntity().toString());
 	}
 
 	public void assertHeaderPresent(HttpRequestBase method, String header, String expectedValue) {
@@ -116,8 +117,8 @@ public class OAuthAccessTokenManagerRequestTest {
 
 	private class TestableOAuthAccessTokenManager extends OAuthAccessTokenManager {
 
-		public TestableOAuthAccessTokenManager(boolean useClientCredentialsGrant, boolean authenticatedTokenRequest) throws HttpAuthenticationException {
-			super(tokenEndpoint, scope, client_cf, useClientCredentialsGrant, authenticatedTokenRequest, null, -1);
+		public TestableOAuthAccessTokenManager(boolean useClientCredentials, AuthenticationType type) throws HttpAuthenticationException {
+			super(tokenEndpoint, scope, client_cf, useClientCredentials, type, null, -1);
 		}
 
 		@Override

--- a/core/src/test/java/org/frankframework/http/authentication/OAuthAccessTokenManagerTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/OAuthAccessTokenManagerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.frankframework.http.HttpSender;
+import org.frankframework.http.authentication.OAuthAccessTokenManager.AuthenticationType;
 import org.frankframework.util.CredentialFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ public class OAuthAccessTokenManagerTest {
 	@RegisterExtension
 	public WireMockExtension tokenServer = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
 
-	private HttpSender httpSender = new HttpSender();
+	private HttpSender httpSender;
 
 	@BeforeEach
 	public void setup() throws Exception {
@@ -48,7 +49,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, true, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, true, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
 
 		String accessToken = accessTokenManager.getAccessToken(null, true);
 
@@ -66,7 +67,25 @@ public class OAuthAccessTokenManagerTest {
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 		Credentials credentials = new UsernamePasswordCredentials(username, password);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, false, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, false, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
+
+		String accessToken = accessTokenManager.getAccessToken(credentials, true);
+
+		assertThat(accessToken, startsWith("Bearer"));
+	}
+
+	@Test
+	public void testRetrieveAccessTokenWithAuthHeader() throws Exception {
+		String scope = "email";
+		String clientId = MockTokenServer.CLIENT_ID;
+		String clientSecret = MockTokenServer.CLIENT_SECRET;
+		String username = "fakeUsername";
+		String password = "fakePassword";
+
+		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
+		Credentials credentials = new UsernamePasswordCredentials(username, password);
+
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, false, AuthenticationType.AUTHENTICATION_HEADER, httpSender, -1);
 
 		String accessToken = accessTokenManager.getAccessToken(credentials, true);
 
@@ -81,7 +100,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, true, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint()+MockTokenServer.PATH, scope, client_cf, true, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
 
 		String accessToken = accessTokenManager.getAccessToken(null, true);
 
@@ -96,7 +115,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + "/xxxxx", scope, client_cf, true, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + "/xxxxx", scope, client_cf, true, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
 
 		HttpAuthenticationException actualException = assertThrows(HttpAuthenticationException.class, () -> accessTokenManager.getAccessToken(null, true));
 		assertThat(actualException.getMessage(), containsString("Could not retrieve token"));
@@ -110,7 +129,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + MockTokenServer.EXPIRED_PATH, scope, client_cf, true, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + MockTokenServer.EXPIRED_PATH, scope, client_cf, true, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
 
 		tokenServer.resetScenarios();
 		assertThat(accessTokenManager.getAccessToken(null, true), containsString("Expired"));
@@ -127,7 +146,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + MockTokenServer.EXPIRED_PATH, scope, client_cf, true, false, httpSender, -1);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(getEndpoint() + MockTokenServer.EXPIRED_PATH, scope, client_cf, true, AuthenticationType.REQUEST_PARAMETER, httpSender, -1);
 
 		tokenServer.resetScenarios();
 		assertThat(accessTokenManager.getAccessToken(null, true), containsString("Expired"));


### PR DESCRIPTION
I don't know where to start..
In #2683 I warned about the HttpEntity being wrong, using a StringEntity was not the wrong choice here, but the failure of an attempt to set the content-type was. In #3980 tests were created, which actually prove it's 'faultiness', because the test returns a `text/plain; charset=ISO-8859-1` content-type!

In #3980 we can also see what was intended with the `authenticatedTokenRequest` attribute; The idea being that it uses the provided clientId and secret as a header opposed to (post url-encoded) form-data fields.
In #2597 the preAuthentication methods where 'reorganized' but the beforementioned #3980 severely changed this behavior.