### PR TITLE
Add getMembers endpoint and add ApplicationEvents

### DIFF
--- a/console/backend/src/main/java/org/frankframework/management/web/configuration/WebConfiguration.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/configuration/WebConfiguration.java
@@ -18,9 +18,13 @@ package org.frankframework.management.web.configuration;
 import java.util.List;
 import java.util.Optional;
 
+import org.frankframework.management.bus.LocalGateway;
+import org.frankframework.management.bus.OutboundGatewayFactory;
 import org.frankframework.management.gateway.InputStreamHttpMessageConverter;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
@@ -33,7 +37,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  */
 @Configuration
 @EnableWebMvc
-public class WebConfiguration implements WebMvcConfigurer {
+public class WebConfiguration implements WebMvcConfigurer, EnvironmentAware {
+
+	private String gatewayClassName;
 
 	@Override
 	public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
@@ -50,5 +56,17 @@ public class WebConfiguration implements WebMvcConfigurer {
 	@Bean
 	StandardServletMultipartResolver multipartResolver() {
 		return new StandardServletMultipartResolver();
+	}
+
+	@Bean
+	public OutboundGatewayFactory outboundGateway() {
+		OutboundGatewayFactory factory = new OutboundGatewayFactory();
+		factory.setGatewayClassname(gatewayClassName);
+		return factory;
+	}
+
+	@Override
+	public void setEnvironment(Environment environment) {
+		gatewayClassName = environment.getProperty("management.gateway.outbound.class", String.class, LocalGateway.class.getCanonicalName());
 	}
 }

--- a/console/war/src/main/resources/FrankConsoleContext.xml
+++ b/console/war/src/main/resources/FrankConsoleContext.xml
@@ -13,11 +13,6 @@
 
 	<context:component-scan base-package="org.frankframework.web" />
 
-	<!-- Messaging Gateway -->
-	<bean id="outboundGateway" class="org.frankframework.management.bus.OutboundGatewayFactory">
-		<property name="gatewayClassname" value="${management.gateway.outbound.class}" />
-	</bean>
-
 	<bean id="httpFirewall" class="org.springframework.security.web.firewall.StrictHttpFirewall">
 		<property name="allowSemicolon" value="true"/>
 		<property name="allowUrlEncodedPercent" value="true"/>

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -247,8 +247,8 @@ management.endpoints.jmx.agentId=
 
 
 # Management Gateway Properties
-management.gateway.inbound.class=org.frankframework.management.bus.LocalGateway
 management.gateway.outbound.class=org.frankframework.management.bus.LocalGateway
+management.gateway.inbound.class=
 
 
 

--- a/core/src/main/resources/SpringEnvironmentContext.xml
+++ b/core/src/main/resources/SpringEnvironmentContext.xml
@@ -42,8 +42,6 @@
 	<bean id="inboundGatewayFactory" class="org.frankframework.management.bus.InboundGatewayFactory">
 		<property name="gatewayClassnames" value="${management.gateway.inbound.class}" />
 	</bean>
-	<!-- The LocalGateway is required for internal traffic as well as the Frank!Console -->
-	<alias name="org.frankframework.management.bus.LocalGateway" alias="outboundGateway"/>
 
 	<bean id="org.apache.cxf.bus.spring.BusWiringBeanFactoryPostProcessor" class="org.apache.cxf.bus.spring.BusWiringBeanFactoryPostProcessor"/>
 	<bean id="org.apache.cxf.bus.spring.Jsr250BeanPostProcessor" class="org.apache.cxf.bus.spring.Jsr250BeanPostProcessor"/>

--- a/management-gateway/src/main/java/org/frankframework/management/bus/InboundGatewayFactory.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/InboundGatewayFactory.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2023 - 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -47,9 +47,8 @@ public class InboundGatewayFactory implements InitializingBean, ApplicationConte
 
 	private final Logger log = LogManager.getLogger(this);
 	private @Setter ApplicationContext applicationContext;
-	private static final String LOCAL_GATEWAY_CLASSNAME = LocalGateway.class.getCanonicalName();
 
-	private @Setter String gatewayClassnames = LOCAL_GATEWAY_CLASSNAME;
+	private @Setter String gatewayClassnames;
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
@@ -80,13 +79,11 @@ public class InboundGatewayFactory implements InitializingBean, ApplicationConte
 	 */
 	private Set<String> getInboundGateways() {
 		if(StringUtils.isBlank(gatewayClassnames)) {
-			return Collections.singleton(LOCAL_GATEWAY_CLASSNAME);
+			return Collections.emptySet();
 		}
 
 		// Ensure an unique list of gateways.
 		Set<String> gateways = new TreeSet<>(Arrays.asList(gatewayClassnames.split(",")));
-		gateways.add(LOCAL_GATEWAY_CLASSNAME);
-
 		return Collections.unmodifiableSet(gateways);
 	}
 

--- a/management-gateway/src/main/java/org/frankframework/management/bus/OutboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/OutboundGateway.java
@@ -15,15 +15,34 @@
 */
 package org.frankframework.management.bus;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.integration.IntegrationPattern;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.messaging.Message;
+
+import lombok.Getter;
+import lombok.Setter;
 
 public interface OutboundGateway extends IntegrationPattern {
 
 	@Override
 	default IntegrationPatternType getIntegrationPatternType() {
 		return IntegrationPatternType.outbound_gateway;
+	}
+
+	default List<ClusterMember> getMembers() {
+		return null;
+	}
+
+	@Setter
+	@Getter
+	public static class ClusterMember {
+		private UUID id;
+		private String address;
+		private String name;
+		private boolean localMember;
 	}
 
 	/**

--- a/management-gateway/src/main/java/org/frankframework/management/bus/OutboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/OutboundGateway.java
@@ -15,6 +15,7 @@
 */
 package org.frankframework.management.bus;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,6 +23,7 @@ import org.springframework.integration.IntegrationPattern;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.messaging.Message;
 
+import jakarta.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,8 +34,9 @@ public interface OutboundGateway extends IntegrationPattern {
 		return IntegrationPatternType.outbound_gateway;
 	}
 
+	@Nonnull
 	default List<ClusterMember> getMembers() {
-		return null;
+		return Collections.emptyList();
 	}
 
 	@Setter

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastConfig.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastConfig.java
@@ -21,6 +21,9 @@ import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.util.PropertyLoader;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.impl.DefaultNodeContext;
+import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 
 public class HazelcastConfig {
 
@@ -33,5 +36,11 @@ public class HazelcastConfig {
 		String resource = "frankframework-hazelcast.xml";
 		Properties properties = new PropertyLoader("hazelcast.properties");
 		return Config.loadFromClasspath(classLoader, resource, properties);
+	}
+
+	static HazelcastInstance newHazelcastInstance(String name) {
+		Config config = HazelcastConfig.createHazelcastConfig();
+		config.getMemberAttributeConfig().setAttribute("name", name);
+		return HazelcastInstanceFactory.newHazelcastInstance(config, name, new DefaultNodeContext());
 	}
 }

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastInboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastInboundGateway.java
@@ -35,8 +35,6 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 
 import com.hazelcast.collection.IQueue;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.impl.DefaultNodeContext;
-import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.topic.ITopic;
 import com.hazelcast.topic.MessageListener;
 
@@ -57,7 +55,7 @@ public class HazelcastInboundGateway extends MessagingGatewaySupport {
 
 	@Override
 	protected void onInit() {
-		hzInstance = HazelcastInstanceFactory.newHazelcastInstance(HazelcastConfig.createHazelcastConfig(), "worker-node", new DefaultNodeContext());
+		hzInstance = HazelcastConfig.newHazelcastInstance("worker");
 		SpringUtils.registerSingleton(getApplicationContext(), "hazelcastInboundInstance", hzInstance);
 		requestTopic = hzInstance.getTopic(requestTopicName);
 

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.OutboundGateway;
 import org.frankframework.management.gateway.events.ClusterMemberEvent;
-import org.frankframework.management.gateway.events.ClusterMemberEvent.Type;
+import org.frankframework.management.gateway.events.ClusterMemberEvent.EventType;
 import org.frankframework.util.SpringUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
@@ -161,12 +161,12 @@ public class HazelcastOutboundGateway implements InitializingBean, ApplicationCo
 
 			@Override
 			public void memberAdded(MembershipEvent e) {
-				applicationContext.publishEvent(new ClusterMemberEvent(applicationContext, Type.ADD, mapMember(e.getMember())));
+				applicationContext.publishEvent(new ClusterMemberEvent(applicationContext, EventType.ADD_MEMBER, mapMember(e.getMember())));
 			}
 
 			@Override
 			public void memberRemoved(MembershipEvent e) {
-				applicationContext.publishEvent(new ClusterMemberEvent(applicationContext, Type.REMOVE, mapMember(e.getMember())));
+				applicationContext.publishEvent(new ClusterMemberEvent(applicationContext, EventType.REMOVE_MEMBER, mapMember(e.getMember())));
 			}
 
 		});

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/events/AbstractGatewayEvent.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/events/AbstractGatewayEvent.java
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.management.gateway.events;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEvent;
+
+public class AbstractGatewayEvent extends ApplicationEvent {
+
+	public AbstractGatewayEvent(ApplicationContext source) {
+		super(source);
+	}
+
+}

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/events/AbstractGatewayEvent.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/events/AbstractGatewayEvent.java
@@ -18,7 +18,7 @@ package org.frankframework.management.gateway.events;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
 
-public class AbstractGatewayEvent extends ApplicationEvent {
+public abstract class AbstractGatewayEvent extends ApplicationEvent {
 
 	public AbstractGatewayEvent(ApplicationContext source) {
 		super(source);

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/events/ClusterMemberEvent.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/events/ClusterMemberEvent.java
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.management.gateway.events;
+
+import org.frankframework.management.bus.OutboundGateway.ClusterMember;
+import org.springframework.context.ApplicationContext;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+
+public class ClusterMemberEvent extends AbstractGatewayEvent {
+
+	public enum Type {
+		ADD, REMOVE
+	}
+
+	private @Getter final Type type;
+	private @Getter final ClusterMember member;
+
+	public ClusterMemberEvent(@Nonnull ApplicationContext source, @Nonnull Type type, @Nonnull ClusterMember member) {
+		super(source);
+		this.type = type;
+		this.member = member;
+	}
+
+	@Override
+	public String toString() {
+		return "Member " + member.getId() + " has been " + (type == Type.ADD ? "added" : "removed");
+	}
+}

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/events/ClusterMemberEvent.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/events/ClusterMemberEvent.java
@@ -23,14 +23,14 @@ import lombok.Getter;
 
 public class ClusterMemberEvent extends AbstractGatewayEvent {
 
-	public enum Type {
-		ADD, REMOVE
+	public enum EventType {
+		ADD_MEMBER, REMOVE_MEMBER
 	}
 
-	private @Getter final Type type;
+	private @Getter final EventType type;
 	private @Getter final ClusterMember member;
 
-	public ClusterMemberEvent(@Nonnull ApplicationContext source, @Nonnull Type type, @Nonnull ClusterMember member) {
+	public ClusterMemberEvent(@Nonnull ApplicationContext source, @Nonnull EventType type, @Nonnull ClusterMember member) {
 		super(source);
 		this.type = type;
 		this.member = member;
@@ -38,6 +38,6 @@ public class ClusterMemberEvent extends AbstractGatewayEvent {
 
 	@Override
 	public String toString() {
-		return "Member " + member.getId() + " has been " + (type == Type.ADD ? "added" : "removed");
+		return "Member " + member.getId() + " has been " + (type == EventType.ADD_MEMBER ? "added" : "removed");
 	}
 }


### PR DESCRIPTION
Can be used in combination with `implements ApplicationListener<AbstractGatewayEvent> {` and
```
@Override
public void onApplicationEvent(AbstractGatewayEvent event) {
    System.err.println(event);
}
```
To retrieve a `ClusterMemberEvent` when a new member joins or leaves the cluster.