### PR TITLE
Fix inputstreams that weren't closed

### DIFF
--- a/core/src/main/java/org/frankframework/pipes/ReplacingInputStream.java
+++ b/core/src/main/java/org/frankframework/pipes/ReplacingInputStream.java
@@ -46,6 +46,13 @@ public class ReplacingInputStream extends InputStream {
 	private final byte[] search;
 	private final InputStream in;
 
+	@Override
+	public void close() throws IOException {
+		if (this.in != null) {
+			this.in.close();
+		}
+	}
+
 	public ReplacingInputStream(InputStream in, String search, String replacement, boolean replaceNonXmlChars,
 								String nonXmlReplacementCharacter, boolean allowUnicodeSupplementaryCharacters) {
 

--- a/core/src/main/java/org/frankframework/pipes/ReplacingVariablesInputStream.java
+++ b/core/src/main/java/org/frankframework/pipes/ReplacingVariablesInputStream.java
@@ -48,6 +48,13 @@ public class ReplacingVariablesInputStream extends InputStream {
 	private final Queue<Integer> outQueue;
 	private boolean lookingForSuffix = false;
 
+	@Override
+	public void close() throws IOException {
+		if (this.in != null) {
+			this.in.close();
+		}
+	}
+
 	protected ReplacingVariablesInputStream(InputStream in, String variablePrefix, Properties properties) {
 		this.in = in;
 		this.variablePrefix = (variablePrefix + "{").getBytes();


### PR DESCRIPTION
Since the inputStreams didn't extend `FilterInputStream` anymore, `close()` wasn't implemented and the streams would not be closed correctly

Niels: we didn't see this working due to some IntelliJ issues. After a restart and fresh run after clean/install it did what we expected.