### PR TITLE
In FF! keep one character more when truncating then in Ladybug

### DIFF
--- a/ladybug/src/main/java/org/frankframework/ibistesttool/Constants.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/Constants.java
@@ -1,3 +1,18 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package org.frankframework.ibistesttool;
 
 public class Constants {

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/Constants.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/Constants.java
@@ -1,0 +1,12 @@
+package org.frankframework.ibistesttool;
+
+public class Constants {
+	private Constants() {}
+
+	// Both Ladybug and the FF! truncate messages as configured through
+	// maxMessageLength. In this class we keep one character more such that
+	// Ladybug can detect when a message is being truncated. This way,
+	// Ladybug can show a message in its GUI that a report message has been
+	// truncated.
+	static final int MAX_MESSAGE_LENGTH_ADJUSTMENT = 1;
+}

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/MessageCapturer.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/MessageCapturer.java
@@ -35,15 +35,11 @@ public class MessageCapturer extends MessageCapturerImpl implements Initializing
 
 	private @Autowired int maxMessageLength;
 
-	// Both Ladybug and the present class in the Frank!Framework
-	// truncate messages as configured through maxMessageLength.
-	// In this class we keep one character more such that
-	// Ladybug can detect when a message is being truncated.
 	private int truncateMessageToLength = -1;
 
 	@Override
 	public void afterPropertiesSet() {
-		truncateMessageToLength = maxMessageLength + 1;
+		truncateMessageToLength = maxMessageLength + Constants.MAX_MESSAGE_LENGTH_ADJUSTMENT;
 	}
 
 	@Override

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/MessageEncoder.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/MessageEncoder.java
@@ -36,15 +36,11 @@ public class MessageEncoder extends MessageEncoderImpl implements InitializingBe
 
 	private @Autowired int maxMessageLength;
 
-	// Both Ladybug and the present class in the Frank!Framework
-	// truncate messages as configured through maxMessageLength.
-	// In this class we keep one character more such that
-	// Ladybug can detect when a message is being truncated.
 	private int truncateMessageToLength = -1;
 
 	@Override
 	public void afterPropertiesSet() {
-		truncateMessageToLength = maxMessageLength + 1;
+		truncateMessageToLength = maxMessageLength + Constants.MAX_MESSAGE_LENGTH_ADJUSTMENT;
 	}
 
 	@Override


### PR DESCRIPTION
Both the Frank!Framework's ladybug module and ladybug itself truncate messages when they are too long. Because the F!F does the truncation first, Ladybug does not see that truncation was necessary. Because of this, Ladybug did not report that a report message was truncated.

This PR lets the F!F keep one extra character such that Ladybug does reduce the message size when truncation is needed. With this PR, the old Ladybug GUI does show it when truncation has been done:

![messageTruncatedOldLadybug](https://github.com/frankframework/frankframework/assets/6784732/dd4d1161-f571-4d30-a8ba-4064748a29d2)

The new Ladybug GUI does not show truncation even with the present PR included in the F!F, see:

![messageTruncatedNewLadybug](https://github.com/frankframework/frankframework/assets/6784732/15362c19-c24c-414f-ba33-d088744e7a6d)
