### PR TITLE
Update SLF4J to API version 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,18 +324,6 @@
 				<version>2.0.1</version>
 			</dependency>
 
-			<!-- SLF4J Log bindings -->
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>1.7.36</version>
-			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-jcl</artifactId>
-				<version>1.7.36</version>
-			</dependency>
-
 			<!-- SPRING to force versions -->
 			<dependency><!-- required for CMIS and the IbisTester class -->
 				<groupId>org.springframework</groupId>
@@ -377,6 +365,12 @@
 				<version>${log4j2.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!-- SLF4J Log binding -->
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>2.0.12</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
I updated the Log4j2 implementation in #6544 but forgot about the 'version lock' in our parent pom.
I've grouped the log dependencies and updated it to the latest version.

Supersedes #6616 which I could not check out due to branch name problems...