### PR TITLE
Revert mariadb.driver.version to 2.7.10 because it fails with BTM

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,9 @@ Requires JDK 11 or later, tested on JDK 11, 17 and 21.
 Package `nl.nn.adapterframework` is renamed to `org.frankframework`.
 Removed many deprecated features.
 
+### Known Issues
+- Tomcat with BTM Transaction Manager does not work in combination with MariaDB. Fixed in v8.0.2 or later. This issue does not appear with other supported databases.
+
 ### Non backwards compatible changes
 - CreateRestViewPipe has been removed. It is no longer possible to open the old (blue) user interface.
 - IBulkDataListener has been removed. This feature was only supported through custom listeners and not tested.

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<mssql.driver.version>12.4.2.jre11</mssql.driver.version>
 		<mysql.driver.version>8.2.0</mysql.driver.version>
 		<!-- Should upgrade to new MariaDB driver 3.1.4, 3.2.0 or newer for JDK17 support but currently not working with XA transaction managers in the framework. -->
-		<mariadb.driver.version>3.3.2</mariadb.driver.version>
+		<mariadb.driver.version>2.7.10</mariadb.driver.version>
 		<postgresql.driver.version>42.7.2</postgresql.driver.version>
 		<mongodb.driver.version>4.11.1</mongodb.driver.version>
 


### PR DESCRIPTION
It was broken since `d156a3eb` 07/11/2023 at 16:58h, since we've upgraded the mariadb driver, for the combination: MariaDB, Tomcat-BTM, ActiveMQ/ArtemisMQ 