### PR TITLE
Revert "Bump org.codehaus.mojo:exec-maven-plugin from 3.3.0 to 3.4.0"

### DIFF
--- a/console/frontend/pom.xml
+++ b/console/frontend/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.3.0</version>
 				<configuration>
 					<workingDirectory>${frontend.source.location}</workingDirectory>
 				</configuration>


### PR DESCRIPTION
Reverts frankframework/frankframework#7270 becouse of this issue: https://github.com/mojohaus/exec-maven-plugin/issues/438