### PR TITLE
Fix for date parser

### DIFF
--- a/commons/src/main/java/org/frankframework/util/DateFormatUtils.java
+++ b/commons/src/main/java/org/frankframework/util/DateFormatUtils.java
@@ -27,7 +27,6 @@ import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQueries;
 import java.util.Date;
 import java.util.Map;

--- a/commons/src/main/java/org/frankframework/util/DateFormatUtils.java
+++ b/commons/src/main/java/org/frankframework/util/DateFormatUtils.java
@@ -159,6 +159,9 @@ public class DateFormatUtils {
 
 	public static java.time.LocalDate parseToLocalDate(String dateString) throws DateTimeParseException {
 		DateTimeFormatter parser = determineDateFormat(dateString);
+		if (parser == null) {
+			throw new IllegalArgumentException("Cannot determine date-format for input [" + dateString + "]");
+		}
 		return parser.parse(dateString, TemporalQueries.localDate());
 	}
 

--- a/commons/src/test/java/org/frankframework/util/DateFormatUtilsTest.java
+++ b/commons/src/test/java/org/frankframework/util/DateFormatUtilsTest.java
@@ -1,11 +1,13 @@
 package org.frankframework.util;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
@@ -101,6 +103,26 @@ public class DateFormatUtilsTest {
 	@Test
 	public void unableToParseFullGenericWithoutTime() {
 		assertThrows(DateTimeParseException.class, ()-> DateFormatUtils.parseToInstant("2000-01-01", DateFormatUtils.FULL_GENERIC_FORMATTER));
+	}
+
+	@Test
+	public void testParseToLocalDate() {
+		LocalDate localDate = DateFormatUtils.parseToLocalDate("2024-05-16");
+		assertAll(
+			()->assertEquals(2024, localDate.getYear()),
+			()->assertEquals(Month.MAY, localDate.getMonth()),
+			()->assertEquals(16, localDate.getDayOfMonth())
+		);
+	}
+
+	@Test
+	public void testParseLocalDateInvalidDatePattern() {
+		assertThrows(IllegalArgumentException.class, ()->DateFormatUtils.parseToLocalDate("not a date"));
+	}
+
+	@Test
+	public void testParseGenericDateInvalidDatePattern() {
+		assertThrows(IllegalArgumentException.class, ()->DateFormatUtils.parseGenericDate("not a date"));
 	}
 
 	@Test

--- a/commons/src/test/java/org/frankframework/util/DateFormatUtilsTest.java
+++ b/commons/src/test/java/org/frankframework/util/DateFormatUtilsTest.java
@@ -127,6 +127,12 @@ public class DateFormatUtilsTest {
 	}
 
 	@Test
+	public void testParseAnyDate5() {
+		Date date = DateFormatUtils.parseAnyDate("2013-12-10");
+		assertEquals(1386633600000L, date.getTime());
+	}
+
+	@Test
 	public void testParseGenericDate1() {
 		assertThrows(IllegalArgumentException.class, ()-> DateFormatUtils.parseGenericDate("12-2013-10"));
 	}
@@ -151,6 +157,12 @@ public class DateFormatUtilsTest {
 	public void testParseGenericDate4() throws Exception {
 		Instant date = DateFormatUtils.parseGenericDate("2013-12-10T12:41:43");
 		assertEquals(adjustForTimezone(1386679303000L), date.toEpochMilli());
+	}
+
+	@Test
+	public void testParseGenericDate5() throws Exception {
+		Instant date = DateFormatUtils.parseGenericDate("2013-12-10");
+		assertEquals(1386633600000L, date.toEpochMilli());
 	}
 
 


### PR DESCRIPTION
This is fix for date-parsing issue for 8.0.

It should be straightforward forward-port the change to 8.1 and master.

7.9 is not affected.