### PR TITLE
Improve Message closing and fail when using a closed message

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -293,6 +293,7 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 			return obj.toString();
 		} else if (obj instanceof Message message) {
 			// Existing messages returned directly so they are not closed
+			message.assertNotClosed();
 			return message.asString();
 		} else {
 			// Other types are wrapped into a message, which is closed after converting to String.

--- a/core/src/main/java/org/frankframework/parameters/ParameterList.java
+++ b/core/src/main/java/org/frankframework/parameters/ParameterList.java
@@ -116,15 +116,18 @@ public class ParameterList extends ArrayList<IParameter> {
 				throw new ParameterException("<input message>", "Cannot preserve message for parameter resolution", e);
 			}
 		}
+		if (inputValueRequiredForResolution && message != null) {
+			message.assertNotClosed();
+		}
 
 		ParameterValueList result = new ParameterValueList();
-		for (IParameter parm : this) {
+		for (IParameter param : this) {
 			// if a parameter has sessionKey="*", then a list is generated with a synthetic parameter referring to
 			// each session variable whose name starts with the name of the original parameter
-			if (isWildcardSessionKey(parm)) {
-				addMatchingSessionKeys(result, parm, message, session, namespaceAware);
+			if (isWildcardSessionKey(param)) {
+				addMatchingSessionKeys(result, param, message, session, namespaceAware);
 			} else {
-				result.add(getValue(result, parm, message, session, namespaceAware));
+				result.add(getValue(result, param, message, session, namespaceAware));
 			}
 		}
 		return result;

--- a/core/src/main/java/org/frankframework/processors/CorePipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CorePipeProcessor.java
@@ -32,11 +32,13 @@ public class CorePipeProcessor implements PipeProcessor {
 
 	@Override
 	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
+		if (message != null) message.assertNotClosed();
 		return pipe.doPipe(message, pipeLineSession);
 	}
 
 	@Override
 	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
+		if (message != null) message.assertNotClosed();
 		return validator.validate(message, pipeLineSession, messageRoot);
 	}
 

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -814,12 +814,7 @@ public class Message implements Serializable, Closeable {
 	 * @return Message[1234abcd:ByteArrayInputStream]
 	 */
 	public String getObjectId() {
-		StringBuilder result = new StringBuilder("Message[");
-		result.append(Integer.toHexString(hashCode()));
-		result.append(":");
-		result.append(getRequestClass());
-
-		return result.append("]").toString();
+		return "Message[" + Integer.toHexString(hashCode()) + ":" + getRequestClass() + "]";
 	}
 
 	public static Message asMessage(Object object) {
@@ -1004,7 +999,7 @@ public class Message implements Serializable, Closeable {
 
 	public void assertNotClosed() {
 		if (isClosed()) {
-			throw new IllegalStateException("Message is already closed!");
+			throw new IllegalStateException("Message is already closed! " + getObjectId());
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -86,8 +86,8 @@ public class Message implements Serializable, Closeable {
 	private static final Logger LOG = LogManager.getLogger(Message.class);
 
 	private static final long serialVersionUID = 437863352486501445L;
-	private final transient Cleaner.Cleanable cleanable;
-	private final transient MessageNotClosedAction messageNotClosedAction;
+	private transient Cleaner.Cleanable cleanable;
+	private transient MessageNotClosedAction messageNotClosedAction;
 
 	private @Nullable Object request;
 	private @Getter @Nonnull String requestClass;
@@ -381,10 +381,8 @@ public class Message implements Serializable, Closeable {
 
 	@Override
 	public void close() throws IOException {
-		if (messageNotClosedAction != null) {
-			messageNotClosedAction.calledByClose = true;
-			cleanable.clean();
-		}
+		messageNotClosedAction.calledByClose = true;
+		cleanable.clean();
 		if (request instanceof AutoCloseable closeable) {
 			CloseUtils.closeSilently(closeable);
 		}
@@ -829,6 +827,7 @@ public class Message implements Serializable, Closeable {
 			return nullMessage();
 		}
 		if (object instanceof Message message) {
+			message.assertNotClosed();
 			return message;
 		}
 		if (object instanceof URL rL) {
@@ -841,6 +840,7 @@ public class Message implements Serializable, Closeable {
 			return new PathMessage(path);
 		}
 		if (object instanceof MessageWrapper wrapper) {
+			wrapper.getMessage().assertNotClosed();
 			return wrapper.getMessage();
 		}
 		if (object instanceof RawMessageWrapper) {
@@ -860,6 +860,7 @@ public class Message implements Serializable, Closeable {
 			return string;
 		}
 		if (object instanceof Message message) {
+			message.assertNotClosed();
 			return message.asString();
 		}
 		if (object instanceof MessageWrapper wrapper) {
@@ -992,6 +993,19 @@ public class Message implements Serializable, Closeable {
 			contextFromStream = new MessageContext().withCharset(charset);
 		}
 		context = contextFromStream;
+		// Register the message for cleaning later
+		messageNotClosedAction = new MessageNotClosedAction(this.toString());
+		cleanable = cleaner.register(this, messageNotClosedAction);
+	}
+
+	public boolean isClosed() {
+		return messageNotClosedAction.calledByClose;
+	}
+
+	public void assertNotClosed() {
+		if (isClosed()) {
+			throw new IllegalStateException("Message is already closed!");
+		}
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -999,7 +999,7 @@ public class Message implements Serializable, Closeable {
 
 	public void assertNotClosed() {
 		if (isClosed()) {
-			throw new IllegalStateException("Message is already closed! " + getObjectId());
+			throw new IllegalStateException(getObjectId() + " is used after is has been closed!");
 		}
 	}
 

--- a/core/src/test/java/org/frankframework/monitoring/MonitorTest.java
+++ b/core/src/test/java/org/frankframework/monitoring/MonitorTest.java
@@ -3,16 +3,16 @@ package org.frankframework.monitoring;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.frankframework.core.Adapter;
-import org.frankframework.core.PipeLineSession;
-import org.frankframework.monitoring.events.FireMonitorEvent;
-import org.frankframework.stream.Message;
-import org.frankframework.testutil.TestConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import lombok.Getter;
+import org.frankframework.core.Adapter;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.monitoring.events.FireMonitorEvent;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.TestConfiguration;
 
 /**
  * This test tests the Spring pub/sub (publishEvent and onApplicationEvent) methods.
@@ -67,7 +67,7 @@ public class MonitorTest {
 		assertEquals(result, ignoreHostname(capturedMessage.asString()));
 		PipeLineSession session = sender.getInputSession();
 		assertTrue(session.containsKey(PipeLineSession.ORIGINAL_MESSAGE_KEY));
-		Message originalMessage = session.getMessage(PipeLineSession.ORIGINAL_MESSAGE_KEY);
+		Message originalMessage = (Message) session.get(PipeLineSession.ORIGINAL_MESSAGE_KEY);
 		assertEquals(message.asString(), sender.getSessionOriginalMessageValue());
 		assertEquals(123, originalMessage.getContext().get("special-key"));
 	}


### PR DESCRIPTION
1. A de-serialized messaged should also be scheduled to close
2. Add `message.isClosed()` to verify if a message was already closed
3. Add `message.assertNotClosed()` to verify if a message was *not* already closed
4. Add several key locations to assert the used message was not closed before. This prevents failures at odd locations, which are hard to find and fix. 