### PR TITLE
Remove leftover javax.annotation imports

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -23,6 +23,11 @@
 			junit.framework,
 			org.apache.commons.lang,
 			software.amazon.awssdk.utils,
+			javax.activation
+			javax.annotation,
+			javax.jms,
+			javax.servlet,
+			javax.ws,
 			" />
 			<property name="illegalClasses" value="
 			org.apache.commons.codec.Charsets,

--- a/core/src/main/java/org/frankframework/configuration/AdapterManager.java
+++ b/core/src/main/java/org/frankframework/configuration/AdapterManager.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;

--- a/core/src/main/java/org/frankframework/jdbc/datasource/DataSourceFactory.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/DataSourceFactory.java
@@ -18,8 +18,8 @@ package org.frankframework.jdbc.datasource;
 import java.util.List;
 import java.util.Properties;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import javax.sql.CommonDataSource;
 import javax.sql.DataSource;
 

--- a/core/src/main/java/org/frankframework/jdbc/datasource/FrankResources.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/FrankResources.java
@@ -22,8 +22,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import javax.sql.DataSource;
 
 import org.apache.commons.lang3.StringUtils;

--- a/core/src/main/java/org/frankframework/jdbc/datasource/TransactionalDbmsSupportAwareDataSourceProxy.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/TransactionalDbmsSupportAwareDataSourceProxy.java
@@ -21,7 +21,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
@@ -28,7 +28,7 @@ import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import lombok.Getter;
 import lombok.Setter;


### PR DESCRIPTION
Fix some methods that still used imports from javax.annotation. Ban these imports in Checkstyle, along with some other imports from former javax packages.