### PR TITLE
Split health checks so each endpoint only target it's own scope

### DIFF
--- a/core/src/main/java/org/frankframework/management/bus/endpoints/HealthCheck.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/HealthCheck.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022 - 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -60,46 +60,12 @@ public class HealthCheck extends BusEndpointBase {
 			return getConfigurationHealth(configuration);
 		}
 
-		return getIbisHealth();
+		return getApplicationHealth();
 	}
 
-	private Message<String> getAdapterHealth(Adapter adapter) {
-		Map<String, Object> response = new HashMap<>();
-		List<String> errors = new ArrayList<>();
-
-		RunState state = adapter.getRunState(); //Let's not make it difficult for ourselves and only use STARTED/ERROR enums
-
-		if(state==RunState.STARTED) {
-			for (Receiver<?> receiver: adapter.getReceivers()) {
-				RunState rState = receiver.getRunState();
-
-				if(rState!=RunState.STARTED) {
-					errors.add("receiver["+receiver.getName()+"] of adapter["+adapter.getName()+"] is in state["+rState.toString()+"]");
-					state = RunState.ERROR;
-				}
-			}
-		} else {
-			errors.add("adapter["+adapter.getName()+"] is in state["+state.toString()+"]");
-			state = RunState.ERROR;
-		}
-
-		Status status = Response.Status.OK;
-		if(state==RunState.ERROR) {
-			status = Response.Status.SERVICE_UNAVAILABLE;
-		}
-		if(!errors.isEmpty())
-			response.put("errors", errors);
-		response.put("status", status);
-
-		JsonMessage responseMessage = new JsonMessage(response);
-		responseMessage.setStatus(status.getStatusCode());
-		return responseMessage;
-	}
-
-	private Message<String> getIbisHealth() {
+	private Message<String> getApplicationHealth() {
 		Map<String, Object> response = new HashMap<>();
 
-		Map<RunState, Integer> stateCount = new EnumMap<>(RunState.class);
 		List<String> errors = new ArrayList<>();
 
 		for(Configuration config : getIbisManager().getConfigurations()) {
@@ -110,43 +76,13 @@ public class HealthCheck extends BusEndpointBase {
 				} else {
 					errors.add("configuration["+config.getName()+"] is in state["+state+"]");
 				}
-				stateCount.put(RunState.ERROR, 1); //We're not really using stateCount other then to determine the HTTP response code.
 			}
-		}
-
-		for (Adapter adapter : getIbisManager().getRegisteredAdapters()) {
-			RunState state = adapter.getRunState(); //Let's not make it difficult for ourselves and only use STARTED/ERROR enums
-
-			if(state==RunState.STARTED) {
-				for (Receiver<?> receiver: adapter.getReceivers()) {
-					RunState rState = receiver.getRunState();
-
-					if(rState!=RunState.STARTED) {
-						errors.add("receiver["+receiver.getName()+"] of adapter["+adapter.getName()+"] is in state["+rState.toString()+"]");
-						state = RunState.ERROR;
-					}
-				}
-			}
-			else {
-				errors.add("adapter["+adapter.getName()+"] is in state["+state.toString()+"]");
-				state = RunState.ERROR;
-			}
-
-			int count;
-			if(stateCount.containsKey(state))
-				count = stateCount.get(state);
-			else
-				count = 0;
-
-			stateCount.put(state, ++count);
 		}
 
 		Status status = Response.Status.OK;
-		if(stateCount.containsKey(RunState.ERROR))
-			status = Response.Status.SERVICE_UNAVAILABLE;
-
 		if(!errors.isEmpty()) {
 			response.put("errors", errors);
+			status = Response.Status.SERVICE_UNAVAILABLE;
 		}
 		response.put("status", status);
 
@@ -156,10 +92,10 @@ public class HealthCheck extends BusEndpointBase {
 	}
 
 	/**
-*Returns the status of a configuration. If an Adapter is not in state STARTED it is flagged as NOT-OK.
-	 * header configuration The name of the Configuration to delete
+	 * Returns the status of a configuration. If an Adapter is not in state STARTED it is flagged as NOT-OK.
+	 * @param configuration The name of the Configuration to get health info from
 	 */
-	public Message<String> getConfigurationHealth(Configuration configuration) {
+	private Message<String> getConfigurationHealth(Configuration configuration) {
 		if(!configuration.isActive()) {
 			throw new BusException("configuration not active", configuration.getConfigurationException());
 		}
@@ -199,6 +135,43 @@ public class HealthCheck extends BusEndpointBase {
 		if(stateCount.containsKey(RunState.ERROR))
 			status = Status.SERVICE_UNAVAILABLE;
 
+		if(!errors.isEmpty())
+			response.put("errors", errors);
+		response.put("status", status);
+
+		JsonMessage responseMessage = new JsonMessage(response);
+		responseMessage.setStatus(status.getStatusCode());
+		return responseMessage;
+	}
+
+	/**
+	 * Returns the status of an {@link Adapter}. If the adapter is not in state STARTED it is flagged as NOT-OK.
+	 * @param adapter The name of the Adapter to get health info from
+	 */
+	private Message<String> getAdapterHealth(Adapter adapter) {
+		Map<String, Object> response = new HashMap<>();
+		List<String> errors = new ArrayList<>();
+
+		RunState state = adapter.getRunState(); //Let's not make it difficult for ourselves and only use STARTED/ERROR enums
+
+		if(state==RunState.STARTED) {
+			for (Receiver<?> receiver: adapter.getReceivers()) {
+				RunState rState = receiver.getRunState();
+
+				if(rState!=RunState.STARTED) {
+					errors.add("receiver["+receiver.getName()+"] of adapter["+adapter.getName()+"] is in state["+rState.toString()+"]");
+					state = RunState.ERROR;
+				}
+			}
+		} else {
+			errors.add("adapter["+adapter.getName()+"] is in state["+state.toString()+"]");
+			state = RunState.ERROR;
+		}
+
+		Status status = Response.Status.OK;
+		if(state==RunState.ERROR) {
+			status = Response.Status.SERVICE_UNAVAILABLE;
+		}
 		if(!errors.isEmpty())
 			response.put("errors", errors);
 		response.put("status", status);

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestHealth.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestHealth.java
@@ -62,7 +62,7 @@ public class TestHealth extends BusTestBase {
 		Message<?> response = callSyncGateway(request);
 
 		String result = response.getPayload().toString();
-		assertEquals("{\"errors\":[\"configuration[TestConfiguration] is in state[STARTING]\",\"adapter[TestAdapter] is in state[STOPPED]\"],\"status\":\"SERVICE_UNAVAILABLE\"}", result);
+		assertEquals("{\"errors\":[\"configuration[TestConfiguration] is in state[STARTING]\"],\"status\":\"SERVICE_UNAVAILABLE\"}", result);
 	}
 
 	@Test


### PR DESCRIPTION
server/health --> verifies all configuraties are started
configuration/name/health --> verifies all adapters are started
configuration/name/adapters/name/health --> detailed health info per adapter