### PR TITLE
Move FileSystem dependencies from core to their own module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -445,23 +445,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>com.hierynomus</groupId>
-			<artifactId>smbj</artifactId>
-			<version>0.13.0</version>
-		</dependency>
-		<dependency>
-			<groupId>jcifs</groupId>
-			<artifactId>jcifs</artifactId>
-			<version>1.3.17</version>
-			<exclusions>
-				<!-- this should never have been added as a compile dependency! -->
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 
 		<!-- Http Components -->
 		<dependency>
@@ -512,16 +495,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.microsoft.ews-java-api</groupId>
-			<artifactId>ews-java-api</artifactId>
-			<version>2.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>msal4j</artifactId>
-			<version>1.15.0</version>
-		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>

--- a/filesystem/pom.xml
+++ b/filesystem/pom.xml
@@ -26,6 +26,36 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.microsoft.ews-java-api</groupId>
+			<artifactId>ews-java-api</artifactId>
+			<version>2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>msal4j</artifactId>
+			<version>1.15.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.hierynomus</groupId>
+			<artifactId>smbj</artifactId>
+			<version>0.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jcifs</groupId>
+			<artifactId>jcifs</artifactId>
+			<version>1.3.17</version>
+			<exclusions>
+				<!-- this should never have been added as a compile dependency! -->
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+
 		<!-- FTP and SFTP -->
 		<dependency>
 			<groupId>com.github.mwiede</groupId>

--- a/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
+++ b/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
@@ -52,6 +52,7 @@ import jcifs.util.Base64;
 import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
@@ -68,6 +69,8 @@ import org.frankframework.util.StreamUtil;
  *
  * @author  Peter Leeuwenburgh
  */
+@Deprecated(forRemoval = true, since = "8.0")
+@ConfigurationWarning("NTLM authentication is unsecure and should be avoided.")
 public class WebServiceNtlmSender extends SenderWithParametersBase implements HasPhysicalDestination {
 
 	private final @Getter String domain = "Http";

--- a/filesystem/src/test/java/org/frankframework/xml/StaxParserTest.java
+++ b/filesystem/src/test/java/org/frankframework/xml/StaxParserTest.java
@@ -14,6 +14,13 @@ import microsoft.exchange.webservices.data.core.EwsServiceMultiResponseXmlReader
 import microsoft.exchange.webservices.data.core.EwsXmlReader;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
 
+/**
+ * Tests if XML 1.1 has been enabled, to avoid errors like:
+ * Illegal character entity: expansion character (code 0x3 at [row,col {unknown-source}]: [1,53]
+ * 
+ * Required for MS Exchange.
+ * See {@link StaxParserFactory}.
+ */
 public class StaxParserTest {
 
 	private final String validDocument   = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>testContent</test>";


### PR DESCRIPTION
Moved the (now deprecated) WebServiceNtlmSender as well.