### PR TITLE
Download all active configurations

### DIFF
--- a/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
@@ -227,6 +227,18 @@ public class ConfigurationsEndpoint extends FrankApiBase {
 	@AllowAllIbisUserRoles
 	@Relation("configuration")
 	@Description("download a specific configuration version")
+	@GetMapping(value = "/configurations/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public ResponseEntity<?> downloadActiveConfigurations(@RequestParam(value = "dataSourceName", required = false) String dataSourceName) throws ApiException {
+		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.DOWNLOAD);
+		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, "*");
+		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, dataSourceName);
+		// TODO zip it
+		return callSyncGateway(builder);
+	}
+
+	@AllowAllIbisUserRoles
+	@Relation("configuration")
+	@Description("download a specific configuration version")
 	@GetMapping(value = "/configurations/{configuration}/versions/{version}/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
 	public ResponseEntity<?> downloadConfiguration(@PathVariable("configuration") String configurationName, @PathVariable(PATH_VARIABLE_VERSION) String version,
 												   @RequestParam(value = "dataSourceName", required = false) String dataSourceName) throws ApiException {

--- a/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
@@ -230,7 +230,7 @@ public class ConfigurationsEndpoint extends FrankApiBase {
 	@GetMapping(value = "/configurations/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
 	public ResponseEntity<?> downloadActiveConfigurations(@RequestParam(value = "dataSourceName", required = false) String dataSourceName) throws ApiException {
 		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.DOWNLOAD);
-		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, "*");
+		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, dataSourceName);
 		return callSyncGateway(builder);
 	}

--- a/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
@@ -227,17 +227,6 @@ public class ConfigurationsEndpoint extends FrankApiBase {
 	@AllowAllIbisUserRoles
 	@Relation("configuration")
 	@Description("download a specific configuration version")
-	@GetMapping(value = "/configurations/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-	public ResponseEntity<?> downloadActiveConfigurations(@RequestParam(value = "dataSourceName", required = false) String dataSourceName) throws ApiException {
-		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.DOWNLOAD);
-		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
-		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, dataSourceName);
-		return callSyncGateway(builder);
-	}
-
-	@AllowAllIbisUserRoles
-	@Relation("configuration")
-	@Description("download a specific configuration version")
 	@GetMapping(value = "/configurations/{configuration}/versions/{version}/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
 	public ResponseEntity<?> downloadConfiguration(@PathVariable("configuration") String configurationName, @PathVariable(PATH_VARIABLE_VERSION) String version,
 												   @RequestParam(value = "dataSourceName", required = false) String dataSourceName) throws ApiException {

--- a/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ConfigurationsEndpoint.java
@@ -232,7 +232,6 @@ public class ConfigurationsEndpoint extends FrankApiBase {
 		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.DOWNLOAD);
 		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, "*");
 		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, dataSourceName);
-		// TODO zip it
 		return callSyncGateway(builder);
 	}
 

--- a/console/backend/src/main/java/org/frankframework/management/web/ServerStatistics.java
+++ b/console/backend/src/main/java/org/frankframework/management/web/ServerStatistics.java
@@ -17,11 +17,14 @@ package org.frankframework.management.web;
 
 import jakarta.annotation.security.PermitAll;
 import org.frankframework.management.bus.BusAction;
+import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
+import org.frankframework.web.AllowAllIbisUserRoles;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,9 +38,21 @@ public class ServerStatistics extends FrankApiBase {
 	}
 
 	@PermitAll
+	@Relation("configuration")
 	@GetMapping(value = "/configurations", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<?> getAllConfigurations() {
 		return callSyncGateway(RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.FIND));
+	}
+
+	@AllowAllIbisUserRoles
+	@Relation("configuration")
+	@Description("download all active configurations")
+	@GetMapping(value = "/configurations/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+	public ResponseEntity<?> downloadActiveConfigurations(@RequestParam(value = "dataSourceName", required = false) String dataSourceName) {
+		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.CONFIGURATION, BusAction.DOWNLOAD);
+		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
+		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, dataSourceName);
+		return callSyncGateway(builder);
 	}
 
 	@PermitAll

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.html
@@ -1,6 +1,3 @@
-<!-- Angular ui-router hack-->
-<div ui-view></div>
-
 <div class="wrapper wrapper-content animated fadeInRight">
   <div class="row">
     <div class="col-lg-12 table-responsive">
@@ -8,8 +5,16 @@
         <div class="ibox-title">
           <div class="pull-right">
             <button
+              class="btn btn-xs btn-info space-it-out"
+              type="button"
+              (click)="downloadAll()"
+            >
+              <i class="fa fa-download" aria-hidden="true"></i
+              ><span> Download Active Configs</span>
+            </button>
+            <button
               routerLink="/configurations/upload"
-              class="btn btn-xs pull-right btn-info"
+              class="btn btn-xs btn-info"
               type="button"
             >
               <i class="fa fa-upload" aria-hidden="true"></i

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
@@ -40,7 +40,7 @@ export class ConfigurationsManageComponent implements OnInit, OnDestroy {
 
   downloadAll(): void {
     window.open(
-      `${this.appService.absoluteApiPath}configurations/download`,
+      `${this.appService.absoluteApiPath}/server/configurations/download`,
       '_blank',
     );
   }

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
@@ -1,14 +1,17 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AppService, Configuration } from 'src/app/app.service';
 import { ConfigurationsService } from '../configurations.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-configurations-manage',
   templateUrl: './configurations-manage.component.html',
   styleUrls: ['./configurations-manage.component.scss'],
 })
-export class ConfigurationsManageComponent implements OnInit {
+export class ConfigurationsManageComponent implements OnInit, OnDestroy {
   configurations: Configuration[] = [];
+
+  private subscriptions = new Subscription();
 
   constructor(
     private configurationsService: ConfigurationsService,
@@ -17,12 +20,28 @@ export class ConfigurationsManageComponent implements OnInit {
 
   ngOnInit(): void {
     this.configurations = this.appService.configurations;
-    this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-    });
+    const appConfigurationsSubscription =
+      this.appService.configurations$.subscribe(() => {
+        this.configurations = this.appService.configurations;
+      });
+    this.subscriptions.add(appConfigurationsSubscription);
 
-    this.configurationsService.getConfigurations().subscribe((data) => {
-      this.appService.updateConfigurations(data);
-    });
+    const localConfigurationsSubscription = this.configurationsService
+      .getConfigurations()
+      .subscribe((data) => {
+        this.appService.updateConfigurations(data);
+      });
+    this.subscriptions.add(localConfigurationsSubscription);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  downloadAll(): void {
+    window.open(
+      `${this.appService.absoluteApiPath}configurations/download`,
+      '_blank',
+    );
   }
 }

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.management.bus.BusMessageUtils;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -252,10 +253,10 @@ public class IbisContext extends IbisApplicationContext {
 		}
 
 		try {
-			loadingConfigs.add(IbisManager.ALL_CONFIGS_KEY);
+			loadingConfigs.add(BusMessageUtils.ALL_CONFIGS_KEY);
 			load(null);
 		} finally {
-			loadingConfigs.remove(IbisManager.ALL_CONFIGS_KEY);
+			loadingConfigs.remove(BusMessageUtils.ALL_CONFIGS_KEY);
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/configuration/IbisManager.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisManager.java
@@ -35,7 +35,6 @@ import org.springframework.context.ApplicationEventPublisherAware;
  * @since   4.8
  */
 public interface IbisManager extends ApplicationEventPublisherAware, ApplicationContextAware {
-	String ALL_CONFIGS_KEY = "*ALL*";
 
 	void setIbisContext(IbisContext ibisContext);
 

--- a/core/src/main/java/org/frankframework/lifecycle/MessageEventListener.java
+++ b/core/src/main/java/org/frankframework/lifecycle/MessageEventListener.java
@@ -18,10 +18,10 @@ package org.frankframework.lifecycle;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.frankframework.management.bus.BusMessageUtils;
 import org.springframework.context.ApplicationListener;
 
 import org.frankframework.configuration.ConfigurationMessageEvent;
-import org.frankframework.configuration.IbisManager;
 import org.frankframework.util.MessageKeeper;
 
 public class MessageEventListener implements ApplicationListener<ApplicationMessageEvent> {
@@ -40,7 +40,7 @@ public class MessageEventListener implements ApplicationListener<ApplicationMess
 	 * @return MessageKeeper for the application
 	 */
 	public MessageKeeper getMessageKeeper() {
-		return getMessageKeeper(IbisManager.ALL_CONFIGS_KEY);
+		return getMessageKeeper(BusMessageUtils.ALL_CONFIGS_KEY);
 	}
 
 	/**
@@ -55,7 +55,7 @@ public class MessageEventListener implements ApplicationListener<ApplicationMess
 	}
 
 	private MessageKeeper globalLog() {
-		return configLog(IbisManager.ALL_CONFIGS_KEY);
+		return configLog(BusMessageUtils.ALL_CONFIGS_KEY);
 	}
 
 	private MessageKeeper configLog(String key) {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/AdapterStatistics.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/AdapterStatistics.java
@@ -15,7 +15,6 @@
 */
 package org.frankframework.management.bus.endpoints;
 import jakarta.annotation.security.RolesAllowed;
-import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
 import org.frankframework.management.bus.ActionSelector;
 import org.frankframework.management.bus.BusAction;
@@ -51,7 +50,7 @@ public class AdapterStatistics extends BusEndpointBase {
 	@ActionSelector(BusAction.STATUS)
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public Message<String> getStatistics(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/BrowseMessageBrowsers.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/BrowseMessageBrowsers.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.security.RolesAllowed;
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
 import org.frankframework.core.IListener;
 import org.frankframework.core.IMessageBrowser;
@@ -97,7 +96,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.GET)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public Message<String> getMessageById(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
 		String messageId = BusMessageUtils.getHeader(message, HEADER_MESSAGEID_KEY);
@@ -126,7 +125,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.DOWNLOAD)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public StringMessage downloadMessageById(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
 		String messageId = BusMessageUtils.getHeader(message, HEADER_MESSAGEID_KEY);
@@ -158,7 +157,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.FIND)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public Message<String> browseMessages(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
 
@@ -220,7 +219,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.STATUS)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public void resend(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		String receiverName = BusMessageUtils.getHeader(message, HEADER_RECEIVER_NAME_KEY);
 		String messageId = BusMessageUtils.getHeader(message, HEADER_MESSAGEID_KEY);
@@ -242,7 +241,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.DELETE)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public void delete(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		String receiverName = BusMessageUtils.getHeader(message, HEADER_RECEIVER_NAME_KEY);
 		String messageId = BusMessageUtils.getHeader(message, HEADER_MESSAGEID_KEY);
@@ -266,7 +265,7 @@ public class BrowseMessageBrowsers extends BusEndpointBase {
 	@ActionSelector(BusAction.MANAGE)
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public void changeProcessState(Message<?> message) {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_ADAPTER_NAME_KEY);
 		String receiverName = BusMessageUtils.getHeader(message, HEADER_RECEIVER_NAME_KEY);
 		String messageId = BusMessageUtils.getHeader(message, HEADER_MESSAGEID_KEY);

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/BusEndpointBase.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/BusEndpointBase.java
@@ -24,6 +24,7 @@ import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
 import org.frankframework.core.IPipe;
 import org.frankframework.management.bus.BusException;
+import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.receivers.Receiver;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.SpringUtils;
@@ -110,7 +111,7 @@ public class BusEndpointBase implements ApplicationContextAware, InitializingBea
 		if(StringUtils.isEmpty(adapterName)) {
 			throw new BusException("no adapter name specified");
 		}
-		if(IbisManager.ALL_CONFIGS_KEY.equals(configurationName)) {
+		if(BusMessageUtils.ALL_CONFIGS_KEY.equals(configurationName)) {
 			return getIbisManager().getRegisteredAdapter(adapterName);
 		}
 

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -188,7 +188,7 @@ public class ConfigManagement extends BusEndpointBase {
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public BinaryMessage downloadConfiguration(Message<?> message) throws IOException {
 		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY);
-		if ("*".equals(configurationName)) {
+		if (BusMessageUtils.ALL_CONFIGS_KEY.equals(configurationName)) {
 			String datasourceName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, IDataSourceFactory.GLOBAL_DEFAULT_DATASOURCE_NAME);
 			List<Map<String, Object>> activeConfigsFromDb;
 			try {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/DatabaseMigrator.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/DatabaseMigrator.java
@@ -32,7 +32,6 @@ import org.frankframework.management.bus.message.StringMessage;
 import org.springframework.messaging.Message;
 
 import org.frankframework.configuration.Configuration;
-import org.frankframework.configuration.IbisManager;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.core.BytesResource;
 import org.frankframework.core.Resource;
@@ -54,8 +53,8 @@ public class DatabaseMigrator extends BusEndpointBase {
 	@ActionSelector(BusAction.DOWNLOAD)
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public BinaryMessage downloadMigrationScript(Message<?> message) throws IOException {
-		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
-		if(IbisManager.ALL_CONFIGS_KEY.equals(configurationName)) {
+		String configurationName = BusMessageUtils.getHeader(message, BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
+		if(BusMessageUtils.ALL_CONFIGS_KEY.equals(configurationName)) {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			try (ZipOutputStream zos = new ZipOutputStream(out)) {
 				for(Configuration configuration : getIbisManager().getConfigurations()) {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/HandleIbisManagerAction.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/HandleIbisManagerAction.java
@@ -18,7 +18,6 @@ package org.frankframework.management.bus.endpoints;
 import org.frankframework.management.bus.TopicSelector;
 import org.springframework.messaging.Message;
 import jakarta.annotation.security.RolesAllowed;
-import org.frankframework.configuration.IbisManager;
 import org.frankframework.management.Action;
 import org.frankframework.management.bus.BusAware;
 import org.frankframework.management.bus.BusException;
@@ -32,7 +31,7 @@ public class HandleIbisManagerAction extends BusEndpointBase {
 	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
 	public void handleIbisAction(Message<?> message) {
 		Action action = BusMessageUtils.getEnumHeader(message, "action", Action.class);
-		String configurationName = BusMessageUtils.getHeader(message, "configuration", IbisManager.ALL_CONFIGS_KEY);
+		String configurationName = BusMessageUtils.getHeader(message, "configuration", BusMessageUtils.ALL_CONFIGS_KEY);
 		String adapterName = BusMessageUtils.getHeader(message, "adapter");
 		String receiverName = BusMessageUtils.getHeader(message, "receiver");
 		String userPrincipalName = BusMessageUtils.getUserPrincipalName();

--- a/core/src/main/java/org/frankframework/unmanaged/DefaultIbisManager.java
+++ b/core/src/main/java/org/frankframework/unmanaged/DefaultIbisManager.java
@@ -23,6 +23,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.Logger;
+import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.RunState;
 import org.springframework.context.ApplicationContext;
@@ -125,8 +126,8 @@ public class DefaultIbisManager implements IbisManager {
 			Assert.notNull(adapterName, "no adapterName provided");
 			Assert.notNull(configurationName, "no configurationName provided");
 
-			if (adapterName.equals(ALL_CONFIGS_KEY)) {
-				if (configurationName.equals(ALL_CONFIGS_KEY)) {
+			if (adapterName.equals(BusMessageUtils.ALL_CONFIGS_KEY)) {
+				if (configurationName.equals(BusMessageUtils.ALL_CONFIGS_KEY)) {
 					log.info("Stopping all adapters on request of [{}]", commandIssuedBy);
 					for (Configuration configuration : configurations) {
 						stopAdapters(configuration);
@@ -150,8 +151,8 @@ public class DefaultIbisManager implements IbisManager {
 			Assert.notNull(adapterName, "no adapterName provided");
 			Assert.notNull(configurationName, "no configurationName provided");
 
-			if (adapterName.equals(ALL_CONFIGS_KEY)) {
-				if (configurationName.equals(ALL_CONFIGS_KEY)) {
+			if (adapterName.equals(BusMessageUtils.ALL_CONFIGS_KEY)) {
+				if (configurationName.equals(BusMessageUtils.ALL_CONFIGS_KEY)) {
 					log.info("Starting all adapters on request of [{}]", commandIssuedBy);
 					for (Configuration configuration : configurations) {
 						startAdapters(configuration);

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
@@ -53,7 +53,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 	@Test
 	public void downloadAllMigrationScripts() throws Exception {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.JDBC_MIGRATION, BusAction.DOWNLOAD);
-		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, IbisManager.ALL_CONFIGS_KEY);
+		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		Message<?> response = callSyncGateway(request);
 		assertEquals("application/octet-stream", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
 		Object cdk = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY);

--- a/management-gateway/src/main/java/org/frankframework/management/bus/BusMessageUtils.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/BusMessageUtils.java
@@ -44,6 +44,8 @@ public class BusMessageUtils {
 	public static final String HEADER_PREFIX = "meta-";
 	public static final String HEADER_PREFIX_PATTERN = "meta-*";
 
+	public static final String ALL_CONFIGS_KEY = "*ALL*";
+
 	@SuppressWarnings("unchecked")
 	private static @Nullable <T> T getHeader(Message<?> message, String headerName, Class<T> type) {
 		MessageHeaders headers = message.getHeaders();


### PR DESCRIPTION
Retrieves all active configurations from the database & zips it into a file, downloadable through the new button in 'Configurations > Manage'
![image](https://github.com/user-attachments/assets/b3697a4f-7002-42a0-a050-d762cfa275c2)
