### PR TITLE
Remove Message.asByteArray

### DIFF
--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -859,34 +859,10 @@ public class Message implements Serializable, Closeable {
 		if (object instanceof MessageWrapper wrapper) {
 			return wrapper.getMessage().asString();
 		}
+
 		// In other cases, message can be closed directly after converting to String.
 		try (Message message = Message.asMessage(object)) {
 			return message.asString();
-		}
-	}
-
-	/**
-	 * Convert an object to a byte array. Does not close object when it is of type Message or MessageWrapper.
-	 */
-	public static byte[] asByteArray(Object object) throws IOException {
-		if (object == null) {
-			return null;
-		}
-		if (object instanceof byte[] bytes) {
-			return bytes;
-		}
-		if (object instanceof String string) {
-			return string.getBytes();
-		}
-		if (object instanceof Message message) {
-			return message.asByteArray();
-		}
-		if (object instanceof MessageWrapper wrapper) {
-			return wrapper.getMessage().asByteArray();
-		}
-		// In other cases, message can be closed directly after converting to byte array.
-		try (Message message = Message.asMessage(object)) {
-			return message.asByteArray();
 		}
 	}
 

--- a/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
@@ -22,12 +22,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.input.ReaderInputStream;
-import org.frankframework.stream.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+
+import org.apache.commons.io.input.ReaderInputStream;
+import org.frankframework.stream.Message;
 
 /**
  * Lots of bugs tests, focus on getMessage(String)
@@ -61,7 +62,7 @@ public class PipeLineSessionTest {
 		session.put("key8", 123);
 		session.put("key8b", "456");
 		session.put("key8c", Message.asMessage("456"));
-		session.put("key8d", Message.asByteArray((Object)"456"));
+		session.put("key8d", "456".getBytes());
 		session.put("key9", true);
 		session.put("key9b", "true");
 		session.put("key9c", "false");

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -45,6 +45,10 @@ import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.Logger;
 import org.frankframework.functional.ThrowingSupplier;
@@ -57,9 +61,6 @@ import org.frankframework.util.LogUtil;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.XmlUtils;
 import org.frankframework.xml.XmlWriter;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
@@ -357,16 +358,14 @@ public class MessageTest {
 	}
 
 	@Test
-	public void testStringAsStaticByteArray() throws Exception {
-		Object source = testString;
-		byte[] byteArray = Message.asByteArray(source);
+	public void testStringAsStaticByteArray() {
+		byte[] byteArray = testString.getBytes();
 		assertEquals(byteArray.length, testString.getBytes().length, "lengths differ");
 	}
 
 	@Test
-	public void testByteArrayAsStaticByteArray() throws Exception {
-		Object source = testString.getBytes();
-		byte[] byteArray = Message.asByteArray(source);
+	public void testByteArrayAsStaticByteArray() {
+		byte[] byteArray = testString.getBytes();
 		assertEquals(byteArray.length, testString.getBytes().length, "lengths differ");
 		assertEquals(testString, new String(byteArray), "content differ");
 	}
@@ -1363,10 +1362,10 @@ public class MessageTest {
 	@Test
 	void testMessageAsByteArrayDoesNotCloseMessage() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
-		Object msg = Message.asMessage(new StringReader("text"));
+		Message msg = Message.asMessage(new StringReader("text"));
 
 		// Act
-		byte[] content = Message.asByteArray(msg);
+		byte[] content = msg.asByteArray();
 
 		// Assert
 		Message message = (Message) msg;
@@ -1379,10 +1378,10 @@ public class MessageTest {
 	void testMessageAsByteArrayDoesNotCloseMessageWrapper() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
 		Message msg = Message.asMessage(new StringReader("text"));
-		Object wrapper = new MessageWrapper<Message>(msg, null, null);
+		MessageWrapper wrapper = new MessageWrapper<Message>(msg, null, null);
 
 		// Act
-		byte[] content = Message.asByteArray(wrapper);
+		byte[] content = wrapper.getMessage().asByteArray();
 
 		// Assert
 		MessageWrapper<Message> messageWrapper = (MessageWrapper) wrapper;

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -358,19 +358,6 @@ public class MessageTest {
 	}
 
 	@Test
-	public void testStringAsStaticByteArray() {
-		byte[] byteArray = testString.getBytes();
-		assertEquals(byteArray.length, testString.getBytes().length, "lengths differ");
-	}
-
-	@Test
-	public void testByteArrayAsStaticByteArray() {
-		byte[] byteArray = testString.getBytes();
-		assertEquals(byteArray.length, testString.getBytes().length, "lengths differ");
-		assertEquals(testString, new String(byteArray), "content differ");
-	}
-
-	@Test
 	public void testReaderAsString() throws Exception {
 		StringReader source = new StringReader(testString);
 		adapter = new Message(source);


### PR DESCRIPTION
As discussed with Tim, I try to split this up in different pull requests, to make it managable. This removes the static Message.asByteArray.