### PR TITLE
Add an unsafe annotation for unsafe attributes.

### DIFF
--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
@@ -1144,7 +1144,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.getTrustManagerAlgorithm();
 	}
 
-	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setVerifyHostname(boolean verifyHostname) {
 		sessionBuilder.setVerifyHostname(verifyHostname);
@@ -1154,7 +1154,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.isVerifyHostname();
 	}
 
-	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setAllowSelfSignedCertificates(boolean testModeNoCertificatorCheck) {
 		sessionBuilder.setAllowSelfSignedCertificates(testModeNoCertificatorCheck);
@@ -1164,7 +1164,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.isAllowSelfSignedCertificates();
 	}
 
-	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException) {
 		sessionBuilder.setIgnoreCertificateExpiredException(ignoreCertificateExpiredException);

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
@@ -61,6 +61,7 @@ import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
 import org.frankframework.doc.Mandatory;
+import org.frankframework.doc.Unsafe;
 import org.frankframework.encryption.HasKeystore;
 import org.frankframework.encryption.HasTruststore;
 import org.frankframework.encryption.KeystoreType;
@@ -1143,6 +1144,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.getTrustManagerAlgorithm();
 	}
 
+	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
 	@Override
 	public void setVerifyHostname(boolean verifyHostname) {
 		sessionBuilder.setVerifyHostname(verifyHostname);
@@ -1152,6 +1154,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.isVerifyHostname();
 	}
 
+	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
 	@Override
 	public void setAllowSelfSignedCertificates(boolean testModeNoCertificatorCheck) {
 		sessionBuilder.setAllowSelfSignedCertificates(testModeNoCertificatorCheck);
@@ -1161,6 +1164,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		return sessionBuilder.isAllowSelfSignedCertificates();
 	}
 
+	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
 	@Override
 	public void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException) {
 		sessionBuilder.setIgnoreCertificateExpiredException(ignoreCertificateExpiredException);

--- a/commons/src/main/java/org/frankframework/doc/Unsafe.java
+++ b/commons/src/main/java/org/frankframework/doc/Unsafe.java
@@ -1,3 +1,18 @@
+/*
+   Copyright 2022 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
 package org.frankframework.doc;
 
 import java.lang.annotation.Documented;

--- a/commons/src/main/java/org/frankframework/doc/Unsafe.java
+++ b/commons/src/main/java/org/frankframework/doc/Unsafe.java
@@ -1,0 +1,17 @@
+package org.frankframework.doc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({METHOD})
+@Inherited
+public @interface Unsafe {
+	String description();
+}

--- a/commons/src/main/java/org/frankframework/doc/Unsafe.java
+++ b/commons/src/main/java/org/frankframework/doc/Unsafe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/commons/src/main/java/org/frankframework/doc/Unsafe.java
+++ b/commons/src/main/java/org/frankframework/doc/Unsafe.java
@@ -28,5 +28,5 @@ import static java.lang.annotation.ElementType.METHOD;
 @Target({METHOD})
 @Inherited
 public @interface Unsafe {
-	String description();
+
 }

--- a/core/src/main/java/org/frankframework/configuration/SuppressKeys.java
+++ b/core/src/main/java/org/frankframework/configuration/SuppressKeys.java
@@ -37,7 +37,8 @@ public enum SuppressKeys {
 	XSLT_STREAMING_SUPRESS_KEY("warnings.suppress.xslt.streaming", true),
 	XSD_VALIDATION_WARNINGS_SUPPRESS_KEY("warnings.suppress.xsd.warning", true),
 	XSD_VALIDATION_ERROR_SUPPRESS_KEY("warnings.suppress.xsd.error", true),
-	XSD_VALIDATION_FATAL_ERROR_SUPPRESS_KEY("warnings.suppress.xsd.fatalError", true);
+	XSD_VALIDATION_FATAL_ERROR_SUPPRESS_KEY("warnings.suppress.xsd.fatalError", true),
+	UNSAFE_ATTRIBUTE_SUPPRESS_KEY("warnings.suppress.unsafeAttribute", true);
 
 	private final @Getter String key;
 	private final @Getter boolean allowGlobalSuppression;

--- a/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
+++ b/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
@@ -73,7 +73,7 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 		}
 
 		checkDeprecationAndConfigurationWarning(name, value, m); //check if the setter or enum value is deprecated
-		checkUnsafe(m);
+		checkIfMethodIsMarkedAsUnsafe(m, name);
 
 		if (value.contains(StringResolver.DELIM_START) && value.contains(StringResolver.DELIM_STOP)) { //If value contains a property, resolve it
 			value = resolveValue(value);

--- a/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
+++ b/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
@@ -154,14 +154,15 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 		}
 	}
 
-	private void checkUnsafe(Method setterMethod) {
+	private void checkIfMethodIsMarkedAsUnsafe(Method setterMethod, String attributeName) {
 		Unsafe unsafe = AnnotationUtils.findAnnotation(setterMethod, Unsafe.class);
 
 		if (unsafe == null) {
 			return;
 		}
 
-		addSuppressibleWarning(unsafe.description(), SuppressKeys.UNSAFE_ATTRIBUTE_SUPPRESS_KEY);
+		String warning = "[" + attributeName + "] is unsafe and should not be used in a production environment.";
+		addSuppressibleWarning(warning, SuppressKeys.UNSAFE_ATTRIBUTE_SUPPRESS_KEY);
 	}
 
 	private void addConfigWarning(Class<?> clazz) {

--- a/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
+++ b/core/src/main/java/org/frankframework/configuration/digester/ValidateAttributeRule.java
@@ -26,6 +26,7 @@ import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.configuration.HasSpecialDefaultValues;
 import org.frankframework.configuration.SuppressKeys;
 import org.frankframework.doc.Protected;
+import org.frankframework.doc.Unsafe;
 import org.frankframework.util.ClassUtils;
 import org.frankframework.util.EnumUtils;
 import org.frankframework.util.StringResolver;
@@ -61,36 +62,41 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 		if (pd != null) {
 			m = pd.getWriteMethod();
 		}
-		if (m==null) { //validate if the attribute exists
+		if (m == null) { //validate if the attribute exists
 			addLocalWarning("does not have an attribute ["+name+"] to set to value ["+value+"]");
-		} else if(AnnotationUtils.findAnnotation(m, Protected.class) != null) {
+			return;
+		}
+
+		if (AnnotationUtils.findAnnotation(m, Protected.class) != null) {
 			addLocalWarning("attribute ["+name+"] is protected, cannot be set from configuration");
-		} else {
-			checkDeprecationAndConfigurationWarning(name, value, m); //check if the setter or enum value is deprecated
+			return;
+		}
 
-			if(value.contains(StringResolver.DELIM_START) && value.contains(StringResolver.DELIM_STOP)) { //If value contains a property, resolve it
-				value = resolveValue(value);
-			} else { //Only check for default values for non-property values
-				Method readMethod = pd.getReadMethod();
-				if(readMethod != null) { //And if a read method (getter) exists
-					checkTypeCompatibility(readMethod, name, value, attributes);
-				}
+		checkDeprecationAndConfigurationWarning(name, value, m); //check if the setter or enum value is deprecated
+		checkUnsafe(m);
+
+		if (value.contains(StringResolver.DELIM_START) && value.contains(StringResolver.DELIM_STOP)) { //If value contains a property, resolve it
+			value = resolveValue(value);
+		} else { //Only check for default values for non-property values
+			Method readMethod = pd.getReadMethod();
+			if(readMethod != null) { //And if a read method (getter) exists
+				checkTypeCompatibility(readMethod, name, value, attributes);
 			}
+		}
 
-			log.trace("attempting to populate field [{}] with value [{}] on bean [{}]", name, value, getBean());
-			try {
-				ClassUtils.invokeSetter(getBean(), m, value);
-			} catch (IllegalStateException e) {
-				log.warn("error while invoking method [{}] with value [{}] on bean [{}]", m, value, getBean(), e);
-				addLocalWarning(e.getCause().getMessage());
-			} catch (IllegalArgumentException e) {
-				log.debug("unable to set attribute [{}] on method [{}] with value [{}]", name, m, value, e);
-				// When it's unable to convert to the provided type and:
-				// The type is not a String AND The value is empty
-				// Do not create a warning.
-				if(!"".equals(value)) {
-					addLocalWarning(e.getMessage());
-				}
+		log.trace("attempting to populate field [{}] with value [{}] on bean [{}]", name, value, getBean());
+		try {
+			ClassUtils.invokeSetter(getBean(), m, value);
+		} catch (IllegalStateException e) {
+			log.warn("error while invoking method [{}] with value [{}] on bean [{}]", m, value, getBean(), e);
+			addLocalWarning(e.getCause().getMessage());
+		} catch (IllegalArgumentException e) {
+			log.debug("unable to set attribute [{}] on method [{}] with value [{}]", name, m, value, e);
+			// When it's unable to convert to the provided type and:
+			// The type is not a String AND The value is empty
+			// Do not create a warning.
+			if(!"".equals(value)) {
+				addLocalWarning(e.getMessage());
 			}
 		}
 	}
@@ -146,6 +152,16 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 			}
 		} catch (IllegalArgumentException ignored) { // Can not happen with enums
 		}
+	}
+
+	private void checkUnsafe(Method setterMethod) {
+		Unsafe unsafe = AnnotationUtils.findAnnotation(setterMethod, Unsafe.class);
+
+		if (unsafe == null) {
+			return;
+		}
+
+		addSuppressibleWarning(unsafe.description(), SuppressKeys.UNSAFE_ATTRIBUTE_SUPPRESS_KEY);
 	}
 
 	private void addConfigWarning(Class<?> clazz) {

--- a/core/src/main/java/org/frankframework/encryption/HasTruststore.java
+++ b/core/src/main/java/org/frankframework/encryption/HasTruststore.java
@@ -44,17 +44,17 @@ public interface HasTruststore extends IScopeProvider {
 	void setTrustManagerAlgorithm(String trustManagerAlgorithm);
 
 	/** If <code>true</code>, the hostname in the certificate will be checked against the actual hostname of the peer */
-	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
+	@Unsafe
 	void setVerifyHostname(boolean verifyHostname);
 	/** If <code>true</code>, self signed certificates are accepted
 	 * @ff.default false
 	 */
-	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
+	@Unsafe
 	void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates);
 	/**
 	 * If <code>true</code>, CertificateExpiredExceptions are ignored
 	 * @ff.default false
 	 */
-	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
+	@Unsafe
 	void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException);
 }

--- a/core/src/main/java/org/frankframework/encryption/HasTruststore.java
+++ b/core/src/main/java/org/frankframework/encryption/HasTruststore.java
@@ -16,6 +16,7 @@
 package org.frankframework.encryption;
 
 import org.frankframework.core.IScopeProvider;
+import org.frankframework.doc.Unsafe;
 
 public interface HasTruststore extends IScopeProvider {
 
@@ -43,14 +44,17 @@ public interface HasTruststore extends IScopeProvider {
 	void setTrustManagerAlgorithm(String trustManagerAlgorithm);
 
 	/** If <code>true</code>, the hostname in the certificate will be checked against the actual hostname of the peer */
+	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
 	void setVerifyHostname(boolean verifyHostname);
 	/** If <code>true</code>, self signed certificates are accepted
 	 * @ff.default false
 	 */
+	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
 	void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates);
 	/**
 	 * If <code>true</code>, CertificateExpiredExceptions are ignored
 	 * @ff.default false
 	 */
+	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
 	void setIgnoreCertificateExpiredException(boolean ignoreCertificateExpiredException);
 }

--- a/core/src/main/java/org/frankframework/http/HttpSessionBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSessionBase.java
@@ -71,6 +71,7 @@ import org.apache.logging.log4j.Logger;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.doc.Unsafe;
 import org.frankframework.encryption.AuthSSLContextFactory;
 import org.frankframework.encryption.HasKeystore;
 import org.frankframework.encryption.HasTruststore;
@@ -739,16 +740,19 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	}
 
 	@Override
+	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
 	public void setVerifyHostname(boolean b) {
 		verifyHostname = b;
 	}
 
+	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
 	@Override
 	public void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates) {
 		this.allowSelfSignedCertificates = allowSelfSignedCertificates;
 	}
 
 	@Override
+	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
 	public void setIgnoreCertificateExpiredException(boolean b) {
 		ignoreCertificateExpiredException = b;
 	}

--- a/core/src/main/java/org/frankframework/http/HttpSessionBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSessionBase.java
@@ -740,19 +740,19 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	}
 
 	@Override
-	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
+	@Unsafe
 	public void setVerifyHostname(boolean b) {
 		verifyHostname = b;
 	}
 
-	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setAllowSelfSignedCertificates(boolean allowSelfSignedCertificates) {
 		this.allowSelfSignedCertificates = allowSelfSignedCertificates;
 	}
 
 	@Override
-	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
+	@Unsafe
 	public void setIgnoreCertificateExpiredException(boolean b) {
 		ignoreCertificateExpiredException = b;
 	}

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpSession.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpSession.java
@@ -33,6 +33,7 @@ import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IConfigurable;
 import org.frankframework.doc.DocumentedEnum;
 import org.frankframework.doc.EnumLabel;
+import org.frankframework.doc.Unsafe;
 import org.frankframework.encryption.AuthSSLContextFactory;
 import org.frankframework.encryption.HasKeystore;
 import org.frankframework.encryption.HasTruststore;
@@ -406,6 +407,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	}
 
 	/** (ftps) If <code>true</code>, the hostname in the certificate will be checked against the actual hostname of the peer */
+	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
 	@Override
 	public void setVerifyHostname(boolean b) {
 		verifyHostname = b;
@@ -414,6 +416,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	/** (ftps) If <code>true</code>, self signed certificates are accepted
 	 * @ff.default false
 	 */
+	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
 	@Override
 	public void setAllowSelfSignedCertificates(boolean b) {
 		allowSelfSignedCertificates = b;
@@ -423,6 +426,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	 * (ftps) If <code>true</code>, CertificateExpiredExceptions are ignored
 	 * @ff.default false
 	 */
+	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
 	@Override
 	public void setIgnoreCertificateExpiredException(boolean b) {
 		ignoreCertificateExpiredException = b;

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpSession.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpSession.java
@@ -407,7 +407,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	}
 
 	/** (ftps) If <code>true</code>, the hostname in the certificate will be checked against the actual hostname of the peer */
-	@Unsafe(description = "verifyHostname is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setVerifyHostname(boolean b) {
 		verifyHostname = b;
@@ -416,7 +416,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	/** (ftps) If <code>true</code>, self signed certificates are accepted
 	 * @ff.default false
 	 */
-	@Unsafe(description = "allowSelfSignedCertificates is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setAllowSelfSignedCertificates(boolean b) {
 		allowSelfSignedCertificates = b;
@@ -426,7 +426,7 @@ public abstract class FtpSession implements IConfigurable, HasKeystore, HasTrust
 	 * (ftps) If <code>true</code>, CertificateExpiredExceptions are ignored
 	 * @ff.default false
 	 */
-	@Unsafe(description = "ignoreCertificateExpiredException is unsafe and should not be used in a production environment.")
+	@Unsafe
 	@Override
 	public void setIgnoreCertificateExpiredException(boolean b) {
 		ignoreCertificateExpiredException = b;


### PR DESCRIPTION
Closes #2727 

Will be used for the following:
- A warning in the console when an unsafe attribute is used.
- A warning in the frankdoc to alert them that the use of this attribute might be unsafe.

The annotation sadly isn't as sophisticated as I would like it to be. A lambda in the annotation which returns true when the value is actually unsafe would be my prefered solution, but that is not possible because members of the annotation must be primatives. This means that this annotation is only really useful for boolean values with a safe default. Checking the length of a password is currently not possible for example, because it would mark the usage of the attribute as unsafe while that may not be the case.

The current non exhaustive list of unsafe attributes are the following:
- verifyHostname 
- allowSelfSignedCertificates
- ignoreCertificateExpiredException

An Frankdoc issue can be made to further implement this into the Frankdoc when this is merged.