### PR TITLE
Revert FF!Test docker version in .env to 8.2.0-SNAPSHOT

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,3 +1,3 @@
 # Properties for Docker Compose
 
-VERSION=8.2.0-20240423.042425
+VERSION=8.2.0-SNAPSHOT


### PR DESCRIPTION
I've accidentally committed a wrong version while testing.