### PR TITLE
Ensure all CXF endpoints are loaded as Servlet instead of a Filter

### DIFF
--- a/cmis/src/main/java/org/frankframework/extensions/cmis/servlets/WebServicesServletBase.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/servlets/WebServicesServletBase.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018-2020 Nationale-Nederlanden, 2022-2023 WeAreFrank!
+   Copyright 2018-2020 Nationale-Nederlanden, 2022-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,12 +15,18 @@
 */
 package org.frankframework.extensions.cmis.servlets;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.chemistry.opencmis.server.impl.webservices.CmisWebServicesServlet;
-
+import org.frankframework.http.HttpServletBase;
 import org.frankframework.lifecycle.DynamicRegistration;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 
 /**
  * It is important that we register the correct CXF bus, or else
@@ -28,18 +34,37 @@ import org.frankframework.lifecycle.DynamicRegistration;
  *
  * @author Niels Meijer
  */
-public abstract class WebServicesServletBase extends CmisWebServicesServlet implements DynamicRegistration.ServletWithParameters {
+public abstract class WebServicesServletBase extends HttpServletBase implements DynamicRegistration.ServletWithParameters {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
+	private transient CmisWebServicesServlet servlet;
 	protected abstract String getCmisVersion();
+
+	@Override
+	public void init(ServletConfig config) throws ServletException {
+		servlet = new CmisWebServicesServlet();
+		servlet.init(config);
+		super.init(config);
+	}
+
+	@Override
+	public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+		servlet.service(req, res);
+	}
 
 	@Override
 	public Map<String, String> getParameters() {
 		Map<String, String> returnMap = new HashMap<>();
-		returnMap.put(PARAM_CMIS_VERSION, getCmisVersion());
+		returnMap.put(CmisWebServicesServlet.PARAM_CMIS_VERSION, getCmisVersion());
 
 		return returnMap;
+	}
+
+	@Override
+	public void destroy() {
+		servlet.destroy();
+		super.destroy();
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/cxf/FrankCXFServlet.java
+++ b/core/src/main/java/org/frankframework/http/cxf/FrankCXFServlet.java
@@ -1,0 +1,44 @@
+/*
+   Copyright 2022 - 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.cxf;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.transport.servlet.CXFServlet;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class FrankCXFServlet extends CXFServlet {
+
+	@Override
+	public void setBus(Bus bus) {
+		if(bus != null) {
+			String busInfo = "Successfully created %s with SpringBus [%s]".formatted(getServletName(), bus.getId());
+			log.info(busInfo);
+			getServletContext().log(busInfo);
+		}
+
+		super.setBus(bus);
+	}
+
+	@Override
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		// This event listens to all Spring refresh events.
+		// When adding new Spring contexts (with this as a parent) refresh events originating from other contexts will also trigger this method.
+		// Since we never want to reinitialize this servlet, we can ignore the 'refresh' event completely!
+	}
+}

--- a/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
+++ b/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022 - 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,44 +15,44 @@
 */
 package org.frankframework.http.cxf;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.cxf.Bus;
-import org.apache.cxf.transport.servlet.CXFServlet;
-import org.apache.logging.log4j.Logger;
-import org.springframework.context.event.ContextRefreshedEvent;
-
+import org.frankframework.http.HttpServletBase;
 import org.frankframework.lifecycle.DynamicRegistration;
 import org.frankframework.lifecycle.IbisInitializer;
-import org.frankframework.util.LogUtil;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 
 @IbisInitializer
-public class SoapProviderServlet extends CXFServlet implements DynamicRegistration.ServletWithParameters {
-	private Logger log = LogUtil.getLogger(this);
-
+public class SoapProviderServlet extends HttpServletBase implements DynamicRegistration.ServletWithParameters {
+	private transient FrankCXFServlet servlet;
 
 	@Override
-	public void setBus(Bus bus) {
-		if(bus != null) {
-			String busInfo = "Successfully created %s with SpringBus [%s]".formatted(getName(), bus.getId());
-			log.info(busInfo);
-			getServletContext().log(busInfo);
-		}
-
-		super.setBus(bus);
+	public void init(ServletConfig config) throws ServletException {
+		servlet = new FrankCXFServlet();
+		servlet.init(config);
+		super.init(config);
 	}
 
 	@Override
-	public void onApplicationEvent(ContextRefreshedEvent event) {
-		// This event listens to all Spring refresh events.
-		// When adding new Spring contexts (with this as a parent) refresh events originating from other contexts will also trigger this method.
-		// Since we never want to reinitialize this servlet, we can ignore the 'refresh' event completely!
+	public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+		servlet.service(req, res);
 	}
 
 	@Override
 	public String[] getAccessGrantingRoles() {
 		return IBIS_FULL_SERVICE_ACCESS_ROLES;
+	}
+
+	@Override
+	public void destroy() {
+		servlet.destroy();
+		super.destroy();
 	}
 
 	@Override
@@ -63,8 +63,8 @@ public class SoapProviderServlet extends CXFServlet implements DynamicRegistrati
 	@Override
 	public Map<String, String> getParameters() {
 		Map<String, String> parameters = new HashMap<>();
-//		parameters.put("config-location", "/WEB-INF/cxf-servlet.xml"); //Default CXF Spring config
 		parameters.put("bus", "cxf"); //Default bus
 		return parameters;
 	}
+
 }


### PR DESCRIPTION
Since Spring Boot 3.x all filter beans are picked up and loaded first, and for some reason the magnificent CXF people decided that their 'CXFServlet' class can sercretly behave as a filter as well. This breaks the load order as well the way initParameters are loaded, so for us this is a big no-go. Wrapping it in a class that only implements servlet (and not filter) ensures correct loading behavior.


This does not fix the `ServletDispatcher` issue, as that Servlet is being migrated away in #6755