### PR TITLE
Backport param substitution

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@ Requires JDK 17 or later, tested on JDK 17 and 21.
 
 ### Non backwards compatible changes
 - Larva package is renamed from `testtool` to `larva`. References inside the Larva property files to the `testtool` package should be updated to larva. Such as: `org.frankframework.testtool.FileSender` -> `org.frankframework.larva.FileSender`. It still works with the old package name in 8.1, as a compatibility feature.
+- By default the PipelineSession substitution delimiter has been changed from `${` to `?{` so it's consistent with the `FixedQuerySender`. Backwards compatibility key `useOldSubstitutionStartDelimiter` has been added so minimal change is required during upgrades. Note that when using caches in combination with `diskPersistent="true"` you may need to purge your cache!
 
 8.0.0 - December 23rd, 2023
 --------------

--- a/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
@@ -56,22 +56,22 @@ import lombok.Getter;
  * <ol>
  * <li>During execution, this pipe first obtains a string based on attributes <code>returnString</code>, <code>filename</code> or <code>filenameSessionKey</code>.</li>
  * <li>The resulting string is transformed according to attributes <code>replaceFrom</code> and <code>replaceTo</code> if set.
- * Please note that the plain value of attribute <code>replaceFrom</code> is matched, no <code>${...}</code> here.</li>
+ * Please note that the plain value of attribute <code>replaceFrom</code> is matched, no <code>?{...}</code> here.</li>
  * <li>The resulting string is substituted based on the parameters of this pipe. This step depends on attribute <code>replaceFixedParams</code>.
  * Assume that there is a parameter with name <code>xyz</code>. If <code>replaceFixedParams</code> is <code>false</code>, then
- * each occurrence of <code>${xyz}</code> is replaced by the parameter's value. Otherwise, the text <code>xyz</code>
+ * each occurrence of <code>?{xyz}</code> is replaced by the parameter's value. Otherwise, the text <code>xyz</code>
  * is substituted. See {@link Parameter} to see how parameter values are determined.</li>
- * <li>If attribute <code>substituteVars</code> is <code>true</code>, then expressions <code>${...}</code> are substituted using
+ * <li>If attribute <code>substituteVars</code> is <code>true</code>, then expressions <code>?{...}</code> are substituted using
  * system properties, pipelinesession variables and application properties. Please note that
- * no <code>${...}</code> patterns are left if the initial string came from attribute <code>returnString</code>, because
- * any <code>${...}</code> pattern in attribute <code>returnString</code> is substituted when the configuration is loaded.</li>
+ * no <code>?{...}</code> patterns are left if the initial string came from attribute <code>returnString</code>, because
+ * any <code>?{...}</code> pattern in attribute <code>returnString</code> is substituted when the configuration is loaded.</li>
  * <li>If attribute <code>styleSheetName</code> is set, then the referenced XSLT stylesheet is applied to the resulting string.</li>
  * </ol>
  * <br/>
  * Many attributes of this pipe reference file names. If a file is referenced by a relative path, the path
  * is relative to the configuration's root directory.
  *
- * @ff.parameters Used for substitution. For a parameter named <code>xyz</code>, the string <code>${xyz}</code> or
+ * @ff.parameters Used for substitution. For a parameter named <code>xyz</code>, the string <code>?{xyz}</code> or
  * <code>xyz</code> (if <code>replaceFixedParams</code> is true) is substituted by the parameter's value.
  *
  * @ff.forward filenotfound the configured file was not found (when this forward isn't specified an exception will be thrown)
@@ -174,7 +174,7 @@ public class FixedResultPipe extends FixedForwardPipe {
 					if (isReplaceFixedParams()) {
 						replaceFrom=pv.getName();
 					} else {
-						replaceFrom="${"+pv.getName()+"}";
+						replaceFrom="?{"+pv.getName()+"}";
 					}
 					String to = pv.asStringValue("");
 					result= result.replace(replaceFrom, to);
@@ -204,7 +204,7 @@ public class FixedResultPipe extends FixedForwardPipe {
 	}
 
 	/**
-	 * Should values between ${ and } be resolved. If true, the search order of replacement values is:
+	 * Should values between ?{ and } be resolved. If true, the search order of replacement values is:
 	 * system properties (1), pipelinesession variables (2), application properties (3).
 	 *
 	 * @ff.default false
@@ -256,7 +256,7 @@ public class FixedResultPipe extends FixedForwardPipe {
 	}
 
 	/**
-	 * When set <code>true</code>, parameter replacement matches <code>name-of-parameter</code>, not <code>${name-of-parameter}</code>
+	 * When set <code>true</code>, parameter replacement matches <code>name-of-parameter</code>, not <code>?{name-of-parameter}</code>
 	 *
 	 * @ff.default false
 	 */

--- a/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
@@ -58,14 +58,16 @@ import lombok.Getter;
  * <li>During execution, this pipe first obtains a string based on attributes <code>returnString</code>, <code>filename</code> or <code>filenameSessionKey</code>.</li>
  * <li>The resulting string is transformed according to attributes <code>replaceFrom</code> and <code>replaceTo</code> if set.
  * Please note that the plain value of attribute <code>replaceFrom</code> is matched, no <code>?{...}</code> here.</li>
+ * 
  * <li>The resulting string is substituted based on the parameters of this pipe. This step depends on attribute <code>replaceFixedParams</code>.
  * Assume that there is a parameter with name <code>xyz</code>. If <code>replaceFixedParams</code> is <code>false</code>, then
  * each occurrence of <code>?{xyz}</code> is replaced by the parameter's value. Otherwise, the text <code>xyz</code>
  * is substituted. See {@link Parameter} to see how parameter values are determined.</li>
- * <li>If attribute <code>substituteVars</code> is <code>true</code>, then expressions <code>?{...}</code> are substituted using
+ * 
+ * <li>If attribute <code>substituteVars</code> is <code>true</code>, then expressions <code>${...}</code> are substituted using
  * system properties, pipelinesession variables and application properties. Please note that
- * no <code>?{...}</code> patterns are left if the initial string came from attribute <code>returnString</code>, because
- * any <code>?{...}</code> pattern in attribute <code>returnString</code> is substituted when the configuration is loaded.</li>
+ * no <code>${...}</code> patterns are left if the initial string came from attribute <code>returnString</code>, because
+ * any <code>${...}</code> pattern in attribute <code>returnString</code> is substituted when the configuration is loaded.</li>
  * <li>If attribute <code>styleSheetName</code> is set, then the referenced XSLT stylesheet is applied to the resulting string.</li>
  * </ol>
  * <br/>
@@ -205,8 +207,8 @@ public class FixedResultPipe extends FixedForwardPipe {
 	}
 
 	/**
-	 * Should values between ?{ and } be resolved. If true, the search order of replacement values is:
-	 * system properties (1), pipelinesession variables (2), application properties (3).
+	 * Should values between ${ and } be resolved. If true, the search order of replacement values is:
+	 * system properties (1), PipelineSession variables (2), application properties (3).
 	 *
 	 * @ff.default false
 	 */

--- a/core/src/test/java/org/frankframework/pipes/FixedResultTest.java
+++ b/core/src/test/java/org/frankframework/pipes/FixedResultTest.java
@@ -40,7 +40,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		pipe.setFilename(sourceFolderPath);
 		pipe.setReplaceFrom("param1");
 		pipe.setReplaceTo("kar");
-		pipe.setReturnString("${param1}andandandparam2");
+		pipe.setReturnString("?{param1}andandandparam2");
 		pipe.configure();
 		PipeRunResult res = doPipe(pipe, "whatisthis", session);
 		assertEquals("inside the file", res.getResult().asString());
@@ -53,7 +53,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		pipe.setFilename(sourceFolderPath + "/something");
 		pipe.setReplaceFrom("param1");
 		pipe.setReplaceTo("kar");
-		pipe.setReturnString("${param1}andandandparam2");
+		pipe.setReturnString("?{param1}andandandparam2");
 
 		ConfigurationException e = assertThrows(ConfigurationException.class, this::configurePipe);
 		assertThat(e.getMessage(), Matchers.endsWith("cannot find resource [/Pipes/2.txt/something]"));
@@ -73,7 +73,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		pipe.setStyleSheetName("/Xslt/importNotFound/name.xsl");
 		pipe.setReplaceFrom("param1");
 		pipe.setReplaceTo("kar");
-		pipe.setReturnString("${param1}andandandparam2");
+		pipe.setReturnString("?{param1}andandandparam2");
 		pipe.configure();
 		PipeRunResult res = doPipe(pipe, "whatisthis", session);
 		assertEquals("success", res.getPipeForward().getName());
@@ -86,7 +86,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		pipe.setStyleSheetName("/Xslt/importNotFound/name2.xsl");
 		pipe.setReplaceFrom("param1");
 		pipe.setReplaceTo("kar");
-		pipe.setReturnString("${param1}andandandparam2");
+		pipe.setReturnString("?{param1}andandandparam2");
 		pipe.configure();
 
 		PipeRunException e = assertThrows(PipeRunException.class, ()->doPipe(pipe, "whatisthis", session));
@@ -101,7 +101,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		pipe.setStyleSheetName("/Xslt/extract.xslt");
 		pipe.setReplaceFrom("param1");
 		pipe.setReplaceTo("param");
-		pipe.setReturnString("${param1}");
+		pipe.setReturnString("?{param1}");
 		pipe.configure();
 
 		PipeRunResult res = doPipe(pipe, "dummy", session);
@@ -182,7 +182,7 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 		param.setDefaultValue("DefaultValue");
 		pipe.addParameter(param);
 
-		pipe.setReturnString("This is replaceFrom ${param}");
+		pipe.setReturnString("This is replaceFrom ?{param}");
 		pipe.setReplaceFrom("replaceFrom");
 		pipe.setReplaceTo("replaceTo");
 		pipe.configure();

--- a/core/src/test/java/org/frankframework/pipes/FixedResultTest.java
+++ b/core/src/test/java/org/frankframework/pipes/FixedResultTest.java
@@ -193,6 +193,21 @@ public class FixedResultTest extends PipeTestBase<FixedResultPipe> {
 	}
 
 	@Test
+	public void substitudeVarsOld() throws Exception{
+		Parameter param = ParameterBuilder.create().withName("param");
+		param.setDefaultValue("DefaultValue");
+		pipe.addParameter(param);
+
+		pipe.setReturnString("This is ${param}");
+		pipe.setUseOldSubstitutionStartDelimiter(true);
+		pipe.configure();
+
+		PipeRunResult res = doPipe(pipe, "propValueFromInput", session);
+		assertEquals("success", res.getPipeForward().getName());
+		assertEquals("This is propValueFromInput", res.getResult().asString());
+	}
+
+	@Test
 	public void substitudeVarsInCombinationOfReplacePairWithReplaceFixedParams() throws Exception{
 		Parameter param = ParameterBuilder.create().withName("param");
 		param.setDefaultValue("DefaultValue");

--- a/core/src/test/resources/FixedResult/fixedResultPipeInput.txt
+++ b/core/src/test/resources/FixedResult/fixedResultPipeInput.txt
@@ -1,1 +1,1 @@
-Hello ${myprop}
+Hello ?{myprop}

--- a/test/src/main/configurations/MainConfig/ConfigurationParameters.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationParameters.xml
@@ -47,6 +47,16 @@
 				<forward name="success" path="EXIT" />
 			</pipe>
 
+			<pipe name="FixedParamSubstitution" className="org.frankframework.pipes.FixedResultPipe" returnString="result [param]" replaceFixedParams="true">
+				<param name="param" value="xyz" />
+				<forward name="success" path="EXIT" />
+			</pipe>
+
+			<pipe name="ParamSubstitution" className="org.frankframework.pipes.FixedResultPipe" returnString="result [?{param}]">
+				<param name="param" value="xyz" />
+				<forward name="success" path="EXIT" />
+			</pipe>
+
 		</pipeline>
 	</adapter>
 </module>

--- a/test/src/main/configurations/MainConfig/cache/resultTemplate.xml
+++ b/test/src/main/configurations/MainConfig/cache/resultTemplate.xml
@@ -1,3 +1,3 @@
 <result>
-	<input>${input}</input>
+	<input>?{input}</input>
 </result>

--- a/test/src/test/testtool/Parameters/scenario06.properties
+++ b/test/src/test/testtool/Parameters/scenario06.properties
@@ -1,0 +1,6 @@
+scenario.description = Parameters - Substitute 'fixed' param (FixedQuerySender style)
+
+include = common.properties
+
+step1.java.Parameters.write = scenario06/in.xml
+step2.java.Parameters.read  = scenario06/out.txt

--- a/test/src/test/testtool/Parameters/scenario06/in.xml
+++ b/test/src/test/testtool/Parameters/scenario06/in.xml
@@ -1,0 +1,1 @@
+<request action="FixedParamSubstitution" />

--- a/test/src/test/testtool/Parameters/scenario06/out.txt
+++ b/test/src/test/testtool/Parameters/scenario06/out.txt
@@ -1,0 +1,1 @@
+result [xyz]

--- a/test/src/test/testtool/Parameters/scenario07.properties
+++ b/test/src/test/testtool/Parameters/scenario07.properties
@@ -1,0 +1,6 @@
+scenario.description = Parameters - Substitute normal param (FixedQuerySender style)
+
+include = common.properties
+
+step1.java.Parameters.write = scenario07/in.xml
+step2.java.Parameters.read  = scenario07/out.txt

--- a/test/src/test/testtool/Parameters/scenario07/in.xml
+++ b/test/src/test/testtool/Parameters/scenario07/in.xml
@@ -1,0 +1,1 @@
+<request action="ParamSubstitution" />

--- a/test/src/test/testtool/Parameters/scenario07/out.txt
+++ b/test/src/test/testtool/Parameters/scenario07/out.txt
@@ -1,0 +1,1 @@
+result [xyz]


### PR DESCRIPTION
By default the PipelineSession substitution delimiter has been changed from `${` to `?{` so it's consistent with the `FixedQuerySender`. Backwards compatibility key `useOldSubstitutionStartDelimiter` has been added so minimal change is required during upgrades. Note that when using caches in combination with `diskPersistent="true"` you may need to purge your cache!