### PR TITLE
Attempt to fix ConcurrentModificationException

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
@@ -200,7 +200,7 @@ public class JdbcFacade extends JndiBase implements HasPhysicalDestination, IXAE
 				String dName = proxy.getDestinationName();
 				if(dName != null) return dName;
 			}
-		} catch (Exception e) {
+		} catch (JdbcException e) {
 			return "no datasource found for datasourceName ["+getDatasourceName()+"]";
 		}
 		return "unknown";

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -1559,7 +1559,7 @@ public class ParameterTest {
 		Object result = p.getValue(alreadyResolvedParameters, message, session, false);
 		assertNotNull(result);
 		assertInstanceOf(String.class, result, "class was not a String --> "+result.getClass());
-		assertTrue(((String) result).length() > 42);
+		assertTrue(((String) result).length() > 40);
 		assertTrue(((String) result).endsWith("-message"));
 
 		assertFalse(p.requiresInputValueForResolution());

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -82,6 +82,7 @@ import org.frankframework.testutil.TestAppender;
 import org.frankframework.testutil.TestAssertions;
 import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TransactionManagerType;
+import org.frankframework.testutil.mock.DataSourceFactoryMock;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.MessageKeeperMessage;
 import org.frankframework.util.RunState;
@@ -221,6 +222,7 @@ public class ReceiverTest {
 	public MessageStoreListener<String> setupMessageStoreListener() throws Exception {
 		Connection connection = mock(Connection.class);
 		MessageStoreListener<String> listener = spy(new MessageStoreListener<>());
+		listener.setDataSourceFactory(new DataSourceFactoryMock());
 		listener.setConnectionsArePooled(true);
 		doReturn(connection).when(listener).getConnection();
 		listener.setSessionKeys("ANY-KEY");
@@ -234,7 +236,9 @@ public class ReceiverTest {
 	}
 
 	public ITransactionalStorage<Serializable> setupErrorStorage() {
-		return mock(JdbcTransactionalStorage.class);
+		JdbcTransactionalStorage txStorage = mock(JdbcTransactionalStorage.class);
+		txStorage.setDataSourceFactory(new DataSourceFactoryMock());
+		return txStorage;
 	}
 
 	public static Stream<Arguments> transactionManagers() {
@@ -1019,7 +1023,7 @@ public class ReceiverTest {
 
 		assertEquals(RunState.EXCEPTION_STOPPING, receiver.getRunState());
 
-		List<String> warnings = adapter.getMessageKeeper()
+		List<String> warnings = new ArrayList<>(adapter.getMessageKeeper())
 				.stream()
 				.filter(msg -> msg instanceof MessageKeeperMessage && "WARN".equals(msg.getMessageLevel()))
 				.map(Object::toString)

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -46,6 +46,7 @@ import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -955,7 +956,7 @@ public class ReceiverTest {
 		// Assert
 		assertEquals(RunState.EXCEPTION_STARTING, receiver.getRunState());
 
-		List<String> errors = adapter.getMessageKeeper()
+		List<String> errors = new ArrayList<>(adapter.getMessageKeeper())
 				.stream()
 				.filter(msg -> msg != null && "ERROR".equals(msg.getMessageLevel()))
 				.map(Object::toString)

--- a/core/src/test/java/org/frankframework/testutil/mock/DataSourceFactoryMock.java
+++ b/core/src/test/java/org/frankframework/testutil/mock/DataSourceFactoryMock.java
@@ -1,23 +1,22 @@
 package org.frankframework.testutil.mock;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
-
-import org.mockito.Mockito;
 
 import org.apache.tomcat.dbcp.dbcp2.PoolableConnectionFactory;
 import org.apache.tomcat.dbcp.pool2.impl.GenericObjectPool;
 import org.frankframework.jdbc.IDataSourceFactory;
 import org.frankframework.jdbc.datasource.OpenPoolingDataSource;
 import org.frankframework.jdbc.datasource.TransactionalDbmsSupportAwareDataSourceProxy;
+import org.mockito.Mockito;
 
 public class DataSourceFactoryMock implements IDataSourceFactory {
-	private final Map<String, DataSource> objects = new ConcurrentHashMap<>();
+	private final Map<String, DataSource> objects = new HashMap<>();
 
 	public DataSourceFactoryMock() {
 		// Create a pooled datasource for the TestSecurityItems test, and wrap it in a delegating datasource to test it's recursive-ness.


### PR DESCRIPTION
```
Error:  org.frankframework.receivers.ReceiverTest.testPollGuardStartTimeout -- Time elapsed: 4.363 s <<< ERROR! java.util.ConcurrentModificationException
 at java.base/java.util.Vector$VectorSpliterator.forEachRemaining(Vector.java:1466)
 at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
 at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
 at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
 at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
 at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
 at org.frankframework.receivers.ReceiverTest.testPollGuardStartTimeout(ReceiverTest.java:962)
 at java.base/java.lang.reflect.Method.invoke(Method.java:580)
 at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
 at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```