### PR TITLE
Replace some LinkedLists with ArrayLists 

### DIFF
--- a/commons/src/main/java/org/frankframework/util/ClassUtils.java
+++ b/commons/src/main/java/org/frankframework/util/ClassUtils.java
@@ -24,8 +24,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.CodeSource;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -296,7 +296,7 @@ public abstract class ClassUtils {
 
 	public static List<Object> getClassInfoList(Class<?> clazz) {
 		ClassLoader classLoader = clazz.getClassLoader();
-		List<Object> infoList = new LinkedList<>();
+		List<Object> infoList = new ArrayList<>();
 		String className = clazz.getName();
 		while (true) {
 			infoList.add(getClassInfo(clazz, classLoader));

--- a/console/backend/src/main/java/org/frankframework/web/filters/CspFilter.java
+++ b/console/backend/src/main/java/org/frankframework/web/filters/CspFilter.java
@@ -16,7 +16,7 @@
 package org.frankframework.web.filters;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.servlet.Filter;
@@ -41,7 +41,7 @@ public class CspFilter implements Filter {
 	public void init(FilterConfig filterConfig) {
 		cspWriter = new ContentSecurityPolicyHeaderWriter();
 
-		List<String> policyDirectives = new LinkedList<>();
+		List<String> policyDirectives = new ArrayList<>();
 		policyDirectives.add("default-src 'self';");
 		policyDirectives.add("style-src 'self' https://fonts.googleapis.com/css 'unsafe-inline';");
 		policyDirectives.add("font-src 'self' https://fonts.gstatic.com;");

--- a/console/frontend/pom.xml
+++ b/console/frontend/pom.xml
@@ -42,7 +42,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.3.0</version>
 				<configuration>
 					<workingDirectory>${frontend.source.location}</workingDirectory>
 				</configuration>

--- a/core/src/main/java/org/frankframework/align/XmlAligner.java
+++ b/core/src/main/java/org/frankframework/align/XmlAligner.java
@@ -16,9 +16,9 @@
 package org.frankframework.align;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
@@ -416,9 +416,7 @@ public class XmlAligner extends XMLFilterImpl {
 	protected static List<XSModel> getSchemaInformation(URL schemaURL) {
 		XMLSchemaLoader xsLoader = new XMLSchemaLoader();
 		XSModel xsModel = xsLoader.loadURI(schemaURL.toExternalForm());
-		List<XSModel> schemaInformation= new LinkedList<>();
-		schemaInformation.add(xsModel);
-		return schemaInformation;
+		return Collections.singletonList(xsModel);
 	}
 
 	public void handleRecoverableError(String message, boolean ignoreFlag) throws SAXParseException {

--- a/core/src/main/java/org/frankframework/align/content/JsonElementContainer.java
+++ b/core/src/main/java/org/frankframework/align/content/JsonElementContainer.java
@@ -15,8 +15,8 @@
 */
 package org.frankframework.align.content;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,6 @@ import org.apache.xerces.impl.dv.XSSimpleType;
 import org.apache.xerces.xs.XSComplexTypeDefinition;
 import org.apache.xerces.xs.XSSimpleTypeDefinition;
 import org.apache.xerces.xs.XSTypeDefinition;
-
 import org.frankframework.align.ScalarType;
 import org.frankframework.util.LogUtil;
 
@@ -170,7 +169,7 @@ public class JsonElementContainer implements ElementContainer {
 		}
 		if (isXmlArrayContainer() && content.isRepeatedElement() && skipArrayElementContainers) {
 			if (array==null) {
-				array=new LinkedList<>();
+				array=new ArrayList<>();
 				setType(content.getType());
 			}
 			array.add(content.getContent());
@@ -185,13 +184,14 @@ public class JsonElementContainer implements ElementContainer {
 		Object current=contentMap.get(childName);
 		if (content.isRepeatedElement()) {
 			if (current==null) {
-				current=new LinkedList<Object>();
+				current=new ArrayList<>();
 				contentMap.put(childName,current);
 			} else {
 				if (!(current instanceof List)) {
 					throw new IllegalArgumentException("element ["+childName+"] is not an array");
 				}
 			}
+			// noinspection unchecked
 			((List)current).add(content.getContent());
 		} else {
 			if (current!=null) {

--- a/core/src/main/java/org/frankframework/configuration/ApplicationWarningsBase.java
+++ b/core/src/main/java/org/frankframework/configuration/ApplicationWarningsBase.java
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package org.frankframework.configuration;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -31,7 +31,7 @@ import org.springframework.context.ApplicationContextAware;
 public abstract class ApplicationWarningsBase implements ApplicationContextAware, InitializingBean, DisposableBean {
 	private ApplicationContext applicationContext;
 	private AppConstants appConstants;
-	private final List<String> warnings = new LinkedList<>();
+	private final List<String> warnings = new ArrayList<>();
 
 	@Override
 	public void afterPropertiesSet() {

--- a/core/src/main/java/org/frankframework/configuration/ConfigurationUtils.java
+++ b/core/src/main/java/org/frankframework/configuration/ConfigurationUtils.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -471,7 +470,7 @@ public class ConfigurationUtils {
 	}
 
 	private static <T> Map<String, T> sort(final Map<String, T> allConfigNameItems) {
-		List<String> sortedConfigurationNames = new LinkedList<>(allConfigNameItems.keySet());
+		List<String> sortedConfigurationNames = new ArrayList<>(allConfigNameItems.keySet());
 		sortedConfigurationNames.sort(new ParentConfigComparator());
 
 		Map<String, T> sortedConfigurations = new LinkedHashMap<>();

--- a/core/src/main/java/org/frankframework/core/PipeForwards.java
+++ b/core/src/main/java/org/frankframework/core/PipeForwards.java
@@ -15,7 +15,7 @@
 */
 package org.frankframework.core;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import lombok.Getter;
@@ -26,7 +26,7 @@ import lombok.Getter;
  */
 public class PipeForwards {
 
-	private final @Getter List<PipeForward> forwards = new LinkedList<>();
+	private final @Getter List<PipeForward> forwards = new ArrayList<>();
 
 	/**
 	 * Defines what pipe or exit to execute next. When the execution of a pipe is done, the pipe looks up the next pipe or exit to execute.

--- a/core/src/main/java/org/frankframework/core/PipeLineExits.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineExits.java
@@ -15,7 +15,7 @@
 */
 package org.frankframework.core;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import lombok.Getter;
@@ -41,7 +41,7 @@ import lombok.Getter;
  */
 public class PipeLineExits {
 
-	private final @Getter List<PipeLineExit> exits = new LinkedList<>();
+	private final @Getter List<PipeLineExit> exits = new ArrayList<>();
 
 	/**
 	 * PipeLine exits.

--- a/core/src/main/java/org/frankframework/http/authentication/OAuthAccessTokenManager.java
+++ b/core/src/main/java/org/frankframework/http/authentication/OAuthAccessTokenManager.java
@@ -19,8 +19,24 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedList;
 import java.util.List;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationGrant;
+import com.nimbusds.oauth2.sdk.ClientCredentialsGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResourceOwnerPasswordCredentialsGrant;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -47,27 +63,10 @@ import org.frankframework.util.LogUtil;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.StringUtil;
 
-import com.nimbusds.oauth2.sdk.AccessTokenResponse;
-import com.nimbusds.oauth2.sdk.AuthorizationGrant;
-import com.nimbusds.oauth2.sdk.ClientCredentialsGrant;
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.ResourceOwnerPasswordCredentialsGrant;
-import com.nimbusds.oauth2.sdk.Scope;
-import com.nimbusds.oauth2.sdk.TokenErrorResponse;
-import com.nimbusds.oauth2.sdk.TokenRequest;
-import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
-import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
-import com.nimbusds.oauth2.sdk.auth.Secret;
-import com.nimbusds.oauth2.sdk.http.HTTPRequest;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import com.nimbusds.oauth2.sdk.id.ClientID;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-
 public class OAuthAccessTokenManager {
 	protected Logger log = LogUtil.getLogger(this);
 
-	private URI tokenEndpoint;
+	private final URI tokenEndpoint;
 	private final Scope scope;
 	private final CredentialFactory clientCredentialFactory;
 	private final boolean useClientCredentials;
@@ -177,9 +176,10 @@ public class OAuthAccessTokenManager {
 		String query = httpRequest.getQuery(); //This is the POST BODY, don't ask me why they called it QUERY...
 
 		if(authenticationType == AuthenticationType.REQUEST_PARAMETER) {
-			List<NameValuePair> clientInfo = new LinkedList<>();
-			clientInfo.add(new BasicNameValuePair("client_id", clientCredentialFactory.getUsername()));
-			clientInfo.add(new BasicNameValuePair("client_secret", clientCredentialFactory.getPassword()));
+			List<NameValuePair> clientInfo = List.of(
+					new BasicNameValuePair("client_id", clientCredentialFactory.getUsername()),
+					new BasicNameValuePair("client_secret", clientCredentialFactory.getPassword())
+			);
 			query = StringUtil.concatStrings(query, "&", URLEncodedUtils.format(clientInfo, "UTF-8"));
 		}
 		switch (httpRequest.getMethod()) {

--- a/core/src/main/java/org/frankframework/http/authentication/OAuthPreferringAuthenticationStrategy.java
+++ b/core/src/main/java/org/frankframework/http/authentication/OAuthPreferringAuthenticationStrategy.java
@@ -15,7 +15,7 @@
 */
 package org.frankframework.http.authentication;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
 
@@ -31,7 +31,6 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.TargetAuthenticationStrategy;
 import org.apache.http.protocol.HttpContext;
 import org.apache.logging.log4j.Logger;
-
 import org.frankframework.util.LogUtil;
 
 /**
@@ -49,7 +48,7 @@ public class OAuthPreferringAuthenticationStrategy extends TargetAuthenticationS
 	public Queue<AuthOption> select(Map<String, Header> challenges, HttpHost authhost, HttpResponse response, HttpContext context) throws MalformedChallengeException {
 		final HttpClientContext clientContext = HttpClientContext.adapt(context);
 
-		final Queue<AuthOption> options = new LinkedList<>();
+		final Queue<AuthOption> options = new ArrayDeque<>();
 
 		final CredentialsProvider credsProvider = clientContext.getCredentialsProvider();
 		if (credsProvider == null) {

--- a/core/src/main/java/org/frankframework/jdbc/migration/LiquibaseResourceAccessor.java
+++ b/core/src/main/java/org/frankframework/jdbc/migration/LiquibaseResourceAccessor.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -70,8 +69,7 @@ public class LiquibaseResourceAccessor implements ResourceAccessor {
 	}
 
 	protected List<liquibase.resource.Resource> asResourceList(String path, URI uri, ThrowingSupplier<InputStream,IOException> inputStreamSupplier) {
-		List<liquibase.resource.Resource> result = new LinkedList<>();
-		result.add(new AbstractResource(path, uri) {
+		return Collections.singletonList(new AbstractResource(path, uri) {
 
 			@Override
 			public InputStream openInputStream() throws IOException {
@@ -102,7 +100,6 @@ public class LiquibaseResourceAccessor implements ResourceAccessor {
 			}
 
 		});
-		return result;
 	}
 
 
@@ -113,9 +110,7 @@ public class LiquibaseResourceAccessor implements ResourceAccessor {
 
 	@Override
 	public List<String> describeLocations() {
-		List<String> list = new LinkedList<>();
-		list.add(resource.toString());
-		return list;
+		return Collections.singletonList(resource.toString());
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/jta/TransactionConnectorCoordinator.java
+++ b/core/src/main/java/org/frankframework/jta/TransactionConnectorCoordinator.java
@@ -15,16 +15,15 @@
 */
 package org.frankframework.jta;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
-
 import org.frankframework.functional.ThrowingRunnable;
 import org.frankframework.functional.ThrowingSupplier;
 import org.frankframework.jdbc.FixedQuerySender;
 import org.frankframework.util.LogUtil;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 	protected static Logger log = LogUtil.getLogger(TransactionConnectorCoordinator.class);
@@ -102,7 +101,7 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 		TransactionConnectorCoordinator<T,R> coordinator = (TransactionConnectorCoordinator<T,R>)coordinators.get();
 		if (coordinator!=null) {
 			if (coordinator.onEndChildThreadActions==null) {
-				coordinator.onEndChildThreadActions = new LinkedList<>();
+				coordinator.onEndChildThreadActions = new ArrayList<>();
 			}
 			coordinator.onEndChildThreadActions.add(action);
 			return true;
@@ -112,7 +111,6 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 
 
 	public void resumeTransactionInChildThread(TransactionConnector<T,R> requester) {
-		Thread thread = Thread.currentThread();
 		numBeginChildThreadsCalled++;
 		if (numBeginChildThreadsCalled==connectorCount) {
 			lastInThread = requester;

--- a/core/src/main/java/org/frankframework/ldap/LdapClient.java
+++ b/core/src/main/java/org/frankframework/ldap/LdapClient.java
@@ -20,12 +20,12 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.security.cert.CertPathValidatorException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -518,11 +518,7 @@ public class LdapClient implements ICacheEnabled<String,Set<String>> {
 
 			@Override
 			public void handle(Attribute key, Object value) {
-				List<String> list = getData().get(key.getID());
-				if (list == null) {
-					list = new LinkedList<>();
-					getData().put(key.getID(), list);
-				}
+				List<String> list = getData().computeIfAbsent(key.getID(), k -> new ArrayList<>());
 				list.add((String) value);
 			}
 

--- a/core/src/main/java/org/frankframework/management/bus/dto/StorageItemsDTO.java
+++ b/core/src/main/java/org/frankframework/management/bus/dto/StorageItemsDTO.java
@@ -16,20 +16,18 @@
 package org.frankframework.management.bus.dto;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import lombok.Getter;
 import lombok.Setter;
-
+import org.apache.logging.log4j.Logger;
 import org.frankframework.core.IMessageBrowser;
 import org.frankframework.core.IMessageBrowsingIterator;
 import org.frankframework.core.IMessageBrowsingIteratorItem;
@@ -68,7 +66,7 @@ public class StorageItemsDTO {
 		Date endDate = filter.getEndDate();
 		try (IMessageBrowsingIterator iterator = transactionalStorage.getIterator(startDate, endDate, filter.getSortOrder())) {
 			int count;
-			List<StorageItemDTO> messages = new LinkedList<>();
+			List<StorageItemDTO> messages = new ArrayList<>();
 
 			for (count=0; iterator.hasNext(); ) {
 				try (IMessageBrowsingIteratorItem iterItem = iterator.next()) {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -20,9 +20,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -104,11 +104,11 @@ public class ConfigManagement extends BusEndpointBase {
 			return new JsonMessage(Collections.singletonList(new ConfigurationDTO(configuration)));
 		}
 
-		List<ConfigurationDTO> configs = new LinkedList<>();
-		for (Configuration configuration : getIbisManager().getConfigurations()) {
-			configs.add(new ConfigurationDTO(configuration));
-		}
-		configs.sort(new ConfigurationDTO.NameComparator());
+		List<ConfigurationDTO> configs = getIbisManager().getConfigurations()
+				.stream()
+				.map(ConfigurationDTO::new)
+				.sorted(new ConfigurationDTO.NameComparator())
+				.toList();
 		return new JsonMessage(configs);
 	}
 
@@ -222,7 +222,7 @@ public class ConfigManagement extends BusEndpointBase {
 	}
 
 	private List<ConfigurationDTO> getConfigsFromDatabase(String configurationName, @Nonnull final String dataSourceName) {
-		List<ConfigurationDTO> configurations = new LinkedList<>();
+		List<ConfigurationDTO> configurations = new ArrayList<>();
 
 		FixedQuerySender qs = createBean(FixedQuerySender.class);
 		qs.setDatasourceName(dataSourceName);

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
@@ -15,9 +15,9 @@
 */
 package org.frankframework.management.bus.endpoints;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ public class ConnectionOverview extends BusEndpointBase {
 	@TopicSelector(BusTopic.CONNECTION_OVERVIEW)
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public Message<String> getAllConnections(Message<?> message) {
-		List<Object> connectionsIncoming = new LinkedList<>();
+		List<Object> connectionsIncoming = new ArrayList<>();
 
 		for(Configuration config : getIbisManager().getConfigurations()) {
 			for(Adapter adapter: config.getRegisteredAdapters()) {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/InlineStorage.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/InlineStorage.java
@@ -15,21 +15,16 @@
 */
 package org.frankframework.management.bus.endpoints;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import jakarta.annotation.security.RolesAllowed;
-import org.frankframework.management.bus.TopicSelector;
-import org.frankframework.management.bus.message.JsonMessage;
-import org.springframework.messaging.Message;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-
 import org.frankframework.configuration.Configuration;
 import org.frankframework.core.Adapter;
 import org.frankframework.core.IListener;
@@ -39,7 +34,10 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.ProcessState;
 import org.frankframework.management.bus.BusAware;
 import org.frankframework.management.bus.BusTopic;
+import org.frankframework.management.bus.TopicSelector;
+import org.frankframework.management.bus.message.JsonMessage;
 import org.frankframework.receivers.Receiver;
+import org.springframework.messaging.Message;
 
 @BusAware("frank-management-bus")
 public class InlineStorage extends BusEndpointBase {
@@ -79,7 +77,7 @@ public class InlineStorage extends BusEndpointBase {
 	}
 
 	private static class InlineStoreStateItem {
-		private @Getter List<InlineStoreItem> items = new LinkedList<>();
+		private final @Getter List<InlineStoreItem> items = new ArrayList<>();
 		private @Getter @Setter int totalMessageCount;
 	}
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/SecurityItems.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/SecurityItems.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,6 +32,7 @@ import javax.net.ssl.SSLParameters;
 import javax.sql.DataSource;
 
 import jakarta.annotation.security.RolesAllowed;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationException;
@@ -56,8 +56,6 @@ import org.frankframework.util.ClassUtils;
 import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.XmlUtils;
 import org.springframework.messaging.Message;
-
-import lombok.Getter;
 
 @BusAware("frank-management-bus")
 public class SecurityItems extends BusEndpointBase {
@@ -244,13 +242,11 @@ public class SecurityItems extends BusEndpointBase {
 	}
 
 	private List<String> getAuthEntries() {
-		List<String> entries = new LinkedList<>();
+		List<String> entries = new ArrayList<>();
 		try {
 			Collection<String> knownAliases = CredentialFactory.getConfiguredAliases();
-			if (knownAliases!=null) {
-				entries.addAll(knownAliases); // start with all aliases in the CredentialProvider
-				Collections.sort(entries, Comparator.naturalOrder());
-			}
+			entries.addAll(knownAliases); // start with all aliases in the CredentialProvider
+			entries.sort(Comparator.naturalOrder());
 		} catch (Exception e) {
 			log.warn("could not retrieve aliases from CredentialFactory", e);
 		}
@@ -277,7 +273,7 @@ public class SecurityItems extends BusEndpointBase {
 	}
 
 	private List<Object> addAuthEntries() {
-		List<Object> authEntries = new LinkedList<>();
+		List<Object> authEntries = new ArrayList<>();
 
 		for(String authAlias : getAuthEntries()) {
 			Map<String, Object> ae = new HashMap<>();

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/WebServices.java
@@ -21,7 +21,6 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -181,7 +180,7 @@ public class WebServices extends BusEndpointBase {
 	}
 
 	private List<ListenerDAO> getApiListeners() {
-		List<ListenerDAO> apiListeners = new LinkedList<>();
+		List<ListenerDAO> apiListeners = new ArrayList<>();
 		SortedMap<String, ApiDispatchConfig> patternClients = ApiServiceDispatcher.getInstance().getPatternClients();
 		for (Entry<String, ApiDispatchConfig> client : patternClients.entrySet()) {
 			ApiDispatchConfig config = client.getValue();

--- a/core/src/main/java/org/frankframework/metrics/LocalStatisticsRegistry.java
+++ b/core/src/main/java/org/frankframework/metrics/LocalStatisticsRegistry.java
@@ -21,7 +21,6 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -242,7 +241,7 @@ public class LocalStatisticsRegistry extends SimpleMeterRegistry {
 	}
 
 	private List<String> getPotentialMeters(PipeLine pipeline) {
-		List<String> potentialMeterNames = new LinkedList<>();
+		List<String> potentialMeterNames = new ArrayList<>();
 		if(pipeline.getInputValidator() != null) {
 			potentialMeterNames.add(pipeline.getInputValidator().getName());
 		}
@@ -267,7 +266,7 @@ public class LocalStatisticsRegistry extends SimpleMeterRegistry {
 
 	// MessageSendingPipe has 3 additional meters for validators/wrappers and a messagelog.
 	private List<String> getSendingPipeMeters(MessageSendingPipe messageSendingPipe) {
-		List<String> potentialMeterNames = new LinkedList<>();
+		List<String> potentialMeterNames = new ArrayList<>();
 		if (messageSendingPipe.getInputValidator() != null || messageSendingPipe.getInputWrapper() != null) {
 			potentialMeterNames.add(messageSendingPipe.getName() + " -> PreProcessing");
 		}

--- a/core/src/main/java/org/frankframework/monitoring/Trigger.java
+++ b/core/src/main/java/org/frankframework/monitoring/Trigger.java
@@ -58,7 +58,7 @@ public class Trigger implements ITrigger {
 	private @Getter int threshold = 0;
 	private @Getter int period = 0;
 
-	private LinkedList<Instant> eventDates = null;
+	private LinkedList<Instant> eventDates = null; // TODO: Can perhaps be replaced with DeQueue interface / ArrayDeQueue impl
 	private boolean configured = false;
 
 	@Override

--- a/core/src/main/java/org/frankframework/pipes/JsonValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/JsonValidator.java
@@ -17,7 +17,7 @@ package org.frankframework.pipes;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.json.stream.JsonParser;
@@ -74,7 +74,7 @@ public class JsonValidator extends ValidatorBase {
 
 	@Override
 	protected PipeForward validate(Message messageToValidate, PipeLineSession session, boolean responseMode, String messageRoot) throws PipeRunException {
-		final List<String> problems = new LinkedList<>();
+		final List<String> problems = new ArrayList<>();
 		// Problem handler which will print problems found.
 		ProblemHandler handler = service.createProblemPrinter(problems::add);
 		ValidationResult resultEvent;

--- a/core/src/main/java/org/frankframework/pipes/ReplacingInputStream.java
+++ b/core/src/main/java/org/frankframework/pipes/ReplacingInputStream.java
@@ -17,8 +17,8 @@ package org.frankframework.pipes;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayDeque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.stream.IntStream;
 
@@ -54,8 +54,8 @@ public class ReplacingInputStream extends InputStream {
 		this.nonXmlReplacementCharacter = StringUtils.isEmpty(nonXmlReplacementCharacter) ? 0 : nonXmlReplacementCharacter.charAt(0);
 		this.allowUnicodeSupplementaryCharacters = allowUnicodeSupplementaryCharacters;
 
-		this.inQueue = new LinkedList<>();
-		this.outQueue = new LinkedList<>();
+		this.inQueue = new ArrayDeque<>();
+		this.outQueue = new ArrayDeque<>();
 
 		this.search = (search == null) ? "".getBytes() : search.getBytes();
 		this.replacement = (replacement == null) ? "".getBytes() : replacement.getBytes();

--- a/core/src/main/java/org/frankframework/pipes/ReplacingVariablesInputStream.java
+++ b/core/src/main/java/org/frankframework/pipes/ReplacingVariablesInputStream.java
@@ -18,9 +18,9 @@ package org.frankframework.pipes;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Queue;
@@ -53,8 +53,8 @@ public class ReplacingVariablesInputStream extends InputStream {
 		this.variablePrefix = (variablePrefix + "{").getBytes();
 		this.properties = properties;
 
-		this.inQueue = new LinkedList<>();
-		this.outQueue = new LinkedList<>();
+		this.inQueue = new ArrayDeque<>();
+		this.outQueue = new ArrayDeque<>();
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/senders/MailSenderBase.java
+++ b/core/src/main/java/org/frankframework/senders/MailSenderBase.java
@@ -236,7 +236,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 		if (recipientsNode != null && !recipientsNode.isEmpty()) {
 			Iterator<Node> iter = recipientsNode.iterator();
 			if (iter.hasNext()) {
-				recipients = new LinkedList<>();
+				recipients = new ArrayList<>();
 				while (iter.hasNext()) {
 					Element recipientElement = (Element) iter.next();
 					String value = XmlUtils.getStringValue(recipientElement);

--- a/core/src/main/java/org/frankframework/senders/MailSenderBase.java
+++ b/core/src/main/java/org/frankframework/senders/MailSenderBase.java
@@ -20,11 +20,11 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import lombok.Getter;
@@ -126,22 +126,22 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 		return mailSession;
 	}
 
-	private Collection<MailAttachmentStream> retrieveAttachmentsFromParamList(ParameterValue pv, PipeLineSession session) throws SenderException, ParameterException {
-		Collection<MailAttachmentStream> attachments = null;
-		if (pv != null) {
-			attachments = retrieveAttachments(pv.asCollection(), session);
-			log.debug("MailSender [{}] retrieved attachments-parameter [{}]", getName(), attachments);
+	private @Nonnull Collection<MailAttachmentStream> retrieveAttachmentsFromParamList(@Nullable ParameterValue pv, @Nonnull PipeLineSession session) throws SenderException, ParameterException {
+		if (pv == null) {
+			return Collections.emptyList();
 		}
+		Collection<MailAttachmentStream> attachments = retrieveAttachments(pv.asCollection(), session);
+		log.debug("MailSender [{}] retrieved attachments-parameter [{}]", getName(), attachments);
 		return attachments;
 	}
 
-	private Collection<EMail> retrieveRecipientsFromParameterList(ParameterValue pv)
+	private @Nonnull Collection<EMail> retrieveRecipientsFromParameterList(ParameterValue pv)
 			throws ParameterException, SenderException {
-		Collection<EMail> recipients = null;
-		if (pv != null) {
-			recipients = retrieveRecipients(pv.asCollection());
-			log.debug("MailSender [{}] retrieved recipients-parameter [{}]", getName(), recipients);
+		if (pv == null) {
+			return Collections.emptyList();
 		}
+		Collection<EMail> recipients = retrieveRecipients(pv.asCollection());
+		log.debug("MailSender [{}] retrieved recipients-parameter [{}]", getName(), recipients);
 		return recipients;
 	}
 
@@ -211,7 +211,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 			}
 			pv = pvl.get("recipients");
 			Collection<EMail> recipientsCollection = retrieveRecipientsFromParameterList(pv);
-			if (recipientsCollection != null && !recipientsCollection.isEmpty()) {
+			if (!recipientsCollection.isEmpty()) {
 				recipients = new ArrayList<>(recipientsCollection);
 				mail.setRecipientList(recipients);
 			} else {
@@ -220,7 +220,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 
 			pv = pvl.get("attachments");
 			Collection<MailAttachmentStream> attachmentsCollection = retrieveAttachmentsFromParamList(pv, session);
-			if (attachmentsCollection != null && !attachmentsCollection.isEmpty()) {
+			if (!attachmentsCollection.isEmpty()) {
 				attachments = new ArrayList<>(attachmentsCollection);
 				mail.setAttachmentList(attachments);
 			}
@@ -231,65 +231,60 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 		return mail;
 	}
 
-	private List<EMail> retrieveRecipients(Collection<Node> recipientsNode) throws SenderException {
-		List<EMail> recipients = null;
-		if (recipientsNode != null && !recipientsNode.isEmpty()) {
-			Iterator<Node> iter = recipientsNode.iterator();
-			if (iter.hasNext()) {
-				recipients = new ArrayList<>();
-				while (iter.hasNext()) {
-					Element recipientElement = (Element) iter.next();
-					String value = XmlUtils.getStringValue(recipientElement);
-					if (StringUtils.isNotEmpty(value)) {
-						String name = recipientElement.getAttribute("name");
-						String type = recipientElement.getAttribute("type");
-						EMail recipient = new EMail(value, name, StringUtils.isNotEmpty(type) ? type : "to");
-						recipients.add(recipient);
-					} else {
-						log.debug("empty recipient found, ignoring");
-					}
-				}
+	private @Nonnull List<EMail> retrieveRecipients(@Nonnull Collection<Node> recipientsNode) throws SenderException {
+		if (recipientsNode.isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<EMail> recipients = new ArrayList<>(recipientsNode.size());
+		for (Node node : recipientsNode) {
+			Element recipientElement = (Element) node;
+			String value = XmlUtils.getStringValue(recipientElement);
+			if (!StringUtils.isNotEmpty(value)) {
+				log.debug("empty recipient found, ignoring");
+				continue;
 			}
-		} else {
-			throw new SenderException("no recipients for message");
+			String name = recipientElement.getAttribute("name");
+			String type = recipientElement.getAttribute("type");
+			EMail recipient = new EMail(value, name, StringUtils.isNotEmpty(type) ? type : "to");
+			recipients.add(recipient);
 		}
 
 		return recipients;
 	}
 
-	private Collection<MailAttachmentStream> retrieveAttachments(Collection<Node> attachmentsNode, PipeLineSession session) throws SenderException {
-		Collection<MailAttachmentStream> attachments = null;
-		Iterator<Node> iter = attachmentsNode.iterator();
-		if (iter != null && iter.hasNext()) {
-			attachments = new LinkedList<>();
-			while (iter.hasNext()) {
-				Element attachmentElement = (Element) iter.next();
-				String name = attachmentElement.getAttribute("name");
-				String mimeType = attachmentElement.getAttribute("type");
-				if (StringUtils.isNotEmpty(mimeType) && mimeType.indexOf("/")<0) {
-					throw new SenderException("mimeType ["+mimeType+"] of attachment ["+name+"] must contain a forward slash ('/')");
-				}
-				String sessionKey = attachmentElement.getAttribute("sessionKey");
-				boolean base64 = Boolean.parseBoolean(attachmentElement.getAttribute("base64"));
-
-				MailAttachmentStream attachment = null;
-				if (StringUtils.isNotEmpty(sessionKey)) {
-					Object object = session.get(sessionKey);
-					if (object instanceof InputStream stream) {
-						attachment = streamToMailAttachment(stream, base64, mimeType);
-					} else if (object instanceof String string) {
-						attachment = stringToMailAttachment(string, base64, mimeType);
-					} else {
-						throw new SenderException("MailSender ["+getName()+"] received unknown attachment type ["+object.getClass().getName()+"] in sessionkey");
-					}
-				} else {
-					String nodeValue = XmlUtils.getStringValue(attachmentElement);
-					attachment = stringToMailAttachment(nodeValue, base64, mimeType);
-				}
-				attachment.setName(name);
-				log.debug("created attachment [{}]", attachment);
-				attachments.add(attachment);
+	private @Nonnull Collection<MailAttachmentStream> retrieveAttachments(@Nonnull Collection<Node> attachmentsNode, @Nonnull PipeLineSession session) throws SenderException {
+		if (attachmentsNode.isEmpty()) {
+			return Collections.emptyList();
+		}
+		Collection<MailAttachmentStream> attachments = new ArrayList<>(attachmentsNode.size());
+		for (Node node : attachmentsNode) {
+			Element attachmentElement = (Element) node;
+			String name = attachmentElement.getAttribute("name");
+			String mimeType = attachmentElement.getAttribute("type");
+			if (StringUtils.isNotEmpty(mimeType) && !mimeType.contains("/")) {
+				throw new SenderException("mimeType [" + mimeType + "] of attachment [" + name + "] must contain a forward slash ('/')");
 			}
+			String sessionKey = attachmentElement.getAttribute("sessionKey");
+			boolean base64 = Boolean.parseBoolean(attachmentElement.getAttribute("base64"));
+
+			MailAttachmentStream attachment;
+			if (StringUtils.isNotEmpty(sessionKey)) {
+				Object object = session.get(sessionKey);
+				if (object instanceof InputStream stream) {
+					attachment = streamToMailAttachment(stream, base64, mimeType);
+				} else if (object instanceof String string) {
+					attachment = stringToMailAttachment(string, base64, mimeType);
+				} else {
+					throw new SenderException("MailSender [" + getName() + "] received unknown attachment type [" + object.getClass()
+							.getName() + "] in sessionkey");
+				}
+			} else {
+				String nodeValue = XmlUtils.getStringValue(attachmentElement);
+				attachment = stringToMailAttachment(nodeValue, base64, mimeType);
+			}
+			attachment.setName(name);
+			log.debug("created attachment [{}]", attachment);
+			attachments.add(attachment);
 		}
 		return attachments;
 	}
@@ -343,7 +338,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 		if (StringUtils.isEmpty(messageType)) {
 			messageType=getDefaultMessageType();
 		}
-		if (messageType.indexOf("/")<0) {
+		if (!messageType.contains("/")) {
 			throw new SenderException("messageType ["+messageType+"] must contain a forward slash ('/')");
 		}
 		messageBase64 = XmlUtils.getChildTagAsBoolean(emailElement, "messageBase64");
@@ -388,7 +383,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 
 	protected abstract MailSessionBase createMailSession() throws SenderException;
 
-	private EMail getEmailAddress(Element element, String type) throws SenderException {
+	private @Nullable EMail getEmailAddress(Element element, String type) throws SenderException {
 		if (element == null) {
 			return null;
 		}
@@ -632,7 +627,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 	 * @author Niels Meijer
 	 *
 	 */
-	protected abstract class MailAttachmentBase<T> {
+	protected abstract static class MailAttachmentBase<T> {
 		private String name;
 		private String mimeType;
 		private T value;
@@ -667,7 +662,7 @@ public abstract class MailSenderBase extends SenderWithParametersBase {
 		}
 	}
 
-	protected class MailAttachmentStream extends MailAttachmentBase<InputStream>{}
+	public static class MailAttachmentStream extends MailAttachmentBase<InputStream>{}
 
 	/**
 	 * Generic mail class

--- a/core/src/main/java/org/frankframework/senders/SenderSeries.java
+++ b/core/src/main/java/org/frankframework/senders/SenderSeries.java
@@ -15,11 +15,15 @@
 */
 package org.frankframework.senders;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import io.micrometer.core.instrument.DistributionSummary;
 import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.AdapterAware;
 import org.frankframework.core.ISender;
@@ -30,10 +34,6 @@ import org.frankframework.core.TimeoutException;
 import org.frankframework.statistics.FrankMeterType;
 import org.frankframework.stream.Message;
 
-import io.micrometer.core.instrument.DistributionSummary;
-import lombok.Getter;
-import lombok.Setter;
-
 /**
  * Series of Senders, that are executed one after another.
  *
@@ -42,7 +42,7 @@ import lombok.Setter;
  */
 public class SenderSeries extends SenderWrapperBase {
 
-	private final List<ISender> senderList = new LinkedList<>();
+	private final List<ISender> senderList = new ArrayList<>();
 	private final Map<ISender, DistributionSummary> statisticsMap = new ConcurrentHashMap<>();
 	private @Getter @Setter boolean synchronous=true;
 

--- a/core/src/main/java/org/frankframework/util/XmlBuilder.java
+++ b/core/src/main/java/org/frankframework/util/XmlBuilder.java
@@ -16,7 +16,7 @@
 package org.frankframework.util;
 
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.logging.log4j.Logger;
@@ -93,14 +93,14 @@ public class XmlBuilder {
 			if (cdata != null) {
 				throw new IllegalStateException("XmlBuilder cannot have mixed content, cdata already set when trying to add element");
 			}
-			subElements = new LinkedList<>();
+			subElements = new ArrayList<>();
 		}
 		subElements.add(newElement);
 	}
 
 	public void setCdataValue(String value) {
 		text = null;
-		cdata = new LinkedList<>();
+		cdata = new ArrayList<>();
 		if (value != null) {
 			int cdata_end_pos;
 			while ((cdata_end_pos = value.indexOf(CDATA_END)) >= 0) {

--- a/core/src/main/java/org/frankframework/validation/XercesXmlValidator.java
+++ b/core/src/main/java/org/frankframework/validation/XercesXmlValidator.java
@@ -19,8 +19,8 @@ package org.frankframework.validation;
 import static org.apache.xerces.parsers.XMLGrammarCachingConfiguration.BIG_PRIME;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.xml.validation.ValidatorHandler;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.impl.Constants;
 import org.apache.xerces.impl.xs.SchemaGrammar;
@@ -45,20 +47,17 @@ import org.apache.xerces.xni.grammars.XMLGrammarPool;
 import org.apache.xerces.xni.grammars.XSGrammar;
 import org.apache.xerces.xni.parser.XMLInputSource;
 import org.apache.xerces.xs.XSModel;
-import org.frankframework.util.AppConstants;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
-import org.xml.sax.XMLReader;
-
-import lombok.Getter;
-import lombok.Setter;
 import org.frankframework.cache.EhCache;
 import org.frankframework.configuration.ApplicationWarnings;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IConfigurationAware;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
+import org.frankframework.util.AppConstants;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
 
 
 /**
@@ -398,7 +397,7 @@ class PreparseResult {
 
 	public List<XSModel> getXsModels() {
 		if (xsModels == null) {
-			xsModels = new LinkedList<>();
+			xsModels = new ArrayList<>();
 			Grammar[] grammars = grammarPool.retrieveInitialGrammarSet(XMLGrammarDescription.XML_SCHEMA);
 			for (Grammar grammar : grammars) {
 				xsModels.add(((XSGrammar) grammar).toXSModel());

--- a/core/src/test/java/org/frankframework/align/TestXmlSchema2JsonSchema.java
+++ b/core/src/test/java/org/frankframework/align/TestXmlSchema2JsonSchema.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.net.URL;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.json.JsonStructure;
+import jakarta.json.stream.JsonParser;
 import org.apache.commons.lang3.StringUtils;
 import org.frankframework.core.PipeForward;
 import org.frankframework.pipes.Json2XmlValidator;
@@ -17,9 +19,6 @@ import org.frankframework.util.StreamUtil;
 import org.leadpony.justify.api.JsonSchema;
 import org.leadpony.justify.api.JsonValidationService;
 import org.leadpony.justify.api.ProblemHandler;
-
-import jakarta.json.JsonStructure;
-import jakarta.json.stream.JsonParser;
 
 /*
  * @see: https://github.com/networknt/json-schema-validator
@@ -104,7 +103,7 @@ public class TestXmlSchema2JsonSchema extends AlignTestBase {
 	public void validateJson(String jsonString, String jsonSchemaContent) {
 		JsonValidationService service = JsonValidationService.newInstance();
 		JsonSchema schema = service.readSchema(new StringReader(jsonSchemaContent));
-		final List<String> problems = new LinkedList<>();
+		final List<String> problems = new ArrayList<>();
 		// Problem handler which will print problems found.
 		ProblemHandler handler = service.createProblemPrinter(problems::add);
 

--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/RoleToGroupMappingJndiRealm.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/RoleToGroupMappingJndiRealm.java
@@ -17,9 +17,9 @@ package org.frankframework.credentialprovider;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -160,7 +160,7 @@ public class RoleToGroupMappingJndiRealm extends JNDIRealm implements RoleGroupM
 		try {
 			List<String> roles = user.getRoles();
 			Set<String> allRoles = new LinkedHashSet<>(roles);
-			Queue<String> rolesToCheck = new LinkedList<>(allRoles);
+			Queue<String> rolesToCheck = new ArrayDeque<>(allRoles);
 
 			if (this.containerLog.isTraceEnabled()) this.containerLog.trace("allRoles in: "+allRoles);
 

--- a/dbms/src/main/java/org/frankframework/dbms/Db2DbmsSupport.java
+++ b/dbms/src/main/java/org/frankframework/dbms/Db2DbmsSupport.java
@@ -17,7 +17,7 @@ package org.frankframework.dbms;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -81,9 +81,7 @@ public class Db2DbmsSupport extends GenericDbmsSupport {
 	}
 
 	public boolean hasIndexOnColumn(Connection conn, String schemaName, String tableName, String columnName) throws DbmsException {
-		List<String> columns = new LinkedList<>();
-		columns.add(columnName);
-		return hasIndexOnColumns(conn, schemaName, tableName, columns);
+		return hasIndexOnColumns(conn, schemaName, tableName, Collections.singletonList(columnName));
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/util/FileHandler.java
+++ b/filesystem/src/main/java/org/frankframework/util/FileHandler.java
@@ -26,9 +26,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.StringTokenizer;
 
@@ -119,7 +119,7 @@ public class FileHandler implements IScopeProvider {
 	 */
 	public void configure() throws ConfigurationException {
 		// translation action separated string to Transformers
-		transformers = new LinkedList<>();
+		transformers = new ArrayList<>();
 		if (StringUtils.isEmpty(getActions()))
 			throw new ConfigurationException(getLogPrefix(null)+"should at least define one action");
 

--- a/larva/src/main/java/org/frankframework/larva/LarvaTool.java
+++ b/larva/src/main/java/org/frankframework/larva/LarvaTool.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -97,6 +96,7 @@ import org.frankframework.util.Misc;
 import org.frankframework.util.ProcessUtil;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.StringResolver;
+import org.frankframework.util.StringUtil;
 import org.frankframework.util.TemporaryDirectoryUtils;
 import org.frankframework.util.XmlEncodingUtils;
 import org.frankframework.util.XmlUtils;
@@ -2294,11 +2294,9 @@ public class LarvaTool {
 						errorMessage("Could not build node for parameter '" + name + "' with value: " + value, e);
 					}
 				} else if ("list".equals(type)) {
-					List<String> parts = new ArrayList<>(Arrays.asList(propertyValue.split("\\s*(,\\s*)+")));
-
-					value = new LinkedList<>(parts);
+					value = StringUtil.split(propertyValue);
 				} else if ("map".equals(type)) {
-					List<String> parts = new ArrayList<>(Arrays.asList(propertyValue.split("\\s*(,\\s*)+")));
+					List<String> parts = StringUtil.split(propertyValue);
 					Map<String, String> map = new LinkedHashMap<>();
 
 					for (String part : parts) {

--- a/larva/src/main/java/org/frankframework/larva/queues/QueueWrapper.java
+++ b/larva/src/main/java/org/frankframework/larva/queues/QueueWrapper.java
@@ -17,12 +17,10 @@ package org.frankframework.larva.queues;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -178,10 +176,9 @@ public class QueueWrapper extends HashMap<String, Object> implements Queue {
 						throw new IllegalStateException("Could not build node for parameter '" + name + "' with value: " + value, e);
 					}
 				} else if ("list".equals(type)) {
-					List<String> parts = new ArrayList<>(Arrays.asList(propertyValue.split("\\s*(,\\s*)+")));
-					value = new LinkedList<>(parts);
+					value = Arrays.asList(propertyValue.split("\\s*(,\\s*)+"));
 				} else if ("map".equals(type)) {
-					List<String> parts = new ArrayList<>(Arrays.asList(propertyValue.split("\\s*(,\\s*)+")));
+					List<String> parts = Arrays.asList(propertyValue.split("\\s*(,\\s*)+"));
 					Map<String, String> map = new LinkedHashMap<>();
 					for (String part : parts) {
 						String[] splitted = part.split("\\s*(=\\s*)+", 2);

--- a/larva/src/main/java/org/frankframework/larva/queues/QueueWrapper.java
+++ b/larva/src/main/java/org/frankframework/larva/queues/QueueWrapper.java
@@ -17,7 +17,6 @@ package org.frankframework.larva.queues;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -176,9 +175,9 @@ public class QueueWrapper extends HashMap<String, Object> implements Queue {
 						throw new IllegalStateException("Could not build node for parameter '" + name + "' with value: " + value, e);
 					}
 				} else if ("list".equals(type)) {
-					value = Arrays.asList(propertyValue.split("\\s*(,\\s*)+"));
+					value = StringUtil.split(propertyValue);
 				} else if ("map".equals(type)) {
-					List<String> parts = Arrays.asList(propertyValue.split("\\s*(,\\s*)+"));
+					List<String> parts = StringUtil.split(propertyValue);
 					Map<String, String> map = new LinkedHashMap<>();
 					for (String part : parts) {
 						String[] splitted = part.split("\\s*(=\\s*)+", 2);


### PR DESCRIPTION
`LinkedList` heeft een grote per-entry overhead en is met de meeste operaties trager dan een `ArrayList`, zeker als de operaties vooral "append at end" en "read all entries" zijn.
Ook random access, zoals bij sorteren, is trager bij LinkedList.

De per-entry overhead betekent ook voor iedere entry een extra object-allocation en extra werk voor de garbage-collector bij het opruimen van lists.

De daadwerkelijke winst voor het hele Frank!Framework is moeilijk te meten maar dat is de reden om een aantal lists over te zetten.