### PR TITLE
Remove asMessage where possible

### DIFF
--- a/akamai/src/main/java/org/frankframework/extensions/akamai/NetStorageSender.java
+++ b/akamai/src/main/java/org/frankframework/extensions/akamai/NetStorageSender.java
@@ -261,7 +261,7 @@ public class NetStorageSender extends HttpSenderBase {
 			}
 		}
 
-		return Message.asMessage(result.toXML());
+		return new Message(result.toXML());
 	}
 
 	private String getSanitizedResponseBodyAsString(HttpResponseHandler responseHandler) throws IOException {

--- a/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
+++ b/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
@@ -26,7 +26,7 @@ import org.frankframework.filesystem.FileSystemSender;
  * <p>
  *     In addition to regular parameters for filesystem senders, it is possible
  *     to set custom user-metadata on S3 files by prefixing parameter names with
- *     {@value org.frankframework.filesystem.ISupportsCustomFileAttributes#FILE_ATTRIBUTE_PARAM_PREFIX}.
+ *     `{@value org.frankframework.filesystem.ISupportsCustomFileAttributes#FILE_ATTRIBUTE_PARAM_PREFIX}`.
  *     This prefix will be not be part of the actual metadata property name.
  * </p>
  * <p>

--- a/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
+++ b/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
@@ -26,7 +26,7 @@ import org.frankframework.filesystem.FileSystemSender;
  * <p>
  *     In addition to regular parameters for filesystem senders, it is possible
  *     to set custom user-metadata on S3 files by prefixing parameter names with
- *     `{@value org.frankframework.filesystem.ISupportsCustomFileAttributes#FILE_ATTRIBUTE_PARAM_PREFIX}`.
+ *     {@value org.frankframework.filesystem.ISupportsCustomFileAttributes#FILE_ATTRIBUTE_PARAM_PREFIX}.
  *     This prefix will be not be part of the actual metadata property name.
  * </p>
  * <p>

--- a/cmis/src/test/java/org/frankframework/extensions/cmis/TestBindingTypes.java
+++ b/cmis/src/test/java/org/frankframework/extensions/cmis/TestBindingTypes.java
@@ -116,7 +116,7 @@ public class TestBindingTypes extends CmisSenderTestBase {
 		}
 		configure(bindingType, action);
 
-		String actualResult = sender.sendMessageOrThrow(Message.asMessage(input), session).asString();
+		String actualResult = sender.sendMessageOrThrow(new Message(input), session).asString();
 		TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, actualResult);
 	}
 
@@ -126,7 +126,7 @@ public class TestBindingTypes extends CmisSenderTestBase {
 		if (action != CmisSender.CmisAction.GET) return;
 		configure(bindingType, action);
 
-		assertTrue(Message.isEmpty(sender.sendMessageOrThrow(Message.asMessage(input), session)));
+		assertTrue(Message.isEmpty(sender.sendMessageOrThrow(new Message(input), session)));
 		Message message = (Message) session.get("fileContent");
 		TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, message.asString());
 	}

--- a/core/src/main/java/org/frankframework/core/SenderResult.java
+++ b/core/src/main/java/org/frankframework/core/SenderResult.java
@@ -34,7 +34,7 @@ public class SenderResult implements AutoCloseable {
 	private @Getter @Setter String forwardName;
 
 	public SenderResult(String result) {
-		this(Message.asMessage(result));
+		this(new Message(result));
 	}
 
 	public SenderResult(@Nonnull Message result) {

--- a/core/src/main/java/org/frankframework/errormessageformatters/XslErrorMessageFormatter.java
+++ b/core/src/main/java/org/frankframework/errormessageformatters/XslErrorMessageFormatter.java
@@ -83,7 +83,7 @@ public class XslErrorMessageFormatter extends ErrorMessageFormatter {
 				}
 				Source resultSource = result.asSource();
 				result.close();
-				return Message.asMessage(transformerPool.transform(resultSource, parameterValues));
+				return new Message(transformerPool.transform(resultSource, parameterValues));
 			} catch (IOException e) {
 				log.error(" cannot retrieve [{}]", getStyleSheet(), e);
 			} catch (TransformerConfigurationException te) {

--- a/core/src/main/java/org/frankframework/http/HttpListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/HttpListenerServlet.java
@@ -85,7 +85,7 @@ public class HttpListenerServlet extends HttpServletBase {
 	@Override
 	public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 		String message = request.getParameter(MESSAGE_PARAM);
-		invoke(Message.asMessage(message), request,response);
+		invoke(new Message(message), request,response);
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/HttpSender.java
+++ b/core/src/main/java/org/frankframework/http/HttpSender.java
@@ -456,7 +456,7 @@ public class HttpSender extends HttpSenderBase {
 				headerXml.setCdataValue(header.getValue());
 				headersXml.addSubElement(headerXml);
 			}
-			return Message.asMessage(headersXml.toXML());
+			return new Message(headersXml.toXML());
 		}
 
 		return responseHandler.getResponseMessage();

--- a/core/src/main/java/org/frankframework/http/HttpSenderBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSenderBase.java
@@ -478,7 +478,7 @@ public abstract class HttpSenderBase extends HttpSessionBase implements HasPhysi
 				}
 			}
 
-			result = Message.asMessage(xhtml);
+			result = new Message(xhtml);
 		}
 
 		if (result == null) {

--- a/core/src/main/java/org/frankframework/http/RestSender.java
+++ b/core/src/main/java/org/frankframework/http/RestSender.java
@@ -62,6 +62,6 @@ public class RestSender extends HttpSender {
 			result.addSubElement(message);
 		}
 
-		return Message.asMessage(result.toXML());
+		return new Message(result.toXML());
 	}
 }

--- a/core/src/main/java/org/frankframework/jdbc/SimpleJdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/SimpleJdbcListener.java
@@ -130,7 +130,7 @@ public class SimpleJdbcListener extends JdbcFacade implements IPullingListener<S
 
 	@Override
 	public Message extractMessage(@Nonnull RawMessageWrapper<String> rawMessage, @Nonnull Map<String,Object> context) {
-		return Message.asMessage(rawMessage.getRawMessage());
+		return new Message(rawMessage.getRawMessage());
 	}
 
 	protected ResultSet executeQuery(Connection conn, String query) throws ListenerException {

--- a/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
@@ -277,7 +277,7 @@ public class StoredProcedureQuerySender extends FixedQuerySender {
 
 		DB2XMLWriter db2xml = buildDb2XMLWriter();
 		String result = db2xml.getXML(getDbmsSupport(), callableStatement, alsoGetResultSets, outputParameters, getMaxRows(), isIncludeFieldDefinition());
-		return Message.asMessage(result);
+		return new Message(result);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/pipes/JwtPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/JwtPipe.java
@@ -112,7 +112,7 @@ public class JwtPipe extends FixedForwardPipe {
 
 		final JWSSigner signer = getSigner(sharedSecretParam);
 		String jwtToken = createAndSignJwtToken(signer, claimsSetBuilder.build());
-		return new PipeRunResult(getSuccessForward(), Message.asMessage(jwtToken));
+		return new PipeRunResult(getSuccessForward(), new Message(jwtToken));
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
@@ -557,7 +557,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender {
 		correlationID = logToMessageLog(input, session, originalMessage, messageID, correlationID);
 
 		if (getListener() != null) {
-			Message result = Message.asMessage(listenerProcessor.getMessage(getListener(), correlationID, session));
+			Message result = listenerProcessor.getMessage(getListener(), correlationID, session);
 			sendResult.setResult(result);
 		}
 		if (Message.isNull(sendResult.getResult())) {
@@ -706,7 +706,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender {
 		if (outputValidator != null) {
 			log.debug("validating response");
 			PipeRunResult validationResult;
-			validationResult = pipeProcessor.processPipe(getPipeLine(), outputValidator, Message.asMessage(output), session);
+			validationResult = pipeProcessor.processPipe(getPipeLine(), outputValidator, output, session);
 			if (validationResult!=null) {
 				if (!validationResult.isSuccessful()) {
 					return validationResult;

--- a/core/src/main/java/org/frankframework/pipes/PutInSession.java
+++ b/core/src/main/java/org/frankframework/pipes/PutInSession.java
@@ -65,7 +65,7 @@ public class PutInSession extends FixedForwardPipe {
 				}
 				v = message;
 			} else {
-				v = Message.asMessage(getValue());
+				v = new Message(getValue());
 			}
 			session.put(getSessionKey(), v);
 			log.debug("stored [{}] in pipeLineSession under key [{}]", v, getSessionKey());

--- a/core/src/main/java/org/frankframework/pipes/TextSplitterPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/TextSplitterPipe.java
@@ -41,7 +41,7 @@ public class TextSplitterPipe extends FixedForwardPipe {
 	@Override
 	public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
 		if (Message.isNull(message) || message.isEmpty()) {
-			return new PipeRunResult(getSuccessForward(), Message.asMessage("<text/>"));
+			return new PipeRunResult(getSuccessForward(), new Message("<text/>"));
 		}
 
 		try {

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -97,12 +97,12 @@ public class InputOutputPipeProcessor extends PipeProcessorBase {
 			if (StringUtils.isNotEmpty(pipe.getGetInputFromFixedValue())) {
 				log.debug("Pipeline of adapter [{}] replacing input for pipe [{}] with fixed value [{}]", owner::getName, pipe::getName, pipe::getGetInputFromFixedValue);
 				message.closeOnCloseOf(pipeLineSession, owner);
-				message = Message.asMessage(pipe.getGetInputFromFixedValue());
+				message = new Message(pipe.getGetInputFromFixedValue());
 			}
 
 			if (Message.isEmpty(message) && StringUtils.isNotEmpty(pipe.getEmptyInputReplacement())) {
 				log.debug("Pipeline of adapter [{}] replacing empty input for pipe [{}] with fixed value [{}]", owner::getName, pipe::getName, pipe::getEmptyInputReplacement);
-				message = Message.asMessage(pipe.getEmptyInputReplacement());
+				message = new Message(pipe.getEmptyInputReplacement());
 			}
 
 			PipeRunResult pipeRunResult = null;

--- a/core/src/main/java/org/frankframework/receivers/FileRecordListener.java
+++ b/core/src/main/java/org/frankframework/receivers/FileRecordListener.java
@@ -248,7 +248,7 @@ public class FileRecordListener implements IPullingListener<String> {
 
 	@Override
 	public Message extractMessage(@Nonnull RawMessageWrapper<String> rawMessage, @Nonnull Map<String, Object> context) {
-		return Message.asMessage(rawMessage.getRawMessage());
+		return new Message(rawMessage.getRawMessage());
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/receivers/JavaListener.java
+++ b/core/src/main/java/org/frankframework/receivers/JavaListener.java
@@ -132,7 +132,7 @@ public class JavaListener<M> implements IPushingListener<M>, RequestProcessor, H
 		try {
 			HashMap<String, Object> processContext = context != null ? context : new HashMap<>();
 			processContext.put(PipeLineSession.CORRELATION_ID_KEY, correlationId);
-			try (Message message = Message.asMessage(rawMessage);
+			try (Message message = new Message(rawMessage);
 				Message result = processRequest(new MessageWrapper<>(message, null, correlationId), processContext)) {
 					return result.asString();
 			}

--- a/core/src/main/java/org/frankframework/senders/ShadowSender.java
+++ b/core/src/main/java/org/frankframework/senders/ShadowSender.java
@@ -206,7 +206,7 @@ public class ShadowSender extends ParallelSenders {
 		}
 
 		builder.close();
-		return Message.asMessage(builder.toString());
+		return new Message(builder.toString());
 	}
 
 	protected void addResult(SaxDocumentBuilder builder, ISender sender, Map<ISender, ParallelSenderExecutor> executorMap, String tagName) throws SAXException, IOException {

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -815,6 +815,12 @@ public class Message implements Serializable, Closeable {
 		return "Message[" + Integer.toHexString(hashCode()) + ":" + getRequestClass() + "]";
 	}
 
+	/**
+	 * Please note that this method should only be used when you don't know the type of object. In all other cases,
+	 * use the constructor of {@link Message} or a more applicable subclass like {@link FileMessage} or {@link UrlMessage}
+	 *
+	 * @return a Message of the correct type for the given object
+	 */
 	public static Message asMessage(Object object) {
 		if (object == null) {
 			return nullMessage();

--- a/core/src/main/java/org/frankframework/util/CompactSaxHandler.java
+++ b/core/src/main/java/org/frankframework/util/CompactSaxHandler.java
@@ -135,7 +135,7 @@ public class CompactSaxHandler extends FullXmlFilter {
 				&& charDataBuilder.substring(0, VALUE_MOVE_START.length()).equals(VALUE_MOVE_START));
 
 		if (moveElementFound) {
-			Message message = Message.asMessage(charDataBuilder.toString());
+			Message message = new Message(charDataBuilder.toString());
 			try {
 				message.preserve();
 			} catch (IOException e) {

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -1358,7 +1358,7 @@ public class XmlUtils {
 	}
 
 	public static boolean isWellFormed(String input, String root) {
-		return isWellFormed(Message.asMessage(input), root);
+		return isWellFormed(new Message(input), root);
 	}
 
 	public static boolean isWellFormed(Message input, String root) {
@@ -1470,7 +1470,7 @@ public class XmlUtils {
 			XmlWriter xmlWriter = new XmlWriter();
 			ContentHandler handler = new NamespaceRemovingFilter(xmlWriter);
 			parseXml(input.asInputSource(), handler);
-			return Message.asMessage(xmlWriter.toString());
+			return new Message(xmlWriter.toString());
 		} catch (Exception e) {
 			throw new XmlException(e);
 		}

--- a/core/src/test/java/org/frankframework/collection/TestCollector.java
+++ b/core/src/test/java/org/frankframework/collection/TestCollector.java
@@ -37,7 +37,7 @@ public class TestCollector implements ICollector<TestCollectorPart> {
 			input.append(part.asString());
 		}
 
-		return Message.asMessage(parts.size() + ":" + input.toString());
+		return new Message(parts.size() + ":" + input.toString());
 	}
 
 	@Override

--- a/core/src/test/java/org/frankframework/compression/TestZipWriterPipe.java
+++ b/core/src/test/java/org/frankframework/compression/TestZipWriterPipe.java
@@ -68,7 +68,7 @@ public class TestZipWriterPipe extends PipeTestBase<ZipWriterPipe> {
 		pipe.setAction(Action.OPEN);
 		configureAndStartPipe();
 
-		PipeRunResult prr = doPipe(Message.asMessage("test123"));
+		PipeRunResult prr = doPipe(new Message("test123"));
 
 		assertEquals("success", prr.getPipeForward().getName());
 		assertTrue(Message.isEmpty(prr.getResult()));

--- a/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
@@ -61,7 +61,7 @@ public class PipeLineSessionTest {
 		session.put("key7", new Date());
 		session.put("key8", 123);
 		session.put("key8b", "456");
-		session.put("key8c", Message.asMessage("456"));
+		session.put("key8c", new Message("456"));
 		session.put("key8d", "456".getBytes());
 		session.put("key9", true);
 		session.put("key9b", "true");
@@ -179,7 +179,7 @@ public class PipeLineSessionTest {
 		// Arrange
 		session.put("key8e", "123");
 		session.put("key8f", 123L);
-		session.put("key8g", Message.asMessage("123"));
+		session.put("key8g", new Message("123"));
 
 		// Act / Assert
 		assertEquals(123, session.getInteger("key8"));
@@ -244,7 +244,7 @@ public class PipeLineSessionTest {
 		session.put(PipeLineSession.MESSAGE_ID_KEY, messageId); //key inserted as String
 		assertEquals(messageId, session.getMessageId());
 
-		session.put(PipeLineSession.MESSAGE_ID_KEY, Message.asMessage(messageId)); //key inserted as Message
+		session.put(PipeLineSession.MESSAGE_ID_KEY, new Message(messageId)); //key inserted as Message
 		assertEquals(messageId, session.getMessageId());
 	}
 
@@ -255,7 +255,7 @@ public class PipeLineSessionTest {
 		session.put(PipeLineSession.CORRELATION_ID_KEY, correlationId); //key inserted as String
 		assertEquals(correlationId, session.getCorrelationId());
 
-		session.put(PipeLineSession.CORRELATION_ID_KEY, Message.asMessage(correlationId)); //key inserted as Message
+		session.put(PipeLineSession.CORRELATION_ID_KEY, new Message(correlationId)); //key inserted as Message
 		assertEquals(correlationId, session.getCorrelationId());
 	}
 
@@ -288,7 +288,7 @@ public class PipeLineSessionTest {
 		from.put("a", 15);
 		from.put("b", 16);
 
-		Message message1 = Message.asMessage("17");
+		Message message1 = new Message("17");
 		from.put("c", message1);
 		to.put("c", message1);
 
@@ -305,9 +305,9 @@ public class PipeLineSessionTest {
 		// Arrange
 		PipeLineSession from = new PipeLineSession();
 		PipeLineSession to = new PipeLineSession();
-		Message message = Message.asMessage("a message");
+		Message message = new Message("a message");
 		BufferedReader closeable1 = new BufferedReader(new StringReader("a closeable"));
-		Message closeable2 = Message.asMessage("a message is closeable");
+		Message closeable2 = new Message("a message is closeable");
 		from.put("a", 15);
 		from.put("b", 16);
 		from.put("c", message);
@@ -345,8 +345,8 @@ public class PipeLineSessionTest {
 		PipeLineSession from = new PipeLineSession();
 		PipeLineSession to = new PipeLineSession();
 
-		Message message1 = Message.asMessage("m1");
-		Message message2 = Message.asMessage("m2");
+		Message message1 = new Message("m1");
+		Message message2 = new Message("m2");
 
 		String keys = "a,c";
 		from.put("a", 15);

--- a/core/src/test/java/org/frankframework/http/HttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/HttpSenderTest.java
@@ -84,7 +84,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.configure();
 		sender.open();
 
-		String result = sender.sendMessageOrThrow(Message.asMessage("dummy"), session).asString();
+		String result = sender.sendMessageOrThrow(new Message("dummy"), session).asString();
 		assertEqualsIgnoreCRLF(getFile("testWithDefaultPort.txt"), result.trim());
 	}
 
@@ -98,7 +98,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.configure();
 		sender.open();
 
-		String result = sender.sendMessageOrThrow(Message.asMessage("dummy"), session).asString();
+		String result = sender.sendMessageOrThrow(new Message("dummy"), session).asString();
 		assertEqualsIgnoreCRLF(getFile("testWithRandomPort.txt"), result.trim());
 	}
 
@@ -801,7 +801,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.addParameter(new Parameter("string-part", "<string content/>"));
 
 		session.put("stringPart", new Message("mock pdf content"));
-		session.put("binaryPart", Message.asMessage(new Message("mock pdf content").asInputStream()));
+		session.put("binaryPart", new Message(new Message("mock pdf content").asInputStream()));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
 
 		sender.configure();
@@ -837,7 +837,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.addParameter(new Parameter("string-part", "<string content/>"));
 
 		session.put("stringPart", new Message("mock pdf content"));
-		session.put("binaryPart", Message.asMessage(new Message("mock pdf content").asInputStream()));
+		session.put("binaryPart", new Message(new Message("mock pdf content").asInputStream()));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
 
 		sender.configure();
@@ -871,7 +871,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.addParameter(new Parameter("string-part", "<string content/>"));
 
 		session.put("stringPart", new Message("mock pdf content"));
-		session.put("binaryPart", Message.asMessage(new Message("mock pdf content").asInputStream()));
+		session.put("binaryPart", new Message(new Message("mock pdf content").asInputStream()));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
 
 		sender.configure();
@@ -906,7 +906,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.addParameter(new Parameter("string-part", "<string content/>"));
 
 		session.put("stringPart", new Message("mock pdf content"));
-		session.put("binaryPart", Message.asMessage(new Message("mock pdf content").asInputStream()));
+		session.put("binaryPart", new Message(new Message("mock pdf content").asInputStream()));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
 
 		sender.configure();

--- a/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
@@ -92,13 +92,13 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 	private Message sendNonRepeatableMessage() throws SenderException, TimeoutException, IOException {
 		if(sender.getHttpMethod() == HttpMethod.GET) fail("method not allowed when using no HttpEntity");
 		InputStream is = new Message("dummy-string").asInputStream();
-		return sendMessage(Message.asMessage(new FilterInputStream(is) {}));
+		return sendMessage(new Message(new FilterInputStream(is) {}));
 	}
 
 	//Send repeatable message
 	private Message sendRepeatableMessage() throws SenderException, TimeoutException, IOException {
 		if(sender.getHttpMethod() == HttpMethod.GET) fail("method not allowed when using no HttpEntity");
-		return sendMessage(Message.asMessage(new Message("dummy-string").asByteArray()));
+		return sendMessage(new Message(new Message("dummy-string").asByteArray()));
 	}
 
 	@Test
@@ -424,7 +424,7 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 		sender.setClientId(MockTokenServer.CLIENT_ID);
 		sender.setClientSecret(MockTokenServer.CLIENT_SECRET);
 
-		Message nonRepeatableMessage = Message.asMessage(new FilterInputStream(new Message("dummy-string").asInputStream()) {});
+		Message nonRepeatableMessage = new Message(new FilterInputStream(new Message("dummy-string").asInputStream()) {});
 		session.put("binaryPart", nonRepeatableMessage);
 		sender.addParameter(ParameterBuilder.create("xml-part", "<ik><ben/><xml/></ik>"));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
@@ -454,7 +454,7 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 		sender.configure();
 		sender.open();
 
-		Message repeatableMessage = Message.asMessage("dummy-string".getBytes());
+		Message repeatableMessage = new Message("dummy-string".getBytes());
 		session.put("binaryPart", repeatableMessage);
 		sender.addParameter(ParameterBuilder.create("xml-part", "<ik><ben/><xml/></ik>"));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));
@@ -483,7 +483,7 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 		sender.configure();
 		sender.open();
 
-		Message nonRepeatableMessage = Message.asMessage(new FilterInputStream(new Message("dummy-string").asInputStream()) {});
+		Message nonRepeatableMessage = new Message(new FilterInputStream(new Message("dummy-string").asInputStream()) {});
 		session.put("binaryPart", nonRepeatableMessage);
 		sender.addParameter(ParameterBuilder.create("xml-part", "<ik><ben/><xml/></ik>"));
 		sender.addParameter(ParameterBuilder.create().withName("binary-part").withSessionKey("binaryPart"));

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
@@ -305,7 +305,7 @@ public class SoapProviderTest {
 		PipeLineSession session = new PipeLineSession();
 
 		session.put("attachmentXmlSessionKey", "<parts><part sessionKey=\"part_file\"/></parts>");
-		session.put("part_file", Message.asMessage(getFile(attachmentFile).asString())); //as String message / no message context
+		session.put("part_file", new Message(getFile(attachmentFile).asString())); //as String message / no message context
 
 		SOAPProvider.setAttachmentXmlSessionKey("attachmentXmlSessionKey");
 		SOAPProvider.setSession(session);

--- a/core/src/test/java/org/frankframework/http/mime/MultipartEntityTest.java
+++ b/core/src/test/java/org/frankframework/http/mime/MultipartEntityTest.java
@@ -133,7 +133,7 @@ public class MultipartEntityTest {
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setBoundary("test-boundary");
 
-		Message repeatable = Message.asMessage(new Message("dummy-content-here").asByteArray());
+		Message repeatable = new Message(new Message("dummy-content-here").asByteArray());
 
 		builder.addPart("part1", repeatable);
 		builder.addPart("part2", repeatable);
@@ -153,8 +153,8 @@ public class MultipartEntityTest {
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.setBoundary("test-boundary");
 
-		Message repeatable = Message.asMessage(new Message("dummy-content-here").asByteArray());
-		Message nonRepeatable = Message.asMessage(new FilterInputStream(repeatable.asInputStream()) {});
+		Message repeatable = new Message(new Message("dummy-content-here").asByteArray());
+		Message nonRepeatable = new Message(new FilterInputStream(repeatable.asInputStream()) {});
 
 		builder.addPart("part1", repeatable);
 		builder.addPart("part2", nonRepeatable);

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -904,7 +904,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerWithRepeatableMessageAndGloballyDisabled() throws Exception {
 		// Arrange
 		String uri="/etag2";
-		Message repeatableMessage = Message.asMessage(new Message("{\"tralalalallala\":true}").asByteArray());
+		Message repeatableMessage = new Message(new Message("{\"tralalalallala\":true}").asByteArray());
 		new ApiListenerBuilder(uri, List.of(HttpMethod.GET))
 			.withResponseContent(repeatableMessage)
 			.build();
@@ -929,7 +929,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerWithHeadMethodCall() throws Exception {
 		// Arrange
 		String uri = "/apiListenerWithHeadMethodCall";
-		Message repeatableMessage = Message.asMessage(new Message("{\"tralalalallala\":true}").asByteArray());
+		Message repeatableMessage = new Message(new Message("{\"tralalalallala\":true}").asByteArray());
 		new ApiListenerBuilder(uri, List.of(HttpMethod.HEAD), MediaTypes.JSON, MediaTypes.JSON)
 				.withResponseContent(repeatableMessage)
 				.build();
@@ -957,7 +957,7 @@ public class ApiListenerServletTest extends Mockito {
 	public void apiListenerWithHeadMethodCallAndEmptyMessage() throws Exception {
 		// Arrange
 		String uri = "/apiListenerWithHeadMethodCall";
-		Message repeatableMessage = Message.asMessage(new Message("").asByteArray());
+		Message repeatableMessage = new Message(new Message("").asByteArray());
 		new ApiListenerBuilder(uri, List.of(HttpMethod.HEAD), MediaTypes.JSON, MediaTypes.JSON)
 				.withResponseContent(repeatableMessage)
 				.build();

--- a/core/src/test/java/org/frankframework/jdbc/StoredProcedureQuerySenderTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/StoredProcedureQuerySenderTest.java
@@ -243,7 +243,7 @@ public class StoredProcedureQuerySenderTest {
 		p2.setSessionKey("data");
 		p2.setType(ParameterType.CHARACTER);
 		sender.addParameter(p2);
-		Message message1 = Message.asMessage(new StringReader(TEST_DATA_STRING));
+		Message message1 = new Message(new StringReader(TEST_DATA_STRING));
 		message1.getContext().withSize(TEST_DATA_STRING.getBytes().length);
 		session.put("data", message1);
 

--- a/core/src/test/java/org/frankframework/jms/JmsSenderTest.java
+++ b/core/src/test/java/org/frankframework/jms/JmsSenderTest.java
@@ -72,7 +72,7 @@ class JmsSenderTest {
 	@Test
 	void testSendMessageModeAutoWithTextMessage() throws Exception {
 		// Arrange
-		Message message = Message.asMessage("A Textual Message");
+		Message message = new Message("A Textual Message");
 		jmsSender.setMessageClass(JMSFacade.MessageClass.AUTO);
 
 		// Act
@@ -105,14 +105,14 @@ class JmsSenderTest {
 		BytesMessage bytesMessage = (BytesMessage) jmsMessage;
 		byte[] data = new byte[(int) bytesMessage.getBodyLength()];
 		bytesMessage.readBytes(data);
-		Message result = Message.asMessage(data);
+		Message result = new Message(data);
 		assertEquals(message.asString(), result.asString());
 	}
 
 	@Test
 	void testSendMessageModeBytesWithTextMessage() throws Exception {
 		// Arrange
-		Message message = Message.asMessage("A Textual Message");
+		Message message = new Message("A Textual Message");
 		jmsSender.setMessageClass(JMSFacade.MessageClass.BYTES);
 
 		// Act
@@ -132,7 +132,7 @@ class JmsSenderTest {
 	@Test
 	void testSendMessageModeTextWithBinaryMessage() throws Exception {
 		// Arrange
-		Message message = Message.asMessage("A Textual Message".getBytes(StandardCharsets.UTF_8));
+		Message message = new Message("A Textual Message".getBytes(StandardCharsets.UTF_8));
 		jmsSender.setMessageClass(JMSFacade.MessageClass.TEXT);
 
 		// Act

--- a/core/src/test/java/org/frankframework/parameters/NumberParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/NumberParameterTest.java
@@ -299,7 +299,7 @@ public class NumberParameterTest {
 		assertTrue(c.isAssignableFrom(result.getClass()), c + " is expected type but was: " + result.getClass());
 
 		session = new PipeLineSession();
-		session.put("sessionkey", Message.asMessage("8".getBytes()));
+		session.put("sessionkey", new Message("8".getBytes()));
 
 		result = p.getValue(alreadyResolvedParameters, message, session, false);
 		assertTrue(c.isAssignableFrom(result.getClass()), c + " is expected type but was: " + result.getClass());

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -45,6 +45,7 @@ import org.frankframework.processors.CorePipeLineProcessor;
 import org.frankframework.processors.CorePipeProcessor;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
+import org.frankframework.stream.UrlMessage;
 import org.frankframework.testutil.MatchUtils;
 import org.frankframework.testutil.ParameterBuilder;
 import org.frankframework.testutil.TestConfiguration;
@@ -714,7 +715,7 @@ public class ParameterTest {
 		URL originalMessage = TestFileUtils.getTestFileURL("/Xslt/MultiNamespace/in.xml");
 
 		PipeLineSession session = new PipeLineSession();
-		session.put("originalMessage", Message.asMessage(originalMessage));
+		session.put("originalMessage", new UrlMessage(originalMessage));
 
 		Parameter inputMessage = new Parameter();
 		inputMessage.setName("InputMessage");
@@ -735,7 +736,7 @@ public class ParameterTest {
 		URL originalMessage = TestFileUtils.getTestFileURL("/Xslt/MultiNamespace/in.xml");
 		String expectedResultContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><block><XDOC><REF_ID>0</REF_ID><XX>0</XX></XDOC><XDOC><REF_ID>1</REF_ID></XDOC><XDOC><REF_ID>2</REF_ID></XDOC></block>";
 		PipeLineSession session = new PipeLineSession();
-		session.put("originalMessage", Message.asMessage(originalMessage));
+		session.put("originalMessage", new UrlMessage(originalMessage));
 
 		Parameter parameter = new Parameter();
 		parameter.setName("InputMessage");
@@ -760,7 +761,7 @@ public class ParameterTest {
 		URL originalMessage = TestFileUtils.getTestFileURL("/Xslt/MultiNamespace/in.xml");
 		String expectedResultContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><block><XDOC><REF_ID>0</REF_ID><XX>0</XX></XDOC><XDOC><REF_ID>1</REF_ID></XDOC><XDOC><REF_ID>2</REF_ID></XDOC></block>";
 		PipeLineSession session = new PipeLineSession();
-		session.put("originalMessage", Message.asMessage(originalMessage));
+		session.put("originalMessage", new UrlMessage(originalMessage));
 
 		Parameter parameter = new Parameter();
 		parameter.setName("InputMessage");

--- a/core/src/test/java/org/frankframework/pipes/Base64PipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/Base64PipeTest.java
@@ -280,7 +280,7 @@ class Base64PipeTest extends PipeTestBase<Base64Pipe> {
 
 	private PipeRunResult doBase64PipeWithInputStream(final InputStream stream) throws PipeRunException {
 
-		Message input = Message.asMessage(new ThrowingAfterCloseInputStream(stream));
+		Message input = new Message(new ThrowingAfterCloseInputStream(stream));
 		input.closeOnCloseOf(session, pipe);
 
 		assertTrue(input.isScheduledForCloseOnExitOf(session), "Before Base64Pipe, streaming input message should be scheduled for close on close of session");

--- a/core/src/test/java/org/frankframework/pipes/CompressPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CompressPipeTest.java
@@ -379,7 +379,7 @@ public class CompressPipeTest extends PipeTestBase<CompressPipe> {
 		pipe.setMessageIsContent(true);
 
 		configureAndStartPipe();
-		assertThrows(PipeRunException.class, () -> doPipe(Message.asMessage(DUMMY_STRING.getBytes())));
+		assertThrows(PipeRunException.class, () -> doPipe(new Message(DUMMY_STRING.getBytes())));
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/pipes/CrlPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CrlPipeTest.java
@@ -30,8 +30,8 @@ public class CrlPipeTest extends PipeTestBase<CrlPipe> {
 		pipe.setIssuerSessionKey(issuerKey);
 		configureAndStartPipe();
 
-		Message issuer_cert = Message.asMessage(TestFileUtils.getTestFileURL(CRL_ISSUER_CERT_FILE).openStream());
-		Message crl = Message.asMessage(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
+		Message issuer_cert = new Message(TestFileUtils.getTestFileURL(CRL_ISSUER_CERT_FILE).openStream());
+		Message crl = new Message(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
 		session.put(issuerKey, issuer_cert);
 
 		// act
@@ -50,7 +50,7 @@ public class CrlPipeTest extends PipeTestBase<CrlPipe> {
 		configureAndStartPipe();
 
 		InputStream issuer_cert = TestFileUtils.getTestFileURL(CRL_ISSUER_CERT_FILE).openStream();
-		Message crl = Message.asMessage(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
+		Message crl = new Message(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
 		session.put(issuerKey, issuer_cert);
 
 		// act
@@ -68,8 +68,8 @@ public class CrlPipeTest extends PipeTestBase<CrlPipe> {
 		pipe.setIssuerSessionKey(issuerKey);
 		configureAndStartPipe();
 
-		Message issuer_cert = Message.asMessage(TestFileUtils.getTestFileURL(CRL_ISSUER_CERT_FILE_WRONG).openStream());
-		Message crl = Message.asMessage(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
+		Message issuer_cert = new Message(TestFileUtils.getTestFileURL(CRL_ISSUER_CERT_FILE_WRONG).openStream());
+		Message crl = new Message(TestFileUtils.getTestFileURL(CRL_FILE).openStream());
 		session.put(issuerKey, issuer_cert);
 
 		// act

--- a/core/src/test/java/org/frankframework/pipes/IteratingPipeTestBase.java
+++ b/core/src/test/java/org/frankframework/pipes/IteratingPipeTestBase.java
@@ -43,7 +43,7 @@ public abstract class IteratingPipeTestBase<P extends IteratingPipe<String>> ext
 			String result = "["+message.asString()+"]";
 			resultLog.append(result).append("\n");
 			if (message.asString().contains("error")) {
-				return new SenderResult(Message.asMessage(result), "Error triggered");
+				return new SenderResult(new Message(result), "Error triggered");
 			}
 			return new SenderResult(result);
 		} catch (IOException e) {

--- a/core/src/test/java/org/frankframework/pipes/JsonXsltPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/JsonXsltPipeTest.java
@@ -90,7 +90,7 @@ public class JsonXsltPipeTest extends PipeTestBase<JsonXsltPipe> {
 		Message input = new Message(url.openStream());
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 		assertEquals("onSample Konfabulator Widgetmain_window500500Images/Sun.pngsun1250250centerClick Here36boldtext1250100centersun1.opacity = (sun1.opacity / 100) * 90;", result.trim());
 	}
 }

--- a/core/src/test/java/org/frankframework/pipes/PgpPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/PgpPipeTest.java
@@ -84,7 +84,7 @@ public class PgpPipeTest {
 			assertMessage(mid, MESSAGE);
 
 			// Decryption phase
-			Message decryptMessage = Message.asMessage(encryptionResult.getResult());
+			Message decryptMessage = encryptionResult.getResult();
 			PipeRunResult decryptionResult = decryptPipe.doPipe(decryptMessage, session);
 			byte[] result = decryptionResult.getResult().asByteArray();
 

--- a/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
@@ -538,7 +538,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		SoapWrapperPipe outputWrapper = createWrapperSoapPipe(SoapVersion.SOAP11, true);
 
 		// Act: message through unwrap & wrap pipes
-		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap12), session);
+		PipeRunResult pipeRunResult1 = doPipe(pipe, new Message(soapMessageSoap12), session);
 		PipeRunResult pipeRunResult2 = doPipe(outputWrapper, pipeRunResult1.getResult(), session);
 
 		// Assert: message is determined as SOAP 1.2
@@ -559,7 +559,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		session = new PipeLineSession();
 
 		// Act: message SOAP11 through unwrap & wrap pipes
-		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap11), session);
+		PipeRunResult pipeRunResult1 = doPipe(pipe, new Message(soapMessageSoap11), session);
 		PipeRunResult pipeRunResult2 = doPipe(outputWrapper, pipeRunResult1.getResult(), session);
 
 		// Assert: but the output is determined as SOAP 1.2 instead, as configured
@@ -577,7 +577,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		session = new PipeLineSession();
 
 		// Act: message SOAP12 through unwrap & wrap pipes
-		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap12), session);
+		PipeRunResult pipeRunResult1 = doPipe(pipe, new Message(soapMessageSoap12), session);
 		PipeRunResult pipeRunResult2 = doPipe(outputWrapper, pipeRunResult1.getResult(), session);
 
 		// Assert: but the output is determined as SOAP 1.2 instead, as configured
@@ -624,7 +624,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		session = new PipeLineSession();
 
 		// Act: message SOAP12 through pipes
-		PipeRunResult pipeRunResult1 = doPipe(pipe, Message.asMessage(soapMessageSoap12), session);
+		PipeRunResult pipeRunResult1 = doPipe(pipe, new Message(soapMessageSoap12), session);
 		PipeRunResult pipeRunResult2 = doPipe(outputWrapper, pipeRunResult1.getResult(), session);
 		PipeRunResult pipeRunResult3 = doPipe(outputWrapper2, pipeRunResult2.getResult(), session);
 

--- a/core/src/test/java/org/frankframework/pipes/Text2XmlPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/Text2XmlPipeTest.java
@@ -220,7 +220,7 @@ public class Text2XmlPipeTest extends PipeTestBase<Text2XmlPipe> {
 		pipe.setSplitLines(true);
 		configureAndStartPipe();
 
-		PipeRunResult res = doPipe(Message.asMessage(""));
+		PipeRunResult res = doPipe(new Message(""));
 		MatchUtils.assertXmlEquals("<tests/>", res.getResult().asString());
 	}
 
@@ -229,7 +229,7 @@ public class Text2XmlPipeTest extends PipeTestBase<Text2XmlPipe> {
 		pipe.setXmlTag("tests");
 		configureAndStartPipe();
 
-		PipeRunResult res = doPipe(Message.asMessage(""));
+		PipeRunResult res = doPipe(new Message(""));
 		assertEquals("<tests><![CDATA[]]></tests>", res.getResult().asString());
 	}
 

--- a/core/src/test/java/org/frankframework/pipes/TextSplitterPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/TextSplitterPipeTest.java
@@ -39,7 +39,7 @@ public class TextSplitterPipeTest extends PipeTestBase<TextSplitterPipe> {
 		prr = doPipe(Message.nullMessage());
 		assertEquals("<text/>", prr.getResult().asString());
 
-		prr = doPipe(Message.asMessage(""));
+		prr = doPipe(new Message(""));
 		assertEquals("<text/>", prr.getResult().asString());
 	}
 

--- a/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
@@ -230,7 +230,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		session.put("SOAPAction", "add");
 		val.configure();
 		val.start();
-		val.validate(Message.asMessage("""
+		val.validate(new Message("""
 				<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:impl="http://test.example.com">
 					<s:Header/>
 					<s:Body>
@@ -242,7 +242,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 				"""), session, true, null);
 
 		session.put("SOAPAction", "sub");
-		val.validate(Message.asMessage("""
+		val.validate(new Message("""
 				<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:impl="http://test.example.com">
 					<s:Header/>
 					<s:Body>
@@ -253,7 +253,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 				</s:Envelope>\
 				"""), session, true, null);
 
-		val.validate(Message.asMessage("""
+		val.validate(new Message("""
 				<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:impl="http://test.example.com">
 					<s:Header/>
 					<s:Body>

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -206,7 +206,7 @@ public class InputOutputPipeProcessorTest {
 		pipe.configure();
 		pipe.start();
 
-		Message input = Message.asMessage(INPUT_MESSAGE_TEXT);
+		Message input = new Message(INPUT_MESSAGE_TEXT);
 
 		// This should be true
 		assertTrue(pipe.skipPipe(input, session));
@@ -226,7 +226,7 @@ public class InputOutputPipeProcessorTest {
 		pipe.configure();
 		pipe.start();
 
-		Message input = Message.asMessage("dummy");
+		Message input = new Message("dummy");
 		session.put("this-key-is-there", "the-key-the-value");
 
 		// This should be true
@@ -245,7 +245,7 @@ public class InputOutputPipeProcessorTest {
 
 		session.put("this-key-is-there", "value");
 
-		Message input = Message.asMessage(INPUT_MESSAGE_TEXT);
+		Message input = new Message(INPUT_MESSAGE_TEXT);
 
 		// This should be true
 		assertTrue(pipe.skipPipe(input, session));
@@ -347,7 +347,7 @@ public class InputOutputPipeProcessorTest {
 		pipe.configure();
 		pipe.start();
 
-		Message input = Message.asMessage(INPUT_MESSAGE_TEXT);
+		Message input = new Message(INPUT_MESSAGE_TEXT);
 
 		// This should be true, b/c input message is empty
 		assertTrue(pipe.skipPipe(input, session));

--- a/core/src/test/java/org/frankframework/receivers/JavaListenerTest.java
+++ b/core/src/test/java/org/frankframework/receivers/JavaListenerTest.java
@@ -144,7 +144,7 @@ public class JavaListenerTest {
 	public void testProcessRequestMessage() throws Exception {
 		// Arrange
 		String rawTestMessage = "TEST";
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 		listener.setThrowException(true);
 
 		// start adapter
@@ -164,7 +164,7 @@ public class JavaListenerTest {
 	public void testProcessRequestMessageWithHttpRequest() throws Exception {
 		// Arrange
 		String rawTestMessage = "TEST";
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 		listener.setThrowException(true);
 
 		HttpServletRequest servletRequest = mock(HttpServletRequest.class);
@@ -186,7 +186,7 @@ public class JavaListenerTest {
 	@Test
 	public void testProcessRequestMessageWithException() throws Exception {
 		// Arrange 1
-		Message testMessage = Message.asMessage(new StringReader("TEST"));
+		Message testMessage = new Message(new StringReader("TEST"));
 		listener.setThrowException(true);
 		assertSame(Receiver.OnError.CONTINUE, receiver.getOnError()); // Validate default setting: in state CONTINUE after an error occurs
 
@@ -212,7 +212,7 @@ public class JavaListenerTest {
 	public void testProcessRequestMessageWithExceptionDoNotThrow() throws Exception {
 		// Arrange
 		String rawTestMessage = "TEST";
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 		listener.setThrowException(false);
 
 		PipeLine pipeLine = adapter.getPipeLine();
@@ -236,7 +236,7 @@ public class JavaListenerTest {
 	public void testProcessRequestWithReturnSessionKeys() throws Exception {
 		// Arrange
 		String rawTestMessage = "TEST";
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 		session.put("copy-this", "original-value");
 
 		// start adapter
@@ -259,7 +259,7 @@ public class JavaListenerTest {
 	public void testProcessRequestWithReturnSessionKeysWhenNoneConfigured() throws Exception {
 		// Arrange
 		String rawTestMessage = "TEST";
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 		listener.setReturnedSessionKeys(null);
 		session.put("copy-this", "original-value");
 

--- a/core/src/test/java/org/frankframework/receivers/MockListenerBase.java
+++ b/core/src/test/java/org/frankframework/receivers/MockListenerBase.java
@@ -52,7 +52,7 @@ public abstract class MockListenerBase implements IListener<String> {
 		if("extractMessageException".equals(text)) {
 			throw new ListenerException(text);
 		}
-		return Message.asMessage(text);
+		return new Message(text);
 	}
 
 	@Override

--- a/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
@@ -17,7 +17,7 @@ public class MockPushingListener extends MockListenerBase implements IPushingLis
 	public void offerMessage(String text) throws ListenerException {
 		try(PipeLineSession session = new PipeLineSession()) {
 			RawMessageWrapper<String> raw = wrapRawMessage(text, session);
-			handler.processRequest(this, raw, Message.asMessage(text), session);
+			handler.processRequest(this, raw, new Message(text), session);
 		}
 	}
 

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -627,7 +627,7 @@ public class ReceiverTest {
 		// Arrange
 		String rawTestMessage = "TEST";
 		RawMessageWrapper<String> rawTestMessageWrapper = new RawMessageWrapper<>(rawTestMessage, "mid", "cid");
-		Message testMessage = Message.asMessage(new StringReader(rawTestMessage));
+		Message testMessage = new Message(new StringReader(rawTestMessage));
 
 		configuration = buildNarayanaTransactionManagerConfiguration();
 		ITransactionalStorage<Serializable> errorStorage = setupErrorStorage();
@@ -689,7 +689,7 @@ public class ReceiverTest {
 
 		PipeLineResult plr = new PipeLineResult();
 		plr.setState(ExitState.SUCCESS);
-		plr.setResult(Message.asMessage(testMessage));
+		plr.setResult(new Message(testMessage));
 		doReturn(plr).when(adapter).processMessageWithExceptions(any(), messageCaptor.capture(), sessionCaptor.capture());
 
 		// Act

--- a/core/src/test/java/org/frankframework/senders/IbisLocalSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/IbisLocalSenderTest.java
@@ -193,7 +193,7 @@ class IbisLocalSenderTest {
 
 		try (PipeLineSession session = new PipeLineSession()) {
 			session.put("my-parameter1", "parameter1-value");
-			session.put("my-parameter2", Message.asMessage("parameter2-value"));
+			session.put("my-parameter2", new Message("parameter2-value"));
 			Message message = new Message("my-parameter1");
 			session.put("session-message", message);
 

--- a/core/src/test/java/org/frankframework/senders/ShadowSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/ShadowSenderTest.java
@@ -68,7 +68,7 @@ public class ShadowSenderTest extends ParallelSendersTest {
 
 		@Override
 		public SenderResult sendMessage(Message message, PipeLineSession session) throws SenderException, TimeoutException {
-			result = Message.asMessage(message);
+			result = message;
 			return super.sendMessage(message, session);
 		}
 	}

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -772,7 +772,7 @@ public class MessageTest {
 
 		File file = new File(url.toURI());
 		FileInputStream fis = new FileInputStream(file);
-		try (Message message = Message.asMessage(fis)) {
+		try (Message message = new Message(fis)) {
 			testAsInputStream(message);
 		}
 	}
@@ -1024,14 +1024,14 @@ public class MessageTest {
 
 	@Test
 	public void testMessageSizeString() throws IOException {
-		Message message = Message.asMessage("string");
+		Message message = new Message("string");
 		assertEquals(6, message.size(), "size differs or could not be determined");
 		message.close();
 	}
 
 	@Test
 	public void testMessageSizeByteArray() throws IOException {
-		Message message = Message.asMessage("string".getBytes());
+		Message message = new Message("string".getBytes());
 		assertEquals(6, message.size(), "size differs or could not be determined");
 		message.close();
 	}
@@ -1043,7 +1043,7 @@ public class MessageTest {
 
 		File file = new File(url.toURI());
 		try (FileInputStream fis = new FileInputStream(file);
-			 Message message = Message.asMessage(fis)) {
+			 Message message = new Message(fis)) {
 			assertEquals(33, message.size(), "size differs or could not be determined");
 		}
 	}
@@ -1054,7 +1054,7 @@ public class MessageTest {
 		assertNotNull(url, "cannot find testfile");
 
 		File file = new File(url.toURI());
-		try (Message message = Message.asMessage(file)) {
+		try (Message message = new FileMessage(file)) {
 			assertEquals(33, message.size(), "size differs or could not be determined");
 		}
 	}
@@ -1064,7 +1064,7 @@ public class MessageTest {
 		URL url = this.getClass().getResource("/file.xml");
 		assertNotNull(url, "cannot find testfile");
 
-		try (Message message = Message.asMessage(url)) {
+		try (Message message = new UrlMessage(url)) {
 			assertEquals(-1, message.size(), "size differs or could not be determined");
 		}
 	}
@@ -1081,7 +1081,7 @@ public class MessageTest {
 		URL url = new URL("http://www.file.xml");
 		assertNotNull(url, "cannot find testfile");
 
-		try (Message message = Message.asMessage(url)) {
+		try (Message message = new UrlMessage(url)) {
 			assertEquals(-1, message.size());
 		}
 	}
@@ -1236,7 +1236,7 @@ public class MessageTest {
 	@Test
 	public void testCopyMessage1() throws IOException {
 		// Arrange
-		Message msg1 = Message.asMessage("a");
+		Message msg1 = new Message("a");
 
 		// Act
 		Message msg2 = msg1.copyMessage();
@@ -1253,7 +1253,7 @@ public class MessageTest {
 	@Test
 	public void testCopyMessage2() throws IOException {
 		// Arrange
-		Message msg1 = Message.asMessage(new StringReader("á"));
+		Message msg1 = new Message(new StringReader("á"));
 
 		// Act
 		Message msg2 = msg1.copyMessage();
@@ -1270,7 +1270,7 @@ public class MessageTest {
 	@Test
 	public void testCopyMessage3() throws IOException {
 		// Arrange
-		Message msg1 = Message.asMessage(new ByteArrayInputStream("á".getBytes()));
+		Message msg1 = new Message(new ByteArrayInputStream("á".getBytes()));
 
 		// Act
 		Message msg2 = msg1.copyMessage();
@@ -1312,7 +1312,7 @@ public class MessageTest {
 	void testMessageAsStringDoesNotCloseMessage() throws IOException {
 		// Arrange
 		String text = "text";
-		Message msg = Message.asMessage(new StringReader(text));
+		Message msg = new Message(new StringReader(text));
 
 		// Act
 		String content = msg.asString();
@@ -1326,7 +1326,7 @@ public class MessageTest {
 	void testMessageAsStringDoesNotCloseMessageWrapper() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
 		String text = "text";
-		Message msg = Message.asMessage(new StringReader(text));
+		Message msg = new Message(new StringReader(text));
 		MessageWrapper<Message> wrapper = new MessageWrapper<>(msg, null, null);
 
 		// Act
@@ -1340,7 +1340,7 @@ public class MessageTest {
 	@Test
 	void testMessageAsByteArrayDoesNotCloseMessage() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
-		Message msg = Message.asMessage(new StringReader("text"));
+		Message msg = new Message(new StringReader("text"));
 
 		// Act
 		byte[] content = msg.asByteArray();
@@ -1355,7 +1355,7 @@ public class MessageTest {
 	@Test
 	void testMessageAsByteArrayDoesNotCloseMessageWrapper() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
-		Message msg = Message.asMessage(new StringReader("text"));
+		Message msg = new Message(new StringReader("text"));
 		MessageWrapper wrapper = new MessageWrapper<Message>(msg, null, null);
 
 		// Act

--- a/core/src/test/java/org/frankframework/util/MessageToStringResolverTest.java
+++ b/core/src/test/java/org/frankframework/util/MessageToStringResolverTest.java
@@ -22,7 +22,7 @@ class MessageToStringResolverTest {
 	void setUp() {
 		propsA = new HashMap<>();
 		propsB = new HashMap<>();
-		message = Message.asMessage("My Message");
+		message = new Message("My Message");
 		propsA.put("msg", message);
 		propsB.put("msg", "Not My Message");
 	}

--- a/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
@@ -174,7 +174,7 @@ public class MessageUtilsTest {
 		URL url = TestFileUtils.getTestFileURL("/file.xml");
 		assertNotNull(url);
 		try (Message message = new UrlMessage(url)) {
-			MessageDataSource ds = new MessageDataSource(Message.asMessage(message.asString()));
+			MessageDataSource ds = new MessageDataSource(new Message(message.asString()));
 			assertEquals(null, ds.getName(), "filename is unknown");
 			assertEquals("application/octet-stream", ds.getContentType(), "content-type cannot be determined");
 			assertEquals(StreamUtil.streamToString(url.openStream()), StreamUtil.streamToString(ds.getInputStream()), "contents should be the same");
@@ -187,7 +187,7 @@ public class MessageUtilsTest {
 		URL url = TestFileUtils.getTestFileURL("/log4j4ibis.xml");
 		assertNotNull(url);
 		try (Message message = new UrlMessage(url)) {
-			MessageDataSource ds = new MessageDataSource(Message.asMessage(message.asString()));
+			MessageDataSource ds = new MessageDataSource(new Message(message.asString()));
 			assertEquals(null, ds.getName(), "filename is unknown");
 			assertEquals("application/xml", ds.getContentType(), "content-type cannot be determined");
 			assertEquals(StreamUtil.streamToString(ds.getInputStream()), StreamUtil.streamToString(url.openStream()), "contents should be the same");
@@ -197,7 +197,7 @@ public class MessageUtilsTest {
 
 	@Test
 	public void testJsonMessage() {
-		Message json = Message.asMessage("{\"GUID\": \"ABC\"}");
+		Message json = new Message("{\"GUID\": \"ABC\"}");
 		MimeType mimeType = MessageUtils.computeMimeType(json);
 		assertNotNull(mimeType);
 		assertEquals("application/octet-stream", mimeType.toString()); //mime-type cannot be determined
@@ -275,7 +275,7 @@ public class MessageUtilsTest {
 	@Test
 	void testMessageAsStringDoesNotCloseMessage() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
-		Object msg = Message.asMessage(new StringReader("text"));
+		Object msg = new Message(new StringReader("text"));
 
 		// Act
 		String content = MessageUtils.asString(msg);
@@ -290,7 +290,7 @@ public class MessageUtilsTest {
 	@Test
 	void testMessageAsStringDoesNotCloseMessageWrapper() throws IOException {
 		// Arrange: make it an object, so method can do instanceof check
-		Message msg = Message.asMessage(new StringReader("text"));
+		Message msg = new Message(new StringReader("text"));
 		Object wrapper = new MessageWrapper<Message>(msg, null, null);
 
 		// Act

--- a/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
@@ -8,6 +8,8 @@ import java.net.URL;
 import java.util.Arrays;
 
 import org.frankframework.stream.Message;
+import org.frankframework.stream.UrlMessage;
+
 import org.junit.jupiter.api.Test;
 
 class StreamCaptureUtilsTest {
@@ -49,6 +51,6 @@ class StreamCaptureUtilsTest {
 
 		byte[] capture = Arrays.copyOf(boas.toByteArray(), bufferSize); //it is possible more characters have been written to the captured stream
 		assertEquals(new String(magic), new String(capture));
-		assertEquals(message.asString(), Message.asMessage(input).asString()); //verify that the message output, after reading the magic, has not changed
+		assertEquals(message.asString(), new UrlMessage(input).asString()); //verify that the message output, after reading the magic, has not changed
 	}
 }

--- a/core/src/test/java/org/frankframework/xslt/XsltPipeTest.java
+++ b/core/src/test/java/org/frankframework/xslt/XsltPipeTest.java
@@ -80,7 +80,7 @@ public class XsltPipeTest extends XsltErrorTestBase<XsltPipe> {
 		PipeRunResult prr = doPipe(pipe, input, session);
 		Message sessionKey = session.getMessage("sessionKey");
 		assertEquals(expected, sessionKey.asString());
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 		assertEquals(result, input);
 	}
 

--- a/core/src/test/java/org/frankframework/xslt/XsltTestBase.java
+++ b/core/src/test/java/org/frankframework/xslt/XsltTestBase.java
@@ -267,7 +267,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, "<dummy name=\"input\"/>", session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect("b", result, session);
 	}
@@ -282,7 +282,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}
@@ -330,7 +330,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}
@@ -347,7 +347,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}
@@ -365,7 +365,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}
@@ -386,7 +386,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected.trim(), result.trim(), session); // trim is necessary on IBM JDK
 	}
@@ -421,7 +421,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		pipe.start();
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}
@@ -440,7 +440,7 @@ public abstract class XsltTestBase<P extends FixedForwardPipe> extends PipeTestB
 		String expected = TestFileUtils.getTestFile("/Xslt/AnyXml/SkipEmptyTagsIndent.xml");
 
 		PipeRunResult prr = doPipe(pipe, input, session);
-		String result = Message.asMessage(prr.getResult()).asString();
+		String result = prr.getResult().asString();
 
 		assertResultsAreCorrect(expected, result, session);
 	}

--- a/filesystem/src/main/java/org/frankframework/filesystem/FileSystemActor.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/FileSystemActor.java
@@ -364,12 +364,12 @@ public class FileSystemActor<F, S extends IBasicFileSystem<F>> {
 					return createFile(input, pvl, null);
 				}
 				case DELETE: {
-					return Message.asMessage(processAction(input, pvl, f -> { fileSystem.deleteFile(f); return f; }));
+					return new Message(processAction(input, pvl, f -> { fileSystem.deleteFile(f); return f; }));
 				}
 				case INFO: {
 					F file=getFile(input, pvl);
 					FileSystemUtils.checkSource(fileSystem, file, FileSystemAction.INFO);
-					return Message.asMessage(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
+					return new Message(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
 				}
 				case READ: {
 					F file = getFile(input, pvl);
@@ -406,17 +406,17 @@ public class FileSystemActor<F, S extends IBasicFileSystem<F>> {
 					}
 
 					((IWritableFileSystem<F>)fileSystem).appendFile(file, getContents(input, pvl, charset));
-					return Message.asMessage(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
+					return new Message(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
 				}
 				case MKDIR: {
 					String folder = determineInputFolderName(input, pvl);
 					fileSystem.createFolder(folder);
-					return Message.asMessage(folder);
+					return new Message(folder);
 				}
 				case RMDIR: {
 					String folder = determineInputFolderName(input, pvl);
 					fileSystem.removeFolder(folder, isRemoveNonEmptyFolder());
-					return Message.asMessage(folder);
+					return new Message(folder);
 				}
 				case RENAME: {
 					F source=getFile(input, pvl);
@@ -429,15 +429,15 @@ public class FileSystemActor<F, S extends IBasicFileSystem<F>> {
 						destination = fileSystem.toFile(folderPath,destinationName);
 					}
 					F renamed = FileSystemUtils.renameFile((IWritableFileSystem<F>)fileSystem, source, destination, isOverwrite(), getNumberOfBackups());
-					return Message.asMessage(fileSystem.getName(renamed));
+					return new Message(fileSystem.getName(renamed));
 				}
 				case MOVE: {
 					String destinationFolder = determineDestination(pvl);
-					return Message.asMessage(processAction(input, pvl, f -> FileSystemUtils.moveFile(fileSystem, f, destinationFolder, isOverwrite(), getNumberOfBackups(), isCreateFolder(), false)));
+					return new Message(processAction(input, pvl, f -> FileSystemUtils.moveFile(fileSystem, f, destinationFolder, isOverwrite(), getNumberOfBackups(), isCreateFolder(), false)));
 				}
 				case COPY: {
 					String destinationFolder = determineDestination(pvl);
-					return Message.asMessage(processAction(input, pvl, f -> FileSystemUtils.copyFile(fileSystem, f, destinationFolder, isOverwrite(), getNumberOfBackups(), isCreateFolder(), false)));
+					return new Message(processAction(input, pvl, f -> FileSystemUtils.copyFile(fileSystem, f, destinationFolder, isOverwrite(), getNumberOfBackups(), isCreateFolder(), false)));
 				}
 				case FORWARD: {
 					F file=getFile(input, pvl);
@@ -467,7 +467,7 @@ public class FileSystemActor<F, S extends IBasicFileSystem<F>> {
 				}
 			}
 		}
-		return Message.asMessage(directoryBuilder.toString());
+		return new Message(directoryBuilder.toString());
 	}
 
 	private Message createFile(@Nonnull Message input, ParameterValueList pvl, InputStream contents) throws FileSystemException, IOException {
@@ -482,7 +482,7 @@ public class FileSystemActor<F, S extends IBasicFileSystem<F>> {
 		}
 
 		((IWritableFileSystem<F>)fileSystem).createFile(file, contents);
-		return Message.asMessage(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
+		return new Message(FileSystemUtils.getFileInfo(fileSystem, file, getOutputFormat()));
 	}
 
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/FileSystemSenderWithAttachments.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/FileSystemSenderWithAttachments.java
@@ -91,7 +91,7 @@ public class FileSystemSenderWithAttachments<F, A, FS extends IMailFileSystem<F,
 				log.error("unable to list all attachments", e);
 				throw new SenderException(e);
 			}
-			return new SenderResult(Message.asMessage(attachments.toString()));
+			return new SenderResult(new Message(attachments.toString()));
 		}
 	}
 

--- a/filesystem/src/test/java/org/frankframework/filesystem/FileSystemActorTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/FileSystemActorTest.java
@@ -536,7 +536,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		Message message = new Message(folder + "/" + filename);
 		ParameterValueList pvl = null;
 
-		result = Message.asMessage(actor.doAction(message, pvl, session));
+		result = actor.doAction(message, pvl, session);
 
 		assertEquals(contents, result.asString());
 		assertFalse(_fileExists(filename), "Expected file [" + filename + "] not to be present");
@@ -561,7 +561,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		Message message = new Message(filename);
 		ParameterValueList pvl = null;
 
-		result = Message.asMessage(actor.doAction(message, pvl, session));
+		result = actor.doAction(message, pvl, session);
 		assertEquals(contents, result.asString());
 	}
 
@@ -583,7 +583,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		Message message = new Message(filename);
 		ParameterValueList pvl = null;
 
-		Message result = Message.asMessage(actor.doAction(message, pvl, session));
+		Message result = actor.doAction(message, pvl, session);
 		assertEquals(expected, result.asString());
 	}
 
@@ -661,7 +661,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		}
 
 		PipeLineSession session = new PipeLineSession();
-		Message sessionMessage = Message.asMessage(new ThrowingAfterCloseInputStream(new ByteArrayInputStream(contents.getBytes())));
+		Message sessionMessage = new Message(new ThrowingAfterCloseInputStream(new ByteArrayInputStream(contents.getBytes())));
 		session.put("writeLineSeparator", sessionMessage);
 
 		ParameterList params = new ParameterList();
@@ -743,7 +743,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		actor.configure(fileSystem, params, owner);
 		actor.open();
 
-		Message message = Message.asMessage(new ThrowingAfterCloseInputStream(new ByteArrayInputStream(contents.getBytes())));
+		Message message = new Message(new ThrowingAfterCloseInputStream(new ByteArrayInputStream(contents.getBytes())));
 		ParameterValueList pvl = params.getValues(message, session);
 		result = actor.doAction(message, pvl, session);
 		waitForActionToFinish();
@@ -992,7 +992,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 
 		Message message = new Message(filename);
 		for (int i = 0; i < numOfWrites; i++) {
-			Message sessionMessage = Message.asMessage(new ThrowingAfterCloseInputStream(new ByteArrayInputStream((contents + i).getBytes())));
+			Message sessionMessage = new Message(new ThrowingAfterCloseInputStream(new ByteArrayInputStream((contents + i).getBytes())));
 			session.put("appendWriteLineSeparatorTest", sessionMessage);
 			ParameterValueList pvl = params.getValues(message, session);
 			Message result = actor.doAction(message, pvl, session);
@@ -1711,7 +1711,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 
 		InputStream contents = _readFile(null, filename);
 		// test
-		assertEquals("", Message.asMessage(contents).asString(), "Expected file [" + filename + "] " + "to be empty");
+		assertEquals("", new Message(contents).asString(), "Expected file [" + filename + "] " + "to be empty");
 	}
 
 	@Test
@@ -1736,7 +1736,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 
 		InputStream contents = _readFile(null, filename);
 		// test
-		assertEquals("", Message.asMessage(contents).asString(), "Expected file [" + filename + "] " + "to be empty");
+		assertEquals("", new Message(contents).asString(), "Expected file [" + filename + "] " + "to be empty");
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/FileSystemPipeTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/FileSystemPipeTest.java
@@ -718,9 +718,9 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		prr = fileSystemPipe.doPipe(input, session);
 		CloseUtils.closeSilently(input);
 		assertNotNull(prr);
-		String result=prr.getResult().asString();
+		Message result = prr.getResult();
 
-		log.debug(result);
+		log.debug(result.asString());
 
 		// TODO test that the fileSystemPipe has returned the an XML with the details of the file
 //		Iterator<F> it = result;
@@ -813,7 +813,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		prr = fileSystemPipe.doPipe(input, session);
 		CloseUtils.closeSilently(input);
 		assertNotNull(prr);
-		String result=prr.getResult().asString();
+		Message result = prr.getResult();
 		waitForActionToFinish();
 
 		assertFileCountEquals(result, 2);

--- a/filesystem/src/test/java/org/frankframework/filesystem/FileSystemTestBase.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/FileSystemTestBase.java
@@ -115,15 +115,15 @@ public abstract class FileSystemTestBase extends ConfiguredTestBase {
 		assertFalse(_fileExists(folder, filename), filename+" should not exist");
 	}
 
-	protected void assertFileCountEquals(Object result, int expectedFileCount) throws Exception {
+	protected void assertFileCountEquals(Message result, int expectedFileCount) throws Exception {
 		TransformerPool tp = TransformerPool.getXPathTransformerPool(null, "count(*/file[@type='file'])", OutputType.TEXT, false, null);
-		int resultCount = Integer.parseInt(tp.transform(Message.asMessage(result), null, false));
+		int resultCount = Integer.parseInt(tp.transform(result, null, false));
 		assertEquals(expectedFileCount, resultCount, "file count mismatch");
 	}
 
-	protected void assertFolderCountEquals(Object result, int expectedFolderCount) throws Exception {
+	protected void assertFolderCountEquals(Message result, int expectedFolderCount) throws Exception {
 		TransformerPool tp = TransformerPool.getXPathTransformerPool(null, "count(*/file[@type='folder']) ", OutputType.TEXT, false, null);
-		int resultCount = Integer.parseInt(tp.transform(Message.asMessage(result), null, false));
+		int resultCount = Integer.parseInt(tp.transform(result, null, false));
 		assertEquals(expectedFolderCount, resultCount, "folder count mismatch");
 	}
 

--- a/filesystem/src/test/java/org/frankframework/util/FileHandlerTestBase.java
+++ b/filesystem/src/test/java/org/frankframework/util/FileHandlerTestBase.java
@@ -149,7 +149,7 @@ public abstract class FileHandlerTestBase {
 		String contents = MessageTestUtils.getMessage(BASEDIR + contentFile).asString();
 		assertNotNull(contents);
 		String stringContent = contents.replace("\r", ""); //Remove carriage return
-		String actFilename = (String) handler.handle(Message.asMessage(stringContent), session, paramList);
+		String actFilename = (String) handler.handle(new Message(stringContent), session, paramList);
 		if(filename == null) {
 			assertNotNull(actFilename);
 		} else {

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/tibet2/Storage.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/tibet2/Storage.java
@@ -567,7 +567,7 @@ public class Storage extends JdbcFacade implements LogStorage, CrudStorage {
 		}
 		List<Checkpoint> checkpoints = report.getCheckpoints();
 		Checkpoint checkpoint = checkpoints.get(0);
-		Message message = Message.asMessage(checkpoint.getMessage());
+		Message message = new Message(checkpoint.getMessage());
 		Configuration config = ibisDebugger.getIbisManager().getConfiguration(DELETE_ADAPTER_CONFIG);
 		if (config == null) {
 			throw new StorageException("Configuration '" + DELETE_ADAPTER_CONFIG + "' not found");

--- a/ladybug/src/test/java/org/frankframework/ibistesttool/TestPipeDescriptionProvider.java
+++ b/ladybug/src/test/java/org/frankframework/ibistesttool/TestPipeDescriptionProvider.java
@@ -10,6 +10,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.jupiter.api.Test;
+
+import org.frankframework.stream.UrlMessage;
 import org.w3c.dom.Node;
 
 import org.frankframework.stream.Message;
@@ -22,7 +24,7 @@ public class TestPipeDescriptionProvider {
 		PipeDescription description = new PipeDescription();
 
 		URL url = TestPipeDescriptionProvider.class.getResource("/testSchemaLocation.xml");
-		Message input = Message.asMessage(url);
+		Message input = new UrlMessage(url);
 		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 
 		Node root = db.parse(input.asInputSource());
@@ -39,7 +41,7 @@ public class TestPipeDescriptionProvider {
 		PipeDescription description = new PipeDescription();
 
 		URL url = TestPipeDescriptionProvider.class.getResource("/testWithTwoSchemaLocations.xml");
-		Message input = Message.asMessage(url);
+		Message input = new UrlMessage(url);
 		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 
 		Node root = db.parse(input.asInputSource());
@@ -57,7 +59,7 @@ public class TestPipeDescriptionProvider {
 		PipeDescription description = new PipeDescription();
 
 		URL url = TestPipeDescriptionProvider.class.getResource("/testFilename.xml");
-		Message input = Message.asMessage(url);
+		Message input = new UrlMessage(url);
 		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 
 		Node root = db.parse(input.asInputSource());

--- a/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
+++ b/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
@@ -91,7 +91,7 @@ public class IbisTester {
 			LarvaTool.runScenarios(ibisContext, request, writer, silent, webAppPath);
 			if (scenario == null) {
 				String htmlString = "<html><head/><body>" + writer + "</body></html>";
-				return XmlUtils.toXhtml(Message.asMessage(htmlString));
+				return XmlUtils.toXhtml(new Message(htmlString));
 			} else {
 				return writer.toString();
 			}


### PR DESCRIPTION
Changed the code to use alternatives instead of Message.asMessage when the type of the paramter is known.