### PR TITLE
Fix some JTA tests, disable some other broken JTA tests

### DIFF
--- a/core/src/test/java/org/frankframework/jta/StatusRecordingTransactionManagerImplementationTest.java
+++ b/core/src/test/java/org/frankframework/jta/StatusRecordingTransactionManagerImplementationTest.java
@@ -1,10 +1,18 @@
 package org.frankframework.jta;
 
+import static org.frankframework.dbms.Dbms.H2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+
+import lombok.Getter;
 import org.apache.commons.lang3.NotImplementedException;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.SenderException;
@@ -17,14 +25,8 @@ import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.junit.DatabaseTest;
 import org.frankframework.testutil.junit.DatabaseTestEnvironment;
 import org.frankframework.testutil.junit.TxManagerTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
-
-import com.arjuna.ats.arjuna.common.arjPropertyManager;
-
-import lombok.Getter;
 
 public class StatusRecordingTransactionManagerImplementationTest extends StatusRecordingTransactionManagerTestBase<StatusRecordingTransactionManager> {
 
@@ -39,8 +41,8 @@ public class StatusRecordingTransactionManagerImplementationTest extends StatusR
 
 	@BeforeEach
 	public void setup(DatabaseTestEnvironment env) throws IOException {
-		assumeFalse("DATASOURCE".equals(env.getName()));
-		assumeFalse("H2".equals(env.getDataSourceName()));
+		assumeFalse("DATASOURCE".equals(env.getName()), "Testing XA transaction-manager, not the DatasourceTransactionManager");
+		assumeFalse(H2 == env.getDbmsSupport().getDbms(), "Cannot run this test with H2");
 
 		// Release any hanging commits that might be from previous tests
 		XaDatasourceCommitStopper.stop(false);
@@ -101,6 +103,7 @@ public class StatusRecordingTransactionManagerImplementationTest extends StatusR
 
 	@DatabaseTest(cleanupBeforeUse = true, cleanupAfterUse = true)
 	@TxManagerTest
+	@Disabled("This test fails for some databases and hangs for others. Needs to be investigated. (See issue #6935)")
 	public void testShutdownPending() {
 		setupTransactionManager();
 		String uid = txManagerReal.getUid();
@@ -126,7 +129,7 @@ public class StatusRecordingTransactionManagerImplementationTest extends StatusR
 		log.debug("recreating transaction manager");
 		setupTransactionManager();
 
-		assertEquals("tmuid must be the same after restart", uid, txManagerReal.getUid());
+		assertEquals(uid, txManagerReal.getUid(), "tmuid must be the same after restart");
 		txManagerReal.destroy();
 		assertStatus("COMPLETED", uid);
 	}
@@ -184,29 +187,5 @@ public class StatusRecordingTransactionManagerImplementationTest extends StatusR
 				txManager.commit(txStatus);
 			}
 		}
-
-
 	}
-
-
-//
-//	@Test
-//	public void testPresetTmUid() {
-//		log.debug("--> testPresetTmUid)");
-//		String presetTmUid = "fakeTmUid";
-//		write(TMUID_FILE, presetTmUid);
-//		S tm = setupTransactionManager();
-//		tm.afterPropertiesSet();
-//		T delegateTm = (T)tm.getTransactionManager();
-//		assertNotNull(delegateTm); // assert that transaction manager is a javax.transaction.TransactionManager
-//
-//		String serverId = getTMUID(delegateTm);
-//
-//		assertEquals(presetTmUid, serverId);
-//		assertEquals(presetTmUid, tm.getUid());
-//
-//		assertStatus("ACTIVE", presetTmUid);
-//	}
-//
-
 }

--- a/core/src/test/java/org/frankframework/jta/TransactionConnectorTest.java
+++ b/core/src/test/java/org/frankframework/jta/TransactionConnectorTest.java
@@ -8,9 +8,12 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+
 import jakarta.transaction.SystemException;
 import jakarta.transaction.UserTransaction;
-
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.frankframework.task.TimeoutGuard;
@@ -18,15 +21,13 @@ import org.frankframework.testutil.junit.DatabaseTestEnvironment;
 import org.frankframework.testutil.junit.TxManagerTest;
 import org.frankframework.testutil.junit.WithLiquibase;
 import org.frankframework.util.ClassUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.jta.JtaTransactionObject;
 
-import lombok.extern.log4j.Log4j2;
-
 @Log4j2
 @WithLiquibase(file = "Migrator/ChangelogBlobTests.xml", tableName = TransactionConnectorTest.TEST_TABLE)
+@Disabled("When this test is enabled, eventually a later test will fail when running Maven (usually the LockerTest) (See issue #6935)")
 public class TransactionConnectorTest {
 	static final String TEST_TABLE = "temp_table";
 	private IThreadConnectableTransactionManager txManager;
@@ -83,6 +84,7 @@ public class TransactionConnectorTest {
 			log.info("exception caught", e);
 		} finally {
 			if (txStatus.isRollbackOnly()) {
+				txManager.rollback(txStatus);
 				fail("expected commit");
 			} else {
 				txManager.commit(txStatus);

--- a/core/src/test/resources/AppConstants.properties
+++ b/core/src/test/resources/AppConstants.properties
@@ -3,7 +3,7 @@ SPRING.CONFIG.LOCATIONS=springContext.xml
 transactionmanager.log.dir=target/TXLOGS/${TransactionManagerType}/${DataSourceName}
 transactionmanager.uid=${TransactionManagerType}
 
-transactionmanager.narayana.objectStoreType=com.arjuna.ats.internal.arjuna.objectstore.VolatileStore
+#transactionmanager.narayana.objectStoreType=com.arjuna.ats.internal.arjuna.objectstore.VolatileStore
 transactionmanager.narayana.jdbc.connection.maxPoolSize=0
 
 flow.generator=


### PR DESCRIPTION
After merging this PR, it should be possible to to run tests with Maven with one of supported databases enabled, except MariaDB (which still fails, see issues #6910, #6911) and DB2 (not currently tested by me, DB2 JDBC driver seems to be missing some native-code dependencies).
