### PR TITLE
Clean up SneakyThrows annotations

### DIFF
--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -572,6 +572,7 @@ public class Adapter implements IAdapter, NamedBean {
 			result = pipeline.process(messageId, message, pipeLineSession);
 			return result;
 		} catch (Throwable t) {
+			// TODO: Check if t really can never be instance of ListenerException when caught. (Doesn't look likely, perhaps a SneakyThrows somewhere?)
 			ListenerException e;
 			if (t instanceof ListenerException) {
 				e = (ListenerException) t;

--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -15,6 +15,7 @@
 */
 package org.frankframework.core;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -169,13 +170,11 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	 * The ladybug might stub the MessageId. The Stubbed value will be wrapped in a Message.
 	 * Ensure that a proper string is returned in those cases too.
 	 */
-	@SneakyThrows
 	@Nullable
 	public String getMessageId() {
 		return getString(MESSAGE_ID_KEY); // Allow Ladybug to wrap it in a Message
 	}
 
-	@SneakyThrows
 	@Nullable
 	public String getCorrelationId() {
 		return getString(CORRELATION_ID_KEY); // Allow Ladybug to wrap it in a Message
@@ -284,7 +283,7 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	 * @return Value of the session key as String, or NULL of either the key was not present or had a NULL value.
 	 */
 	@Nullable
-	@SneakyThrows
+	@SneakyThrows(IOException.class)
 	public String getString(@Nonnull String key) {
 		Object obj = get(key);
 		if (obj == null) {

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
@@ -112,7 +112,7 @@ public class MessageStoreSender extends JdbcTransactionalStorage<String> impleme
 	 * @param message Message to convert
 	 * @return String of the message.
 	 */
-	@SneakyThrows
+	@SneakyThrows(IOException.class)
 	private String messageAsString(Message message) {
 		return message.asString();
 	}

--- a/core/src/main/java/org/frankframework/jms/JMSFacade.java
+++ b/core/src/main/java/org/frankframework/jms/JMSFacade.java
@@ -427,7 +427,7 @@ public class JMSFacade extends JndiBase implements HasPhysicalDestination, IXAEn
 		return destinations.computeIfAbsent(destinationName, this::computeDestination);
 	}
 
-	@SneakyThrows
+	@SneakyThrows({JMSException.class, JmsException.class, NamingException.class})
 	private Destination computeDestination(String destinationName) {
 		Destination result;
 		if (StringUtils.isEmpty(destinationName)) {

--- a/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
@@ -638,7 +638,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender {
 				});
 	}
 
-	@SneakyThrows
+	@SneakyThrows({PipeRunException.class}) // SneakyThrows because it's used in a Lambda
 	private Message loadMessageFromClasspathResource(final String stubFileName) {
 		Message result;
 		try {

--- a/core/src/main/java/org/frankframework/pipes/RemoveFromSession.java
+++ b/core/src/main/java/org/frankframework/pipes/RemoveFromSession.java
@@ -92,7 +92,7 @@ public class RemoveFromSession extends FixedForwardPipe {
 		return new PipeRunResult(getSuccessForward(), result);
 	}
 
-	@SneakyThrows
+	@SneakyThrows(PipeRunException.class) // SneakyThrows because the method is called from a Lambda
 	private String objectToString(final Object skResult) {
 		try {
 			return Message.asString(skResult);

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
@@ -1,11 +1,13 @@
 package org.frankframework.http.cxf;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.ws.WebServiceContext;
 
+import lombok.Getter;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
@@ -18,13 +20,13 @@ public class SoapProviderStub extends SOAPProviderBase {
 		this.webServiceContext = context;
 	}
 
-	PipeLineSession session = null;
+	@Getter PipeLineSession session = null;
 
 	final Map<String, Message> sessionCopy = new HashMap<>();
 
 	@Override
-	@SneakyThrows
-	Message processRequest(Message message, PipeLineSession pipelineSession) throws ListenerException {
+	@SneakyThrows(IOException.class)
+	Message processRequest(Message message, PipeLineSession pipelineSession) {
 		if(session != null) {
 			pipelineSession.putAll(session);
 			session.getCloseables().clear();
@@ -41,10 +43,6 @@ public class SoapProviderStub extends SOAPProviderBase {
 
 	public void setSession(PipeLineSession session) {
 		this.session = session;
-	}
-
-	public PipeLineSession getSession() {
-		return session;
 	}
 
 	public Message getMessageFromSessionCopy(String key) {

--- a/core/src/test/java/org/frankframework/monitoring/MessageCapturingEchoSender.java
+++ b/core/src/test/java/org/frankframework/monitoring/MessageCapturingEchoSender.java
@@ -1,5 +1,7 @@
 package org.frankframework.monitoring;
 
+import java.io.IOException;
+
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
@@ -16,7 +18,7 @@ class MessageCapturingEchoSender extends EchoSender {
 	private @Getter String sessionOriginalMessageValue;
 
 	@Override
-	@SneakyThrows
+	@SneakyThrows(IOException.class)
 	public SenderResult sendMessage(Message message, PipeLineSession session) throws SenderException, TimeoutException {
 		inputMessage = message;
 		inputSession = session;

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -78,6 +78,7 @@ import org.frankframework.core.PipeLine.ExitState;
 import org.frankframework.core.PipeLineExit;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.SenderException;
 import org.frankframework.core.TransactionAttribute;
 import org.frankframework.jdbc.JdbcTransactionalStorage;
 import org.frankframework.jdbc.MessageStoreListener;
@@ -314,7 +315,7 @@ public class ReceiverTest {
 
 		final Semaphore semaphore = new Semaphore(0);
 		Thread mockListenerThread = new Thread("mock-listener-thread") {
-			@SneakyThrows
+			@SneakyThrows({SenderException.class, IllegalAccessException.class, IllegalArgumentException.class})
 			@Override
 			public void run() {
 				try {
@@ -451,7 +452,7 @@ public class ReceiverTest {
 
 		final Semaphore semaphore = new Semaphore(0);
 		Thread mockListenerThread = new Thread("mock-listener-thread") {
-			@SneakyThrows
+			@SneakyThrows({SenderException.class, IllegalArgumentException.class, IllegalAccessException.class})
 			@Override
 			public void run() {
 				try {

--- a/core/src/test/java/org/frankframework/testutil/TestFileUtils.java
+++ b/core/src/test/java/org/frankframework/testutil/TestFileUtils.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 
@@ -59,11 +60,10 @@ public class TestFileUtils {
 		return string.toString();
 	}
 
-	@SneakyThrows
+	@SneakyThrows(URISyntaxException.class)
 	public static String getTestFilePath(String string) {
 		URL url = getTestFileURL(string);
 		assertNotNull(url);
 		return Paths.get(url.toURI()).toString();
 	}
-
 }

--- a/filesystem/src/main/java/org/frankframework/filesystem/FileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/FileSystemListener.java
@@ -261,7 +261,8 @@ public abstract class FileSystemListener<F, FS extends IBasicFileSystem<F>> impl
 		}
 	}
 
-	private Optional<F> findFirstStableFile(Stream<F> ds) {
+	// Can throw FileSystemException from a Lambda
+	private Optional<F> findFirstStableFile(Stream<F> ds) throws FileSystemException {
 		long stabilityLimit = getMinStableTime();
 		if (stabilityLimit <= 0L) {
 			return ds.findFirst();
@@ -272,7 +273,7 @@ public abstract class FileSystemListener<F, FS extends IBasicFileSystem<F>> impl
 				.findFirst();
 	}
 
-	@SneakyThrows
+	@SneakyThrows(FileSystemException.class) // SneakyThrows because it's used in a Lambda
 	private boolean isFileOlderThan(F file, long timeInMillis) {
 		long filemodtime=fileSystem.getModificationTime(file).getTime();
 		return filemodtime <= timeInMillis;

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/MessageEncoder.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/MessageEncoder.java
@@ -80,7 +80,7 @@ public class MessageEncoder extends MessageEncoderImpl {
 	}
 
 	@Override
-	@SneakyThrows
+	@SneakyThrows(IOException.class)
 	public <T> T toObject(Checkpoint originalCheckpoint, T messageToStub) {
 		if (messageToStub instanceof Message message) {
 			// In case a stream is stubbed the replaced stream needs to be closed as next pipe will read and close the


### PR DESCRIPTION
Make all `@SneakyThrows` annotations explicit about the exceptions that could be thrown from the annotated methods to make it easier to trace what could be thrown.