### PR TITLE
Add search & sort to uploaded configurations table

### DIFF
--- a/console/backend/src/main/java/org/frankframework/management/web/Configuration.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/Configuration.java
@@ -183,7 +183,7 @@ public class Configuration extends FrankApiBase {
 
 		String user = RequestUtils.resolveRequiredProperty("user", multipartBody.getUser(), "");
 		if (StringUtils.isEmpty(user)) {
-			user = principal.getName();
+			user = getUserPrincipalName(principal);
 		}
 
 		String fileNameOrPath = filePart.getOriginalFilename();

--- a/console/backend/src/main/java/org/frankframework/management/web/FrankApiBase.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/FrankApiBase.java
@@ -16,6 +16,7 @@
 package org.frankframework.management.web;
 
 import jakarta.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.frankframework.management.bus.OutboundGateway;
@@ -32,6 +33,8 @@ import org.springframework.messaging.Message;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
+
+import java.security.Principal;
 
 public abstract class FrankApiBase implements ApplicationContextAware, InitializingBean {
 
@@ -91,5 +94,12 @@ public abstract class FrankApiBase implements ApplicationContextAware, Initializ
 
 	protected final boolean allowDeprecatedEndpoints() {
 		return getProperty(DeprecationInterceptor.ALLOW_DEPRECATED_ENDPOINTS_KEY, false);
+	}
+
+	protected String getUserPrincipalName(Principal principal) {
+		if(principal != null && StringUtils.isNotEmpty(principal.getName())) {
+			return principal.getName();
+		}
+		return null;
 	}
 }

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -11,13 +11,13 @@ import {
 
 export type SortDirection = 'asc' | 'desc' | null;
 export type SortEvent = {
-  column: string;
+  column: string | number;
   direction: SortDirection;
 };
 
 export function updateSortableHeaders(
   headers: QueryList<ThSortableDirective>,
-  column: string,
+  column: string | number | symbol,
 ): void {
   for (const header of headers) {
     if (header.sortable !== column) {
@@ -28,6 +28,11 @@ export function updateSortableHeaders(
 
 const compare = (v1: string | number, v2: string | number): 1 | -1 | 0 =>
   v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+
+/** This is pretty bad, non primitive types won't be covered correctly (null, undefined, object, etc) */
+const anyCompare = <T>(v1: T, v2: T): 1 | -1 | 0 =>
+  v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+
 export function basicTableSort<T extends Record<string, string | number>>(
   array: T[],
   headers: QueryList<ThSortableDirective>,
@@ -39,6 +44,22 @@ export function basicTableSort<T extends Record<string, string | number>>(
 
   return [...array].sort((a, b) => {
     const order = compare(a[column], b[column]);
+    return direction === 'asc' ? order : -order;
+  });
+}
+
+/** Doesn't support all keyof types sadly, for now only string | number */
+export function basicAnyValueTableSort<T>(
+  array: T[],
+  headers: QueryList<ThSortableDirective>,
+  { column, direction }: SortEvent,
+): T[] {
+  updateSortableHeaders(headers, column);
+
+  if (direction == null || column == '') return array;
+
+  return [...array].sort((a, b) => {
+    const order = anyCompare(a[column as keyof T], b[column as keyof T]);
     return direction === 'asc' ? order : -order;
   });
 }

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -8,6 +8,7 @@ import {
   Output,
   QueryList,
 } from '@angular/core';
+import { anyCompare, compare } from '../utils';
 
 export type SortDirection = 'asc' | 'desc' | null;
 export type SortEvent = {
@@ -25,13 +26,6 @@ export function updateSortableHeaders(
     }
   }
 }
-
-const compare = (v1: string | number, v2: string | number): 1 | -1 | 0 =>
-  v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
-
-/** This is pretty bad, non primitive types won't be covered correctly (null, undefined, object, etc) */
-const anyCompare = <T>(v1: T, v2: T): 1 | -1 | 0 =>
-  v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
 
 export function basicTableSort<T extends Record<string, string | number>>(
   array: T[],

--- a/console/frontend/src/main/frontend/src/app/utils.ts
+++ b/console/frontend/src/main/frontend/src/app/utils.ts
@@ -66,3 +66,12 @@ export function copyToClipboard(text: string): void {
   document.execCommand('copy'); // TODO: soon deprecated but no real solution yet
   element.remove();
 }
+
+export const compare = (
+  v1: string | number,
+  v2: string | number,
+): 1 | -1 | 0 => (v1 < v2 ? -1 : v1 > v2 ? 1 : 0);
+
+/** This is pretty bad, non primitive types won't be covered correctly (null, undefined, object, etc) */
+export const anyCompare = <T>(v1: T, v2: T): 1 | -1 | 0 =>
+  v1 < v2 ? -1 : v1 > v2 ? 1 : 0;

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
@@ -20,10 +20,10 @@
           <table class="table table-hover">
             <thead>
               <tr>
-                <th>Version</th>
-                <th>Filename</th>
-                <th>Created At</th>
-                <th>User</th>
+                <th sortable="version" (sorted)="onSort($event)">Version</th>
+                <th sortable="filename" (sorted)="onSort($event)">Filename</th>
+                <th sortable="created" (sorted)="onSort($event)">Created At</th>
+                <th sortable="user" (sorted)="onSort($event)">User</th>
                 <th title="The configuration that's loaded upon IBIS startup">
                   Startup Config
                 </th>
@@ -39,7 +39,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr *ngFor="let config of versions">
+              <tr *ngFor="let config of versionsSorted">
                 <td>{{ config.version }}</td>
                 <td>{{ config.filename }}</td>
                 <td>{{ config.created }}</td>

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.html
@@ -17,6 +17,27 @@
         </div>
         <div class="ibox-content">
           <h2>Version History</h2>
+          <div class="ibox-stretch">
+            <div class="input-group" id="searchbar">
+              <input
+                type="text"
+                class="form-control"
+                placeholder="Search ... (Ctrl + Shift + F)"
+                [(ngModel)]="search"
+                name="search"
+              />
+              <i
+                (click)="search = ''"
+                class="fa fa-times input-group-closeSearch{{
+                  search.length < 1 ? ' hidden' : ''
+                }}"
+                aria-hidden="true"
+              ></i>
+              <span class="input-group-addon">
+                <i class="fa fa-search" aria-hidden="true"></i>
+              </span>
+            </div>
+          </div>
           <table class="table table-hover">
             <thead>
               <tr>
@@ -39,7 +60,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr *ngFor="let config of versionsSorted">
+              <tr *ngFor="let config of versionsSorted | searchFilter: search">
                 <td>{{ config.version }}</td>
                 <td>{{ config.filename }}</td>
                 <td>{{ config.created }}</td>

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
@@ -1,9 +1,20 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  ViewChildren,
+} from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppService, Configuration } from 'src/app/app.service';
 import { SweetalertService } from 'src/app/services/sweetalert.service';
 import { ConfigurationsService } from '../../configurations.service';
 import { ToastService } from 'src/app/services/toast.service';
+import {
+  SortEvent,
+  ThSortableDirective,
+  basicAnyValueTableSort,
+} from 'src/app/components/th-sortable.directive';
 
 @Component({
   selector: 'app-configurations-manage-details',
@@ -23,6 +34,11 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
   loading: boolean = false;
   promise: number = -1;
   versions: Configuration[] = [];
+  versionsSorted: Configuration[] = [];
+
+  private lastSortEvent: SortEvent = { direction: null, column: '' };
+
+  @ViewChildren(ThSortableDirective) headers!: QueryList<ThSortableDirective>;
 
   constructor(
     private route: ActivatedRoute,
@@ -71,7 +87,34 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
           }
         }
 
-        this.versions = data;
+        // this.versions = data;
+        this.versions = [
+          {
+            name: 'test',
+            jdbcMigrator: false,
+            stubbed: false,
+            state: 'STOPPED',
+            type: 'DatabaseClassLoader',
+            version: '1.0.0',
+            filename: 'AAAA',
+            created: '2020-01-01 00:00:00',
+          },
+          {
+            name: 'test 2',
+            jdbcMigrator: false,
+            stubbed: false,
+            state: 'STOPPED',
+            type: 'DatabaseClassLoader',
+            version: '1.0.1',
+            filename: 'BBBB',
+            created: '2024-01-01 00:00:00',
+          },
+        ];
+        this.versionsSorted = basicAnyValueTableSort(
+          this.versions,
+          this.headers,
+          this.lastSortEvent,
+        );
         this.loading = false;
       });
   }
@@ -150,5 +193,14 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
           this.update();
         },
       });
+  }
+
+  onSort(event: SortEvent): void {
+    this.lastSortEvent = event;
+    this.versionsSorted = basicAnyValueTableSort<Configuration>(
+      this.versions,
+      this.headers,
+      event,
+    );
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
@@ -35,6 +35,7 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
   promise: number = -1;
   versions: Configuration[] = [];
   versionsSorted: Configuration[] = [];
+  search: string = '';
 
   private lastSortEvent: SortEvent = { direction: null, column: '' };
 
@@ -87,29 +88,7 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
           }
         }
 
-        // this.versions = data;
-        this.versions = [
-          {
-            name: 'test',
-            jdbcMigrator: false,
-            stubbed: false,
-            state: 'STOPPED',
-            type: 'DatabaseClassLoader',
-            version: '1.0.0',
-            filename: 'AAAA',
-            created: '2020-01-01 00:00:00',
-          },
-          {
-            name: 'test 2',
-            jdbcMigrator: false,
-            stubbed: false,
-            state: 'STOPPED',
-            type: 'DatabaseClassLoader',
-            version: '1.0.1',
-            filename: 'BBBB',
-            created: '2024-01-01 00:00:00',
-          },
-        ];
+        this.versions = data;
         this.versionsSorted = basicAnyValueTableSort(
           this.versions,
           this.headers,


### PR DESCRIPTION
Also fixes the configuration upload endpoint, using an old function I didnt think was needed anymore so I had deleted it when moving over to Spring

Yes I know making an `anyCompare` that doesnt properly compare any `keyof T` type where T is the array of table items is kind of bad but I rewrote it like 3 times already, each time overengineering it too much for what is currently needed.
This is now a nice basis that can later be expanded if its _really_ needed.