### PR TITLE
Have extra springIbisTestTool variant to support testing Ladybug

### DIFF
--- a/ladybug/src/main/resources/springIbisTestToolTestLadybugReportTableDifferentViewsDifferentColumns.xml
+++ b/ladybug/src/main/resources/springIbisTestToolTestLadybugReportTableDifferentViewsDifferentColumns.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+    xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+    >
+
+    <import resource="springIbisTestTool.xml"/>
+
+    <bean name="whiteBoxViewLessColumns" parent="whiteBoxView" autowire="byName">
+        <property name="name" value="White box view with less metadata" />
+        <property name="metadataNames">
+            <list>
+                <value>storageId</value>
+                <value>name</value>
+                <value>correlationId</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean name="views" class="nl.nn.testtool.filter.Views" scope="prototype">
+        <property name="views">
+            <list>
+                <ref bean="whiteBoxViewLessColumns"/>
+                <ref bean="whiteBoxView"/>
+                <ref bean="grayBoxView"/>
+                <ref bean="blackBoxView"/>
+            </list>
+        </property>                
+    </bean>
+</beans>


### PR DESCRIPTION
This PR will help the Ladybug team to test Ladybug. The columns in the report table can be different for different views. We would like to test that the shown columns do change when you change views. And a bug was found when changing views is combined with filtering.

Without this PR, we have to manually add a springIbisTestToolCustom.xml in frankframework/ladybug/src/main/resources before letting the Frank!Runner compile the FF!. With this PR, we will be able to do:

```
...\frank-runner\specials\ladybug$ .\restart.bat -Dcustom=TestLadybugReportTableDifferentViewsDifferentColumns
```

provided we have the right `build.properties` files in place.