### PR TITLE
Update J2V8 Javascript engine from 4.6.0 to 6.2.1 version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,7 +11,7 @@
 	<name>Frank!Framework core</name>
 
 	<properties>
-		<j2v8.version>6.2.1</j2v8.version>
+		<j2v8.version>4.8.0</j2v8.version><!-- higher versions don't have all the required binaries in maven central -->
 		<saxon.version>10.9</saxon.version><!--From version 11, duplicate imported resources cause an exception. -->
 	</properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,7 +11,7 @@
 	<name>Frank!Framework core</name>
 
 	<properties>
-		<j2v8.version>4.6.0</j2v8.version>
+		<j2v8.version>6.2.1</j2v8.version>
 		<saxon.version>10.9</saxon.version><!--From version 11, duplicate imported resources cause an exception. -->
 	</properties>
 


### PR DESCRIPTION
Just an experiment, which I can not run on my local machine, due to arm64 CPU architecture. 

It sucks: newer dependencies are just not uploaded into maven central 👎🏻 