### PR TITLE
Fix detection of "Skip locked row" support for MariaDB

### DIFF
--- a/core/src/test/java/org/frankframework/jdbc/dbms/DbmsSupportTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/dbms/DbmsSupportTest.java
@@ -768,4 +768,11 @@ public class DbmsSupportTest extends JdbcTestBase {
 		}
 	}
 
+	@Test
+	public void testSkipLockedSupportPresent() {
+		// We expect this test to run against a MariaDB version 10.6 or later and so it should support "skip locked" when running these tests
+		boolean expectSkipLockedSupport = dbmsSupport.getDbms() != Dbms.H2;
+
+		assertEquals(expectSkipLockedSupport, dbmsSupport.hasSkipLockedFunctionality());
+	}
 }

--- a/dbms/src/main/java/org/frankframework/dbms/Dbms.java
+++ b/dbms/src/main/java/org/frankframework/dbms/Dbms.java
@@ -16,7 +16,6 @@
 package org.frankframework.dbms;
 
 import lombok.Getter;
-
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -47,8 +46,12 @@ public enum Dbms {
 	}
 
 	public static IDbmsSupport findDbmsSupportByProduct(String product, String productVersion) {
-		if (MYSQL.getProductName().equals(product) && productVersion.contains("MariaDB")) {
-			log.debug("Setting databasetype to MARIADB (using MySQL driver)");
+		if (productVersion.contains("MariaDB")) {
+			if (MYSQL.getProductName().equals(product)) {
+				log.debug("Setting databasetype to MARIADB (using MySQL driver)");
+			} else {
+				log.debug("Setting databasetype to MARIADB (using MariaDB driver)");
+			}
 			return new MariaDbDbmsSupport(productVersion);
 		}
 		if (product.startsWith("DB2/")) {

--- a/dbms/src/main/java/org/frankframework/dbms/MariaDbDbmsSupport.java
+++ b/dbms/src/main/java/org/frankframework/dbms/MariaDbDbmsSupport.java
@@ -28,20 +28,15 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 public class MariaDbDbmsSupport extends MySqlDbmsSupport {
 
 	private Boolean dbmsHasSkipLockedFunctionality;
-	private String productVersion;
+	private final String productVersion;
 
 	public MariaDbDbmsSupport() {
-		this(false);
+		throw new IllegalStateException("MariaDbDbmsSupport should be instantiated with product-version to determine supported featureset. Calling this constructor is a code-bug.");
 	}
 
 	public MariaDbDbmsSupport(String productVersion) {
 		this.productVersion = productVersion;
 	}
-
-	public MariaDbDbmsSupport(boolean dbmsHasSkipLockedFunctionality) {
-		this.dbmsHasSkipLockedFunctionality = dbmsHasSkipLockedFunctionality;
-	}
-
 
 	@Override
 	public Dbms getDbms() {
@@ -62,7 +57,10 @@ public class MariaDbDbmsSupport extends MySqlDbmsSupport {
 
 	private boolean determineSkipLockedCapability(String productVersion) {
 		String[] productVersionArr = productVersion.split("-");
-		String strippedProductVersion = productVersionArr.length > 1 ? productVersionArr[1] : productVersion;
+		// The part of productVersion to use depends on whether the MariaDB or MySQL driver is used.
+		// MySQL driver prepends its own version and so we have to take the 2nd entry in the array.
+		// When MariaDB driver is used, take the 1st entry.
+		String strippedProductVersion = productVersionArr.length == 1 || productVersionArr[1].toLowerCase().contains("maria") ? productVersionArr[0] : productVersionArr[1];
 		DefaultArtifactVersion thisVersion = new DefaultArtifactVersion(strippedProductVersion);
 		DefaultArtifactVersion targetVersion = new DefaultArtifactVersion("10.6.0");
 		boolean result = thisVersion.compareTo(targetVersion) >= 0;

--- a/dbms/src/test/java/org/frankframework/dbms/MariaDbDbmsSupportTest.java
+++ b/dbms/src/test/java/org/frankframework/dbms/MariaDbDbmsSupportTest.java
@@ -16,7 +16,7 @@ class MariaDbDbmsSupportTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource({"10.6.0", "10.6.1", "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal", "5.5.5-10.6.26-MariaDB-log"})
+	@CsvSource({"11.3.2", "11.3.2-MariaDB-1:11.3.2+maria~ubu2204", "10.6.0", "10.6.1", "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal", "5.5.5-10.6.26-MariaDB-log"})
 	void testHasSkipLocked(String version) {
 		MariaDbDbmsSupport d = new MariaDbDbmsSupport(version);
 		assertTrue(d.hasSkipLockedFunctionality());


### PR DESCRIPTION
Initial fix for the "Skip Locked Rows" support in MariaDB queries (#6897)

(cherry picked from commit 30124e234288173af468d2a40f81971ccf58c0fd)