### PR TITLE
Use an AWS S3 file reference instead of misusing the S3Object

### DIFF
--- a/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
+++ b/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
@@ -29,6 +29,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -50,7 +51,9 @@ public class S3FileRef {
 	private static final String FILE_DELIMITER = "/";
 	public static final String BUCKET_OBJECT_SEPARATOR = "|";
 
+	@Nonnull //may be empty
 	private final String name;
+	@Nullable
 	private final String folder;
 
 	private @Getter @Setter Long contentLength = null;

--- a/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
+++ b/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
@@ -109,11 +109,10 @@ public class S3FileRef {
 		if(StringUtils.isNotEmpty(name)) { // File: when not empty, return this immediately
 			return name;
 		}
-		if (folder != null) { // Folder: only take part before last slash
-			int lastSlashPos = folder.lastIndexOf('/', folder.length() - 2);
-			return folder.substring(lastSlashPos + 1);
-		}
-		return null;
+
+		// Folder: only take part before last slash
+		String removeEndSlash = StringUtils.chop(folder);
+		return StringUtils.substringAfterLast(removeEndSlash, '/');
 	}
 
 	public void addUserMetadata(String key, String value) {

--- a/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
+++ b/aws/src/main/java/org/frankframework/filesystem/S3FileRef.java
@@ -1,0 +1,138 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.filesystem;
+
+import java.io.InputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.frankframework.util.StringUtil;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Object to hold information about an object stored in Amazon S3.
+ * Since the S3 API uses different types of response objects the object here is to:
+ * <ul>
+ * <li>Allow keys to be prefixed with a bucket-name, separated by {@value #BUCKET_OBJECT_SEPARATOR}.</li>
+ * <li>Ensure the correct filename (with extension) is used.</li>
+ * <li>Ensures correct folder names, using UNIX path delimiters, ending with a {@value #FILE_DELIMITER}.</li>
+ * <li>The content-lenght as well as modification-time are stored.</li>
+ * <li>Everything can be updated with a simple method to simplify code in implementations.</li>
+ * </ul>
+ * 
+ * @author Niels Meijer
+ */
+public class S3FileRef {
+
+	private static final String FILE_DELIMITER = "/";
+	public static final String BUCKET_OBJECT_SEPARATOR = "|";
+
+	private final String name;
+	private final String folder;
+
+	private @Getter @Setter Long contentLength = null;
+	private @Getter @Setter Date lastModified = null;
+	private @Getter @Setter String bucketName;
+	private Map<String, String> userMetadata = new HashMap<>();
+
+	private @Getter InputStream objectContent;
+
+	/** Strip folder prefix of filename if present. May not be changed after creation */
+	private S3FileRef(@Nonnull String key) {
+		int separatorPos = key.indexOf(BUCKET_OBJECT_SEPARATOR);
+		final String rawKey;
+		if (separatorPos < 0) {
+			rawKey = key;
+		} else {
+			setBucketName(key.substring(0,separatorPos));
+			rawKey = key.substring(separatorPos+1);
+		}
+
+		String normalized = FilenameUtils.normalize(rawKey, true);
+		this.name = FilenameUtils.getName(normalized); //may be an empty string
+
+		String folder = FilenameUtils.getFullPathNoEndSeparator(normalized);
+		//crazy hack to always ensure there is a slash at the end
+		this.folder = StringUtils.isNotEmpty(folder) ? folder + FILE_DELIMITER : null;
+	}
+
+	public S3FileRef(S3ObjectSummary summary) {
+		this(summary.getKey());
+		setContentLength(summary.getSize());
+		setLastModified(summary.getLastModified());
+		setBucketName(summary.getBucketName());
+	}
+
+	public S3FileRef(String key, String defaultBucketName) {
+		this(key);
+
+		if(StringUtils.isEmpty(bucketName)) {
+			setBucketName(defaultBucketName);
+		}
+	}
+
+	public S3FileRef(String filename, String folderName, String bucketName) {
+		this(StringUtil.concatStrings(folderName, FILE_DELIMITER, filename), bucketName);
+	}
+
+	/** Returns the canonical name inclusive file path when present */
+	public String getKey() {
+		String prefix = folder != null ? folder : "";
+		return prefix + name;
+	}
+
+	/** Returns either the file or foldername (suffixed with a slash) */
+	public String getName() {
+		if(StringUtils.isNotEmpty(name)) { // File: when not empty, return this immediately
+			return name;
+		}
+		if (folder != null) { // Folder: only take part before last slash
+			int lastSlashPos = folder.lastIndexOf('/', folder.length() - 2);
+			return folder.substring(lastSlashPos + 1);
+		}
+		return null;
+	}
+
+	public void addUserMetadata(String key, String value) {
+		userMetadata.put(key, value);
+	}
+
+	@Nonnull
+	public Map<String, String> getUserMetadata() {
+		return userMetadata;
+	}
+
+	public void updateObject(S3Object obj) {
+		objectContent = obj.getObjectContent();
+		updateObject(obj.getObjectMetadata());
+	}
+
+	public void updateObject(ObjectMetadata omd) {
+		setContentLength(omd.getContentLength());
+		setLastModified(omd.getLastModified());
+		userMetadata.putAll(omd.getUserMetadata());
+	}
+}

--- a/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
+++ b/aws/src/main/java/org/frankframework/senders/AmazonS3Sender.java
@@ -15,11 +15,10 @@
 */
 package org.frankframework.senders;
 
-import com.amazonaws.services.s3.model.S3Object;
-
 import org.frankframework.filesystem.AmazonS3FileSystem;
 import org.frankframework.filesystem.AmazonS3FileSystemDelegator;
 import org.frankframework.filesystem.FileSystemSender;
+import org.frankframework.filesystem.S3FileRef;
 
 /**
  * Sender to work with the Amazon S3 Filesystem.
@@ -33,7 +32,7 @@ import org.frankframework.filesystem.FileSystemSender;
  *     The string value of these parameters will be used as value of the custom metadata attribute.
  * </p>
  */
-public class AmazonS3Sender extends FileSystemSender<S3Object, AmazonS3FileSystem> implements AmazonS3FileSystemDelegator {
+public class AmazonS3Sender extends FileSystemSender<S3FileRef, AmazonS3FileSystem> implements AmazonS3FileSystemDelegator {
 
 	public AmazonS3Sender() {
 		setFileSystem(new AmazonS3FileSystem());

--- a/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemActorTest.java
+++ b/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemActorTest.java
@@ -9,13 +9,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
 
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers(disabledWithoutDocker = true)
-public class AmazonS3FileSystemActorTest extends FileSystemActorCustomFileAttributesTest<S3Object, AmazonS3FileSystem> {
+public class AmazonS3FileSystemActorTest extends FileSystemActorCustomFileAttributesTest<S3FileRef, AmazonS3FileSystem> {
 
 	@TempDir
 	private Path tempdir;

--- a/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemTest.java
+++ b/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemTest.java
@@ -209,7 +209,7 @@ public class AmazonS3FileSystemTest extends FileSystemTest<S3FileRef, AmazonS3Fi
 	}
 
 	@Test
-	public void basicFileSystemTestGetFileName() throws Exception {
+	public void basicFileSystemTestGetCanonicalFileName() throws Exception {
 		String filename = "readName" + FILE1;
 		String contents = "Tekst om te lezen";
 
@@ -225,7 +225,7 @@ public class AmazonS3FileSystemTest extends FileSystemTest<S3FileRef, AmazonS3Fi
 	}
 
 	@Test
-	public void basicFileSystemTestGetFolderName() throws Exception {
+	public void basicFileSystemTestGetCanonicalFolderName() throws Exception {
 		String foldername = "dummy/folder/";
 
 		fileSystem.configure();

--- a/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemTest.java
+++ b/aws/src/test/java/org/frankframework/filesystem/AmazonS3FileSystemTest.java
@@ -23,10 +23,9 @@ import org.junit.jupiter.api.io.TempDir;
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
 
 @Testcontainers(disabledWithoutDocker = true)
-public class AmazonS3FileSystemTest extends FileSystemTest<S3Object, AmazonS3FileSystem> {
+public class AmazonS3FileSystemTest extends FileSystemTest<S3FileRef, AmazonS3FileSystem> {
 
 	private static final int WAIT_TIMEOUT_MILLIS = PropertyUtil.getProperty("AmazonS3.properties", "waitTimeout", 50);
 
@@ -72,7 +71,7 @@ public class AmazonS3FileSystemTest extends FileSystemTest<S3Object, AmazonS3Fil
 			s3Client.createBucket(bucketName);
 			assertFalse(s3Client.doesObjectExist(bucketName, destinationFile));
 
-			S3Object file = fileSystem.toFile(filename);
+			S3FileRef file = fileSystem.toFile(filename);
 			assertEquals(bucketName, file.getBucketName());
 
 			fileSystem.createFile(file, new ThrowingAfterCloseInputStream(new ByteArrayInputStream(contents.getBytes())));
@@ -185,7 +184,7 @@ public class AmazonS3FileSystemTest extends FileSystemTest<S3Object, AmazonS3Fil
 		String combinedFilename = bucketname +"|" + filename;
 
 		// act
-		S3Object ref = fileSystem.toFile(combinedFilename);
+		S3FileRef ref = fileSystem.toFile(combinedFilename);
 
 		// assert
 		assertEquals(bucketname, ref.getBucketName());
@@ -202,10 +201,41 @@ public class AmazonS3FileSystemTest extends FileSystemTest<S3Object, AmazonS3Fil
 		String combinedFilename = bucketname +"|" + foldername +"/"+ filename;
 
 		// act
-		S3Object ref = fileSystem.toFile(combinedFilename);
+		S3FileRef ref = fileSystem.toFile(combinedFilename);
 
 		// assert
 		assertEquals(bucketname, ref.getBucketName());
 		assertEquals(foldername +"/"+ filename, ref.getKey());
+	}
+
+	@Test
+	public void basicFileSystemTestGetFileName() throws Exception {
+		String filename = "readName" + FILE1;
+		String contents = "Tekst om te lezen";
+
+		fileSystem.configure();
+		fileSystem.open();
+
+		createFile(null, filename, contents);
+		waitForActionToFinish();
+
+		S3FileRef file = fileSystem.toFile(filename);
+		// test
+		assertEquals(file.getBucketName()+"|"+filename, fileSystem.getCanonicalName(file));
+	}
+
+	@Test
+	public void basicFileSystemTestGetFolderName() throws Exception {
+		String foldername = "dummy/folder/";
+
+		fileSystem.configure();
+		fileSystem.open();
+
+		_createFolder(foldername);
+		waitForActionToFinish();
+
+		S3FileRef file = fileSystem.toFile(foldername);
+		// test
+		assertEquals(file.getBucketName()+"|"+foldername, fileSystem.getCanonicalName(file));
 	}
 }

--- a/aws/src/test/java/org/frankframework/senders/AmazonS3SenderTest.java
+++ b/aws/src/test/java/org/frankframework/senders/AmazonS3SenderTest.java
@@ -13,13 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
-import com.amazonaws.services.s3.model.S3Object;
 
 import org.frankframework.filesystem.AmazonS3FileSystem;
 import org.frankframework.filesystem.AmazonS3FileSystemTestHelper;
 import org.frankframework.filesystem.FileSystemActor.FileSystemAction;
 import org.frankframework.filesystem.FileSystemSenderTest;
 import org.frankframework.filesystem.IFileSystemTestHelper;
+import org.frankframework.filesystem.S3FileRef;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.ParameterBuilder;
 import org.frankframework.testutil.PropertyUtil;
@@ -34,7 +34,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  *
  */
 @Testcontainers(disabledWithoutDocker = true)
-public class AmazonS3SenderTest extends FileSystemSenderTest<AmazonS3Sender, S3Object, AmazonS3FileSystem> {
+public class AmazonS3SenderTest extends FileSystemSenderTest<AmazonS3Sender, S3FileRef, AmazonS3FileSystem> {
 
 	private final int waitMillis = PropertyUtil.getProperty("AmazonS3.properties", "waitTimeout", 50);
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
@@ -30,6 +30,8 @@ import java.util.NoSuchElementException;
 
 import jakarta.annotation.Nullable;
 import lombok.Getter;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPReply;
@@ -315,10 +317,17 @@ public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTP
 
 	@Override
 	public String getName(FTPFileRef file) {
-		if(file == null) {
-			return null;
+		String name = file.getFileName();
+		if(StringUtils.isNotEmpty(name)) {
+			return name;
 		}
-		return file.getFileName();
+		String folder = file.getFolder();
+		if (folder != null) { // Folder: only take part before last slash
+			int lastSlashPos = folder.lastIndexOf('/', folder.length() - 2);
+			return folder.substring(lastSlashPos + 1);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -369,10 +369,17 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 
 	@Override
 	public String getName(SftpFileRef file) {
-		if(file == null) {
-			return null;
+		String name = file.getFilename();
+		if(StringUtils.isNotEmpty(name)) {
+			return name;
 		}
-		return file.getFilename();
+		String folder = file.getFolder();
+		if (folder != null) { // Folder: only take part before last slash
+			int lastSlashPos = folder.lastIndexOf('/', folder.length() - 2);
+			return folder.substring(lastSlashPos + 1);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
@@ -334,6 +334,9 @@ public class Samba1FileSystem extends FileSystemBase<SmbFile> implements IWritab
 
 	@Override
 	public String getName(SmbFile f) {
+		if(f.getName().endsWith("/")) {
+			return StringUtils.chop(f.getName());
+		}
 		return f.getName();
 	}
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
@@ -415,10 +415,17 @@ public class Samba2FileSystem extends FileSystemBase<SmbFileRef> implements IWri
 
 	@Override
 	public String getName(SmbFileRef file) {
-		if(file == null) {
-			return null;
+		String name = file.getFilename();
+		if(StringUtils.isNotEmpty(name)) {
+			return name;
 		}
-		return file.getFilename();
+		String folder = file.getFolder();
+		if (folder != null) { // Folder: only take part before last slash
+			int lastSlashPos = folder.lastIndexOf('\\', folder.length() - 2);
+			return folder.substring(lastSlashPos + 1);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -233,7 +233,7 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 
 		F file = fileSystem.toFile(foldername);
 		// test
-		assertEquals("folder/", fileSystem.getName(file));
+		assertEquals("folder", fileSystem.getName(file));
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -206,7 +206,7 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 	}
 
 	@Test
-	public void basicFileSystemTestGetName() throws Exception {
+	public void basicFileSystemTestGetFileName() throws Exception {
 		String filename = "readName" + FILE1;
 		String contents = "Tekst om te lezen";
 
@@ -219,6 +219,21 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		F file = fileSystem.toFile(filename);
 		// test
 		assertEquals(filename, fileSystem.getName(file));
+	}
+
+	@Test
+	public void basicFileSystemTestGetFolderName() throws Exception {
+		String foldername = "dummy/folder/";
+
+		fileSystem.configure();
+		fileSystem.open();
+
+		_createFolder(foldername);
+		waitForActionToFinish();
+
+		F file = fileSystem.toFile(foldername);
+		// test
+		assertEquals("folder/", fileSystem.getName(file));
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/FileSystemActorCustomFileAttributesTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/FileSystemActorCustomFileAttributesTest.java
@@ -116,9 +116,9 @@ public abstract class FileSystemActorCustomFileAttributesTest<F, S extends IWrit
 		actor.open();
 
 		actor.doAction(input, pvl, session);
-		actor.setAction(FileSystemActor.FileSystemAction.INFO);
 
 		// Act
+		actor.setAction(FileSystemActor.FileSystemAction.INFO);
 		result = actor.doAction(input, pvl, session);
 
 		// Assert

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTestHelper.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTestHelper.java
@@ -68,9 +68,9 @@ public class LocalFileSystemTestHelper implements IFileSystemTestHelperFullContr
 	}
 
 	@Override
-	public void _createFolder(String filename) throws IOException {
-		Path f = getFileHandle(filename);
-		Files.createDirectory(f);
+	public void _createFolder(String foldername) throws IOException {
+		Path f = getFileHandle(foldername);
+		Files.createDirectories(f);
 	}
 
 	@Override

--- a/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystemWithAttachmentsTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystemWithAttachmentsTest.java
@@ -1,5 +1,6 @@
 package org.frankframework.filesystem.mock;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.frankframework.filesystem.FileSystemWithAttachmentsTest;
@@ -22,5 +23,12 @@ public class MockFileSystemWithAttachmentsTest extends FileSystemWithAttachments
 	@Test
 	public void basicFileSystemTestListDirsAndOrFolders() {
 		// Folder structure not correctly implemented in MockFileSystem. Mock tests are deleted in the near future, because they're not needed anymore.
+	}
+
+	@Test
+	@Override
+	@Disabled("mockfilesystem strips slashes in toFile method")
+	public void basicFileSystemTestGetFolderName() throws Exception {
+		super.basicFileSystemTestGetFolderName();
 	}
 }


### PR DESCRIPTION
The goal here is purely to fix the folder (name) issues and allow file properties to be set/shared between methods.