### PR TITLE
Rework javadoc to use the same syntax everywhere

### DIFF
--- a/akamai/src/main/java/org/frankframework/extensions/akamai/NetStorageSender.java
+++ b/akamai/src/main/java/org/frankframework/extensions/akamai/NetStorageSender.java
@@ -55,9 +55,10 @@ import org.frankframework.util.XmlUtils;
  *
  *
  * <p><b>AuthAlias:</b></p>
- * <p>If you do not want to specify the nonce and the accesstoken used to authenticate with Akamai, you can use the authalias property. The username represents the nonce and the password the accesstoken.</p>
+ * <p>If you do not want to specify the nonce and the access token used to authenticate with Akamai, you can use the authalias property. The username
+ * represents the nonce and the password the access token.</p>
  *
- * @ff.parameters Some actions require specific parameters to be set. Optional parameters for the <code>upload</code> action are: md5, sha1, sha256 and mtime.
+ * @ff.parameters Some actions require specific parameters to be set. Optional parameters for the <code>UPLOAD</code> action are: md5, sha1, sha256 and mtime.
  *
  * @author	Niels Meijer
  * @since	7.0-B4

--- a/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/CisConversionResult.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/CisConversionResult.java
@@ -55,7 +55,7 @@ public class CisConversionResult {
 	private final List<CisConversionResult> attachments = new ArrayList<>();
 
 	/**
-	 * Converted document when succeeded (otherwise <code>null</code>) -
+	 * Converted document when succeeded (otherwise <code>null</code>)
 	 */
 	@Setter @Getter private File pdfResultFile;
 

--- a/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
+++ b/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
@@ -272,7 +272,7 @@ public abstract class AbstractRecordHandler implements IRecordHandler, IWithPara
 	}
 
 	/**
-	 * If set <code>true</code>, trailing spaces are removed from each field
+	 * If set to <code>true</code>, trailing spaces are removed from each field
 	 * @ff.default false
 	 */
 	public void setTrim(boolean b) {

--- a/batch/src/main/java/org/frankframework/batch/AbstractResultHandler.java
+++ b/batch/src/main/java/org/frankframework/batch/AbstractResultHandler.java
@@ -116,7 +116,7 @@ public abstract class AbstractResultHandler implements IResultHandler, IWithPara
 	}
 
 	/**
-	 * if set <code>true</code>, this resulthandler is the default for all {@link RecordHandlingFlow flow}s that do not have a handler specified
+	 * if set to <code>true</code>, this resultHandler is the default for all {@link RecordHandlingFlow flow}s that do not have a handler specified
 	 * @ff.default false
 	 */
 	@Override
@@ -129,7 +129,9 @@ public abstract class AbstractResultHandler implements IResultHandler, IWithPara
 	}
 
 	/**
-	 * When set <code>true</code>(default), every group of records, as indicated by {@link IRecordHandler#isNewRecordType RecordHandler.newRecordType} is handled as a block.
+	 * When set to <code>true</code>(default), every group of records, as indicated by {@link IRecordHandler#isNewRecordType RecordHandler.newRecordType},
+	 * is handled as a block.
+	 *
 	 * @ff.default true
 	 */
 	public void setBlockByRecordType(boolean b) {

--- a/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
+++ b/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
@@ -157,7 +157,7 @@ public class BatchFileTransformerPipe extends StreamTransformerPipe {
 	}
 
 	/**
-	 * If set <code>true</code>, the file processed will deleted after being processed, and not stored
+	 * If set <code>true</code>, the file processed will be deleted after being processed, and not stored
 	 * @ff.default false
 	 */
 	public void setDelete(boolean b) {

--- a/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
@@ -122,7 +122,6 @@ public class RecordXmlTransformer extends AbstractRecordHandler {
 		outputFields.addAll(StringUtil.split(fieldLengths));
 	}
 
-
 	/**
 	 * Root tag for the generated xml document that will be send to the Sender
 	 * @ff.default record

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
@@ -118,7 +118,7 @@ import org.w3c.dom.Node;
  *     <objectTypeId>NNB_Geldlening</objectTypeId>
  *     <mediaType>application/pdf</mediaType>
  *     <properties>
- *         <property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss. SSSz">2014-11-27T16:43:01.268+0100</property>
+ *         <property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss.SSSz">2014-11-27T16:43:01.268+0100</property>
  *         <property name="ArrivedBy">HDN</property>
  *         <property name="DocumentType">Geldlening</property>
  *     </properties>

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisSender.java
@@ -85,46 +85,45 @@ import org.w3c.dom.Node;
 /**
  * Sender to obtain information from and write to a CMIS application.
  *
- *
  * <p>
- * When <code>action</code>=<code>get</code> the input (xml string) indicates the id of the document to get. This input is mandatory.
+ * When <code>action=get</code> the input (xml string) indicates the id of the document to get. This input is mandatory.
  * </p>
  * <p>
  * <b>Example:</b>
- * <pre><code>
- *   &lt;cmis&gt;
- *      &lt;id&gt;documentId&lt;/id&gt;
- *   &lt;/cmis&gt;
- * </code></pre>
+ * <pre>{@code
+ * <cmis>
+ *     <id>documentId</id>
+ * </cmis>
+ * }</pre>
  * </p>
  * <p>
- * When <code>action</code>=<code>delete</code> the input (xml string) indicates the id of the document to get. This input is mandatory.
- * </p>
- * <p>
- * <b>Example:</b>
- * <pre><code>
- *   &lt;cmis&gt;
- *      &lt;id&gt;documentId&lt;/id&gt;
- *   &lt;/cmis&gt;
- * </code></pre>
- * </p>
- * <p>
- * When <code>action</code>=<code>create</code> the input (xml string) indicates document properties to set. This input is optional.
+ * When <code>action=delete</code> the input (xml string) indicates the id of the document to get. This input is mandatory.
  * </p>
  * <p>
  * <b>Example:</b>
- * <pre><code>
- *   &lt;cmis&gt;
- *      &lt;name&gt;Offerte&lt;/name&gt;
- *      &lt;objectTypeId&gt;NNB_Geldlening&lt;/objectTypeId&gt;
- *      &lt;mediaType&gt;application/pdf&lt;/mediaType&gt;
- *      &lt;properties&gt;
- *         &lt;property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss.SSSz"&gt;2014-11-27T16:43:01.268+0100&lt;/property&gt;
- *         &lt;property name="ArrivedBy"&gt;HDN&lt;/property&gt;
- *         &lt;property name="DocumentType"&gt;Geldlening&lt;/property&gt;
- *      &lt;/properties&gt;
- *   &lt;/cmis&gt;
- * </code></pre>
+ * <pre>{@code
+ * <cmis>
+ *     <id>documentId</id>
+ * </cmis>
+ * }</pre>
+ * </p>
+ * <p>
+ * When <code>action=create</code> the input (xml string) indicates document properties to set. This input is optional.
+ * </p>
+ * <p>
+ * <b>Example:</b>
+ * <pre>{@code
+ * <cmis>
+ *     <name>Offerte</name>
+ *     <objectTypeId>NNB_Geldlening</objectTypeId>
+ *     <mediaType>application/pdf</mediaType>
+ *     <properties>
+ *         <property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss. SSSz">2014-11-27T16:43:01.268+0100</property>
+ *         <property name="ArrivedBy">HDN</property>
+ *         <property name="DocumentType">Geldlening</property>
+ *     </properties>
+ * </cmis>
+ * }</pre>
  * </p>
  *
  * <p>
@@ -147,42 +146,42 @@ import org.w3c.dom.Node;
  * </table>
  * </p>
  * <p>
- * When <code>action</code>=<code>find</code> the input (xml string) indicates the query to perform.
+ * When <code>action=find</code> the input (xml string) indicates the query to perform.
  * </p>
  * <p>
  * <b>Example:</b>
- * <pre><code>
- *   &lt;query&gt;
- *      &lt;statement&gt;select * from cmis:document&lt;/statement&gt;
- *      &lt;maxItems&gt;10&lt;/maxItems&gt;
- *      &lt;skipCount&gt;0&lt;/skipCount&gt;
- *      &lt;searchAllVersions&gt;true&lt;/searchAllVersions&gt;
- *      &lt;includeAllowableActions&gt;true&lt;/includeAllowableActions&gt;
- *   &lt;/query&gt;
- * </code></pre>
+ * <pre>{@code
+ * <query>
+ *    <statement>select * from cmis:document</statement>
+ *    <maxItems>10</maxItems>
+ *    <skipCount>0</skipCount>
+ *    <searchAllVersions>true</searchAllVersions>
+ *    <includeAllowableActions>true</includeAllowableActions>
+ * </query
+ * }</pre>
  * </p>
  * <p>
- * When <code>action</code>=<code>update</code> the input (xml string) indicates document properties to update.
+ * When <code>action=update</code> the input (xml string) indicates document properties to update.
  * </p>
  * <p>
  * <b>Example:</b>
- * <pre><code>
- *   &lt;cmis&gt;
- *      &lt;id&gt;123456789&lt;/id&gt;
- *      &lt;properties&gt;
- *         &lt;property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss.SSSz"&gt;2014-11-27T16:43:01.268+0100&lt;/property&gt;
- *         &lt;property name="ArrivedBy"&gt;HDN&lt;/property&gt;
- *         &lt;property name="DocumentType"&gt;Geldlening&lt;/property&gt;
- *      &lt;/properties&gt;
- *   &lt;/cmis&gt;
- * </code></pre>
+ * <pre>{@code
+ * <cmis>
+ *    <id>123456789</id>
+ *    <properties>
+ *       <property name="ArrivedAt" type="datetime" formatString="yyyy-MM-dd'T'HH:mm:ss.SSSz">2014-11-27T16:43:01.268+0100</property>
+ *       <property name="ArrivedBy">HDN</property>
+ *       <property name="DocumentType">Geldlening</property>
+ *    </properties>
+ * </cmis>
+ * }</pre>
  * </p>
  *
  * <p>
  * <table border="1">
  * <tr><th>attributes</th><th>description</th><th>default</th></tr>
  * <tr><td>id</td><td>mandatory property "cmis:objectId" which indicates the document to update</td><td>&nbsp;</td></tr>
- * <tr><td>property</td><td>custom document property to update. See <code>action</code>=<code>create</code> for possible attributes</td><td>&nbsp;</td></tr>
+ * <tr><td>property</td><td>custom document property to update. See <code>action=create</code> for possible attributes</td><td>&nbsp;</td></tr>
  * </table>
  * </p>
  *
@@ -963,18 +962,18 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 		sessionBuilder.setBindingType(bindingType);
 	}
 
-	/** If <code>action</code>=<code>create</code> the sessionKey that contains the file to use. If <code>action</code>=<code>get</code> and <code>getProperties</code>=<code>true</code> the sessionKey to store the result in */
+	/** If <code>action=create</code> the sessionKey that contains the file to use. If <code>action=get</code> and <code>getProperties=true</code> the sessionKey to store the result in */
 	public void setFileSessionKey(String string) {
 		fileSessionKey = string;
 	}
 
-	/** If <code>action</code>=<code>create</code> the session key that contains the name of the file to use. If not set, the value of the property <code>filename</code> from the input message is used */
+	/** If <code>action=create</code> the session key that contains the name of the file to use. If not set, the value of the property <code>filename</code> from the input message is used */
 	public void setFilenameSessionKey(String string) {
 		filenameSessionKey = string;
 	}
 
 	/**
-	 * If <code>action</code>=<code>create</code> the mime type used to store the document when it's not set in the input message by a property
+	 * If <code>action=create</code> the mime type used to store the document when it's not set in the input message by a property
 	 * @ff.default 'application/octet-stream'
 	 */
 	public void setDefaultMediaType(String string) {
@@ -982,7 +981,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	}
 
 	/**
-	 * (Only used when <code>action</code>=<code>get</code>). If true, the content of the document is put to <code>FileSessionKey</code> and all document properties are put in the result as a xml string
+	 * (Only used when <code>action=get</code>). If true, the content of the document is put to <code>FileSessionKey</code> and all document properties are put in the result as a xml string
 	 * @ff.default false
 	 */
 	public void setGetProperties(boolean b) {
@@ -990,7 +989,7 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	}
 
 	/**
-	 * (Only used when <code>action</code>=<code>get</code>). If true, the attachment for the document is the sender result or, if set, stored in <code>FileSessionKey</code>. If false, only the properties are returned
+	 * (Only used when <code>action=get</code>). If true, the attachment for the document is the sender result or, if set, stored in <code>fileSessionKey</code>. If false, only the properties are returned
 	 * @ff.default true
 	 */
 	public void setGetDocumentContent(boolean getDocumentContent) {
@@ -998,14 +997,14 @@ public class CmisSender extends SenderWithParametersBase implements HasKeystore,
 	}
 
 	/**
-	 * (Only used when <code>action</code>=<code>create</code>). If true, the document is created in the root folder of the repository. Otherwise the document is created in the repository
+	 * (Only used when <code>action=create</code>). If true, the document is created in the root folder of the repository. Otherwise the document is created in the repository
 	 * @ff.default true
 	 */
 	public void setUseRootFolder(boolean b) {
 		useRootFolder = b;
 	}
 
-	/** (Only used when <code>action</code>=<code>get</code>) result returned when no document was found for the given id (e.g. '[not_found]'). If empty then 'notFound' is returned as forward name */
+	/** (Only used when <code>action=get</code>) result returned when no document was found for the given id (e.g. '[not_found]'). If empty then 'notFound' is returned as forward name */
 	@Deprecated(forRemoval = true, since = "7.9.0")
 	@ConfigurationWarning("configure forward 'notFound' instead")
 	public void setResultOnNotFound(String string) {

--- a/commons/src/main/java/org/frankframework/functional/FunctionalUtil.java
+++ b/commons/src/main/java/org/frankframework/functional/FunctionalUtil.java
@@ -30,9 +30,9 @@ public class FunctionalUtil {
 	 *     to a function that takes a number of {@link Object} parameters, such as Log4J log methods (in particular the
 	 *     methods where an exception is passed as last argument).
 	 *     For example:
-	 *     <code>
+	 *     <pre>{@code
 	 *         log.error("{} Error with message id [{}]", supplier(this::getLogPrefix), supply(messageId), e);
-	 *     </code>
+	 *     }</pre>
 	 * </p>
 	 *
 	 * @param value Value to be supplied. NB: This should be a constant, otherwise its value is instantly
@@ -51,11 +51,11 @@ public class FunctionalUtil {
 	 *     when an array of mixed arguments should be passed all as type {@link org.apache.logging.log4j.util.Supplier}
 	 *     to a logger method (in particular the methods where an exception is passed as last argument).
 	 *     For example:
-	 *     <code>
+	 *     <pre>{@code
 	 *         String messageId = null;
 	 *         if (true) messageId = "msg id";
 	 *         log.error("{} Error with message id [{}]", supplier(this::getLogPrefix), logValue(messageId), e);
-	 *     </code>
+	 *     }</pre>
 	 * </p>
 	 *
 	 * @param value Value to be supplied. NB: This should be a constant, otherwise its value is instantly
@@ -75,9 +75,9 @@ public class FunctionalUtil {
 	 *     when an array of mixed arguments should be passed all as type {@link org.apache.logging.log4j.util.Supplier}
 	 *     to a logger method (in particular the methods where an exception is passed as last argument).
 	 *     For example:
-	 *     <code>
+	 *     <pre>{@code
 	 *         log.error("Error with message id [{}]", logMethod(this::getLogPrefix), logValue(v), e);
-	 *     </code>
+	 *     }</pre>
 	 * </p>
 	 *
 	 * @param method Single-argument Method to be invoked.
@@ -98,18 +98,18 @@ public class FunctionalUtil {
 	 * </p>
 	 * <p>
 	 *     For example:
-	 *     <code>
+	 *     <pre>{@code
 	 *         log.error("{} Error with message id [{}]", supplier(this::getLogPrefix), e);
-	 *     </code>
+	 *     }</pre>
 	 *     This can also be useful when for instance a no-arguments function should be passed to a JUnit arguments
 	 *     supplier for a parameterized unit test:
-	 *     <code>
-	 *	    public static Stream&lt;Arguments&gt; transactionManagers() {
+	 *     <pre>{@code
+	 *	    public static Stream<Arguments> transactionManagers() {
 	 * 		    return Stream.of(
 	 * 			    Arguments.of(supplier(ReceiverTest::buildNarayanaTransactionManager))
 	 * 		    );
 	 *      }
-	 *     </code>
+	 *     }</pre>
 	 * </p>
 	 *
 	 * @param s Supplier lambda or function reference.
@@ -129,13 +129,13 @@ public class FunctionalUtil {
 	 *     methods that take generic object parameters, such as JUnit {@code Arguments.of()}.
 	 * </p>
 	 * <p>For Example:</p>
-	 * <code>
-	 *  public static Stream&lt;Arguments&gt; transactionManagers() {
+	 * <pre>{@code
+	 *  public static Stream<Arguments> transactionManagers() {
 	 * 		return Stream.of(
 	 * 			Arguments.of(function(ReceiverTest::buildNarayanaTransactionManager))
 	 * 		);
 	 *  }
-	 * </code>
+	 * }</pre>
 	 *
 	 * @param f Lambda or function reference that takes a single parameter and returns a value.
 	 * @return Same lambda or function reference but now type verified by the compiler.

--- a/commons/src/main/java/org/frankframework/util/FieldNameSensitiveToStringStyle.java
+++ b/commons/src/main/java/org/frankframework/util/FieldNameSensitiveToStringStyle.java
@@ -39,7 +39,7 @@ class FieldNameSensitiveToStringStyle extends ToStringStyle {
 	}
 
 	/**
-	 * Ensure <code>Singleton</ode> after serialization.
+	 * Ensure <code>Singleton</code> after serialization.
 	 * 
 	 * @return the singleton
 	 */

--- a/commons/src/main/java/org/frankframework/util/PropertyLoader.java
+++ b/commons/src/main/java/org/frankframework/util/PropertyLoader.java
@@ -188,7 +188,7 @@ public class PropertyLoader extends Properties {
 	/**
 	 * Load the contents of a properties file.
 	 * <p>Optionally, this may be a comma-separated list of files to load, e.g.
-	 * <code><pre>log4j2.properties,DeploymentSpecifics.properties</pre></code>
+	 * <code>log4j2.properties,DeploymentSpecifics.properties</code>
 	 * which will cause both files to be loaded in the listed order.
 	 * </p>
 	 */

--- a/commons/src/main/java/org/frankframework/util/StringResolver.java
+++ b/commons/src/main/java/org/frankframework/util/StringResolver.java
@@ -49,12 +49,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -78,12 +79,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -108,12 +110,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -302,12 +305,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -328,12 +332,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -352,12 +357,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -378,12 +384,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.
@@ -406,12 +413,13 @@ public class StringResolver {
 	/**
 	 * Do variable substitution on a string to resolve ${x2} to the value of the
 	 * property x2. This is done recursive, so that <br/>
-	 * <code><pre>
+	 * <pre>{@code
 	 * Properties prop = new Properties();
 	 * prop.put("test.name", "this is a name with ${test.xx}");
 	 * prop.put("test.xx", "again");
 	 * System.out.println(prop.get("test.name"));
-	 * </pre></code> will print <code>this is a name with again</code>
+	 * }</pre>
+	 * will print <code>this is a name with again</code>
 	 * <p>
 	 * First it looks in the System environment and System properties, if none is found
 	 * then all installed {@link AdditionalStringResolver}s are scanned for providing a replacement.

--- a/core/src/main/java/org/frankframework/cache/CacheAdapterBase.java
+++ b/core/src/main/java/org/frankframework/cache/CacheAdapterBase.java
@@ -164,7 +164,7 @@ public abstract class CacheAdapterBase<V> implements ICache<String,V>, IConfigur
 		this.keyXPathOutputType = keyXPathOutputType;
 	}
 
-	/** namespace defintions for keyxpath. must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions */
+	/** namespace defintions for keyxpath. must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code> definitions */
 	public void setKeyNamespaceDefs(String keyNamespaceDefs) {
 		this.keyNamespaceDefs = keyNamespaceDefs;
 	}
@@ -195,7 +195,7 @@ public abstract class CacheAdapterBase<V> implements ICache<String,V>, IConfigur
 		this.valueXPathOutputType = valueXPathOutputType;
 	}
 
-	/** namespace defintions for valuexpath. must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions */
+	/** namespace defintions for valuexpath. must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code> definitions */
 	public void setValueNamespaceDefs(String valueNamespaceDefs) {
 		this.valueNamespaceDefs = valueNamespaceDefs;
 	}

--- a/core/src/main/java/org/frankframework/collection/CollectorSenderBase.java
+++ b/core/src/main/java/org/frankframework/collection/CollectorSenderBase.java
@@ -28,7 +28,7 @@ import org.frankframework.senders.SenderWithParametersBase;
 import org.frankframework.stream.Message;
 
 /**
- * Sender that writes an item to a collection, created by {@link CollectorPipeBase} with action=<code>OPEN</code>.
+ * Sender that writes an item to a collection, created by {@link CollectorPipeBase} with <code>action=OPEN</code>.
  *
  * @ff.parameters all parameters are handled by the collection.
  *

--- a/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
+++ b/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
@@ -41,8 +41,8 @@ import org.frankframework.util.TemporaryDirectoryUtils;
  * Action <code>CLOSE</code> will generate the ZIP archive which is returned as the pipe ouput.
  * </p>
  *
- * @ff.parameter filename only for action=<code>WRITE</code>: the filename of the zip-entry
- * @ff.parameter contents only for action=<code>WRITE</code>: contents of the zip-entry, If not specified, the input is used.
+ * @ff.parameter filename only for <code>action=WRITE</code>: the filename of the zip-entry
+ * @ff.parameter contents only for <code>action=WRITE</code>: contents of the zip-entry, If not specified, the input is used.
  *
  * @author Gerrit van Brakel
  * @author Niels Meijer

--- a/core/src/main/java/org/frankframework/configuration/ConfigurationDigester.java
+++ b/core/src/main/java/org/frankframework/configuration/ConfigurationDigester.java
@@ -79,19 +79,19 @@ import lombok.extern.log4j.Log4j2;
  * means that you may specify entities that will be resolved during parsing.
  * </p>
  * Example:
- * <code><pre>
-&lt;?xml version="1.0"?&gt;
-&lt;!DOCTYPE configuration
-[
-&lt;!ENTITY HelloWorld SYSTEM "./ConfigurationHelloWorld.xml"&gt;
-]&gt;
-
-&lt;configuration name="HelloWorld"&gt;
-
-&HelloWorld;
-
-&lt;/configuration&gt;
-</pre></code>
+ * <pre>{@code
+ * <?xml version="1.0"?>
+ * <!DOCTYPE configuration
+ * [
+ * <!ENTITY HelloWorld SYSTEM "./ConfigurationHelloWorld.xml">
+ * ]>
+ *
+ * <configuration name="HelloWorld">
+ *
+ * &HelloWorld;
+ *
+ * </configuration>
+ * }</pre>
  * @author Johan Verrips
  * @see Configuration
  */

--- a/core/src/main/java/org/frankframework/configuration/classloaders/ClassLoaderBase.java
+++ b/core/src/main/java/org/frankframework/configuration/classloaders/ClassLoaderBase.java
@@ -189,7 +189,7 @@ public abstract class ClassLoaderBase extends ClassLoader implements IConfigurat
 
 	/**
 	 * @param name of the file to search for in the current local classpath
-	 * @return the URL of the file if found in the ClassLoader or <code>NULL</code> when the file cannot be found
+	 * @return the URL of the file if found in the ClassLoader or <code>null</code> when the file cannot be found
 	 */
 	public abstract URL getLocalResource(String name);
 
@@ -197,7 +197,7 @@ public abstract class ClassLoaderBase extends ClassLoader implements IConfigurat
 	 * In case of the {@link #getResources(String)} we only want the local paths and not the parent path
 	 * @param name of the file to retrieve
 	 * @param useParent only use local classpath or also traverse down the classpath
-	 * @return the URL of the file if found in the ClassLoader or <code>NULL</code>
+	 * @return the URL of the file if found in the ClassLoader or <code>null</code>
 	 */
 	public URL getResource(String name, boolean useParent) {
 		URL url = null;
@@ -276,9 +276,9 @@ public abstract class ClassLoaderBase extends ClassLoader implements IConfigurat
 	/**
 	 * <p>
 	 * Fixes <code>--add-opens=java.base/java.lang=ALL-UNNAMED</code> problem when loading classes dynamically when CGLIB is enabled.
-	 * See https://github.com/spring-projects/spring-framework/issues/26403 for more background information.
+	 * See <a href="https://github.com/spring-projects/spring-framework/issues/26403">spring github</a> for more background information.
 	 * </p>
-	 * 
+	 *
 	 * {@inheritDoc}
 	 */
 	@Override

--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -990,7 +990,7 @@ public class Adapter implements IManagable, HasStatistics, NamedBean {
 
 	/**
 	 * Defines behaviour for logging messages. Configuration is done in the MSG appender in log4j4ibis.properties.
-	 * @ff.default <code>INFO, unless overridden by property msg.log.level.default</code>
+	 * @ff.default <code>INFO</code>, unless overridden by property <code>msg.log.level.default</code>
 	 */
 	public void setMsgLogLevel(MessageLogLevel level) {
 		msgLogLevel = level.getEffectiveLevel();

--- a/core/src/main/java/org/frankframework/core/HasPhysicalDestination.java
+++ b/core/src/main/java/org/frankframework/core/HasPhysicalDestination.java
@@ -16,7 +16,7 @@
 package org.frankframework.core;
 
 /**
- * The <code>HasPhysicalDestination</code> allows objects to declare that they have a physical destination.
+ * Allows objects to declare that they have a physical destination.
  * This is used for instance in ShowConfiguration, to show the physical destination of receivers
  * that have one.
  *

--- a/core/src/main/java/org/frankframework/core/HasSender.java
+++ b/core/src/main/java/org/frankframework/core/HasSender.java
@@ -16,7 +16,7 @@
 package org.frankframework.core;
 
 /**
- * The <code>HasSender</code> is allows objects to declare that they have a Sender.
+ * Allows objects to declare that they have a Sender.
  * This is used for instance in ShowConfiguration, to show the Senders of receivers
  * that have one
  *

--- a/core/src/main/java/org/frankframework/core/ISender.java
+++ b/core/src/main/java/org/frankframework/core/ISender.java
@@ -25,8 +25,7 @@ import org.frankframework.doc.FrankDocGroupValue;
 import org.frankframework.stream.Message;
 
 /**
- * The <code>ISender</code> is responsible for sending a message to
- * some destination.
+ * Marks an implementation as responsible for sending a message to some destination.
  *
  * @author  Gerrit van Brakel
  */

--- a/core/src/main/java/org/frankframework/core/ISenderWithParameters.java
+++ b/core/src/main/java/org/frankframework/core/ISenderWithParameters.java
@@ -18,7 +18,7 @@ package org.frankframework.core;
 import org.frankframework.parameters.Parameter;
 
 /**
- * The <code>ISenderWithParameters</code> allows Senders to declare that they accept and may use {@link Parameter parameters}
+ * Allows Senders to declare that they accept and may use {@link Parameter parameters}
  *
  * @author  Gerrit van Brakel
  */

--- a/core/src/main/java/org/frankframework/core/ITransactionalStorage.java
+++ b/core/src/main/java/org/frankframework/core/ITransactionalStorage.java
@@ -26,8 +26,8 @@ import org.frankframework.receivers.RawMessageWrapper;
 import org.frankframework.receivers.Receiver;
 
 /**
- * The <code>ITransactionalStorage</code> is responsible for storing and
- * retrieving-back messages under transaction control.
+ * Marks an implementation as responsible for storing and retrieving-back messages under transaction control.
+ *
  * @see Receiver
  * @author  Gerrit van Brakel
  * @since   4.1

--- a/core/src/main/java/org/frankframework/core/PipeLineExits.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineExits.java
@@ -26,18 +26,20 @@ import lombok.Getter;
  * <br/><br/>
  * If no exits are specified, a default one is created with name="READY" and state="SUCCESS".
  * <br/><br/>
- * <b>example:</b> <code><pre>
- *   &lt;Exits&gt;
- *      &lt;Exit name="{@value PipeLine#DEFAULT_SUCCESS_EXIT_NAME}" state="{@value PipeLine.ExitState#SUCCESS_EXIT_STATE}" /&gt;
- *      &lt;Exit name="Created" state="ERROR" code="201" empty="true" /&gt;
- *      &lt;Exit name="NotModified" state="ERROR" code="304" empty="true" /&gt;
- *      &lt;Exit name="BadRequest" state="ERROR" code="400" empty="true" /&gt;
- *      &lt;Exit name="NotAuthorized" state="ERROR" code="401" empty="true" /&gt;
- *      &lt;Exit name="NotAllowed" state="ERROR" code="403" empty="true" /&gt;
- *      &lt;Exit name="Teapot" state="SUCCESS" code="418" /&gt;
- *      &lt;Exit name="ServerError" state="ERROR" code="500" /&gt;
- *   &lt;/Exits&gt;
- * </pre></code>
+ * <b>example:</b>
+ * <pre>{@code
+ * <Exits>
+ *    <Exit name="{@value PipeLine#DEFAULT_SUCCESS_EXIT_NAME}" state="{@value PipeLine.ExitState#SUCCESS_EXIT_STATE}" />
+ *    <Exit name="Created" state="ERROR" code="201" empty="true" />
+ *    <Exit name="NotModified" state="ERROR" code="304" empty="true" />
+ *    <Exit name="BadRequest" state="ERROR" code="400" empty="true" />
+ *    <Exit name="NotAuthorized" state="ERROR" code="401" empty="true" />
+ *    <Exit name="NotAllowed" state="ERROR" code="403" empty="true" />
+ *    <Exit name="Teapot" state="SUCCESS" code="418" />
+ *    <Exit name="ServerError" state="ERROR" code="500" />
+ * </Exits>
+ * }</pre>
+ *
  */
 public class PipeLineExits {
 

--- a/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
+++ b/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
@@ -36,23 +36,21 @@ import org.frankframework.util.XmlBuilder;
 import org.frankframework.util.XmlEncodingUtils;
 
 /**
- * This <code>ErrorMessageFormatter</code> wraps an error in an XML string.
- *
- * <br/>
+ * This class wraps an error in an XML string.
+ * <p>
  * Sample xml:
- * <br/>
- * <code><pre>
- * &lt;errorMessage&gt;
- *    &lt;message timestamp="Mon Oct 13 12:01:57 CEST 2003"
- *             originator="NN IOS AdapterFramework(set from 'application.name' and 'application.version')"
- *             message="<i>message describing the error that occurred</i>" &gt;
- *    &lt;location class="org.frankframework.pipes.XmlSwitch" name="ServiceSwitch"/&gt
- *    &lt;details&gt<i>detailed information of the error</i>&lt;/details&gt
- *    &lt;originalMessage messageId="..." receivedTime="Mon Oct 27 12:10:18 CET 2003" &gt;
- *        &lt;![CDATA[<i>contents of message for which the error occurred</i>]]&gt;
- *    &lt;/originalMessage&gt;
- * &lt;/errorMessage&gt;
- * </pre></code>
+ * <pre>{@code
+ * <errorMessage>
+ *    <message timestamp="Mon Oct 13 12:01:57 CEST 2003"
+ *             originator="NN IOS AdapterFramework(set from 'application. name' and 'application. version')"
+ *             message="message describing the error that occurred">
+ *    <location class="org. frankframework. pipes. XmlSwitch" name="ServiceSwitch"/>
+ *    <details>detailed information of the error</details>
+ *    <originalMessage messageId="..." receivedTime="Mon Oct 27 12:10:18 CET 2003" >
+ *        <![CDATA[contents of message for which the error occurred]]>
+ *    </originalMessage>
+ * </errorMessage>
+ * }</pre>
  *
  * @author  Gerrit van Brakel
  */

--- a/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
+++ b/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
@@ -42,9 +42,9 @@ import org.frankframework.util.XmlEncodingUtils;
  * <pre>{@code
  * <errorMessage>
  *    <message timestamp="Mon Oct 13 12:01:57 CEST 2003"
- *             originator="NN IOS AdapterFramework(set from 'application. name' and 'application. version')"
+ *             originator="NN IOS AdapterFramework(set from 'application.name' and 'application.version')"
  *             message="message describing the error that occurred">
- *    <location class="org. frankframework. pipes. XmlSwitch" name="ServiceSwitch"/>
+ *    <location class="org.frankframework.pipes.XmlSwitch" name="ServiceSwitch"/>
  *    <details>detailed information of the error</details>
  *    <originalMessage messageId="..." receivedTime="Mon Oct 27 12:10:18 CET 2003" >
  *        <![CDATA[contents of message for which the error occurred]]>

--- a/core/src/main/java/org/frankframework/http/HttpSender.java
+++ b/core/src/main/java/org/frankframework/http/HttpSender.java
@@ -516,13 +516,13 @@ public class HttpSender extends HttpSenderBase {
 		paramsInUrl = b;
 	}
 
-	/** (Only used when <code>methodType</code>=<code>POST</code> and <code>postType</code>=<code>URLENCODED</code>, <code>FORM-DATA</code> or <code>MTOM</code>) Prepends a new BodyPart using the specified name and uses the input of the Sender as content */
+	/** (Only used when <code>methodType=POST</code> and <code>postType=URLENCODED</code>, <code>FORM-DATA</code> or <code>MTOM</code>) Prepends a new BodyPart using the specified name and uses the input of the Sender as content */
 	public void setFirstBodyPartName(String firstBodyPartName) {
 		this.firstBodyPartName = firstBodyPartName;
 	}
 
 	/**
-	 * If set and <code>methodType</code>=<code>POST</code> and <code>paramsInUrl</code>=<code>false</code>, a multipart/form-data entity is created instead of a request body.
+	 * If set and <code>methodType=POST</code> and <code>paramsInUrl=false</code>, a multipart/form-data entity is created instead of a request body.
 	 * For each part element in the session key a part in the multipart entity is created. Part elements can contain the following attributes:
 	 * <ul>
 	 * <li>name: optional, used as 'filename' in Content-Disposition</li>
@@ -548,7 +548,8 @@ public class HttpSender extends HttpSenderBase {
 	}
 
 	/**
-	 * If <code>true</code>, the input will be added to the URL for <code>methodType</code>=<code>GET</code>, or for <code>methodType</code>=<code>POST</code>, <code>PUT</code> or <code>PATCH</code> if <code>postType</code>=<code>RAW</code>. This used to be the default behaviour in framework version 7.7 and earlier
+	 * If <code>true</code>, the input will be added to the URL for <code>methodType=GET</code>, or for <code>methodType=POST</code>, <code>PUT</code> or
+	 * <code>PATCH</code> if <code>postType=RAW</code>. This used to be the default behaviour in framework version 7.7 and earlier
 	 * @ff.default for methodType=<code>GET</code>: <code>false</code>,<br/>for methodTypes <code>POST</code>, <code>PUT</code>, <code>PATCH</code>: <code>true</code>
 	 */
 	public void setTreatInputMessageAsParameters(Boolean b) {

--- a/core/src/main/java/org/frankframework/http/HttpSessionBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSessionBase.java
@@ -111,7 +111,7 @@ import org.springframework.util.Assert;
  * </p>
  * <p>
  * Note 3:
- * In case <code>javax.net.ssl.SSLHandshakeException: unknown certificate</code>-exceptions are thrown,
+ * In case <code>javax.net.ssl.SSLHandshakeException: unknown certificate</code> exceptions are thrown,
  * probably the certificate of the other party is not trusted. Try to use one of the certificates in the path as your truststore by doing the following:
  * <ul>
  *   <li>open the URL you are trying to reach in InternetExplorer</li>
@@ -135,7 +135,7 @@ import org.springframework.util.Assert;
  * </ul>
  * <p>
  * Note 4:
- * In case <code>cannot create or initialize SocketFactory: (IOException) Unable to verify MAC</code>-exceptions are thrown,
+ * In case <code>cannot create or initialize SocketFactory: (IOException) Unable to verify MAC</code> exceptions are thrown,
  * please check password or authAlias configuration of the corresponding certificate.
  * </p>
  *
@@ -783,7 +783,7 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	}
 
 	/**
-	 * Used when StaleChecking=<code>true</code>. Timeout after which an idle connection will be validated before being used.
+	 * Used when <code>staleChecking</code>> is <code>true</code>. Timeout after which an idle connection will be validated before being used.
 	 * @ff.default 5000 ms
 	 */
 	public void setStaleTimeout(int timeout) {

--- a/core/src/main/java/org/frankframework/http/HttpSessionBase.java
+++ b/core/src/main/java/org/frankframework/http/HttpSessionBase.java
@@ -783,7 +783,7 @@ public abstract class HttpSessionBase implements ConfigurableLifecycle, HasKeyst
 	}
 
 	/**
-	 * Used when <code>staleChecking</code>> is <code>true</code>. Timeout after which an idle connection will be validated before being used.
+	 * Used when <code>staleChecking</code> is <code>true</code>. Timeout after which an idle connection will be validated before being used.
 	 * @ff.default 5000 ms
 	 */
 	public void setStaleTimeout(int timeout) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -302,7 +302,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	}
 
 	/**
-	 * The required contentType on requests, if it doesn't match a <code>415 Unsupported Media Type</code> is replied.
+	 * The required contentType on requests, if it doesn't match a <code>415</code> status (Unsupported Media Type) is returned.
 	 *
 	 * @ff.default ANY
 	 */

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -37,25 +37,21 @@ import org.frankframework.stream.Message;
 import org.frankframework.util.StringUtil;
 
 /**
- * Read messages from the IBISSTORE database table previously stored by a
- * {@link MessageStoreSender}.
- *
+ * Read messages from the IBISSTORE database table previously stored by a {@link MessageStoreSender}.
+ * <p>
  * Example configuration:
- * <code><pre>
-	&lt;Receiver
-		name="03 MessageStoreReceiver"
-		numThreads="4"
-		transactionAttribute="Required"
-		pollInterval="1"
-		&gt;
-		&lt;MessageStoreListener
-			name="03 MessageStoreListener"
-			slotId="${instance.name}/TestMessageStore"
-			statusValueInProcess="I"
-		/&gt;
-	&lt;/Receiver&gt;
-
- * </pre></code>
+ * <pre>{@code
+ * 	<Receiver
+ * 		name="03 MessageStoreReceiver"
+ * 		numThreads="4"
+ * 		transactionAttribute="Required"
+ * 		pollInterval="1">
+ * 		<MessageStoreListener
+ * 			name="03 MessageStoreListener"
+ * 			slotId="${instance. name}/ TestMessageStore"
+ * 			statusValueInProcess="I" />
+ * 	</Receiver>
+ * }</pre>
  *
  * If you have a <code>MessageStoreListener</code>, failed messages are automatically kept in database
  * table IBISSTORE. Messages are also kept after successful processing. The state of a message

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -48,7 +48,7 @@ import org.frankframework.util.StringUtil;
  * 		pollInterval="1">
  * 		<MessageStoreListener
  * 			name="03 MessageStoreListener"
- * 			slotId="${instance. name}/ TestMessageStore"
+ * 			slotId="${instance.name}/TestMessageStore"
  * 			statusValueInProcess="I" />
  * 	</Receiver>
  * }</pre>

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
@@ -59,7 +59,7 @@ import org.frankframework.util.StringUtil;
  * <pre>{@code
  * <SenderPipe name="Send">
  *     <MessageStoreSender
- * 	     slotId="${instance. name}/ TestMessageStore"
+ * 	     slotId="${instance.name}/TestMessageStore"
  * 		 onlyStoreWhenMessageIdUnique="false" />
  * </SenderPipe>
  * }</pre>

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
@@ -56,14 +56,13 @@ import org.frankframework.util.StringUtil;
  * to the adapter around the sender pipe, because errors may occur before the message reaches the sender pipe.
  * <br/><br/>
  * Example configuration:
- * <code><pre>
-	&lt;SenderPipe name="Send"&gt;
-		&lt;MessageStoreSender
-			slotId="${instance.name}/TestMessageStore"
-			onlyStoreWhenMessageIdUnique="false"
-		/&gt;
-	&lt;/SenderPipe&gt;
-</pre></code>
+ * <pre>{@code
+ * <SenderPipe name="Send">
+ *     <MessageStoreSender
+ * 	     slotId="${instance. name}/ TestMessageStore"
+ * 		 onlyStoreWhenMessageIdUnique="false" />
+ * </SenderPipe>
+ * }</pre>
  *
  * @ff.parameter messageId messageId to check for duplicates, when this parameter isn't present the messageId is read from sessionKey messageId
  *

--- a/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
@@ -74,72 +74,72 @@ import jakarta.jms.JMSException;
  * <p>
  *	<h3>Sample Output for queryType=OTHER</h3>
  *	<h4>Basic Example with Only Simple Output Parameters</h4>
- *  <code><pre>
-	&lt;resultset&gt;
-		&lt;result param="r1" type="STRING"&gt;MESSAGE-CONTENTS&lt;/result&gt;
-		&lt;result param="r2" type="STRING"&gt;E&lt;/result&gt;
-	&lt;/resultset&gt;
- *  </pre></code>
+ * <pre>{@code
+ * <resultset>
+ * 	   <result param="r1" type="STRING">MESSAGE-CONTENTS</result>
+ *     <result param="r2" type="STRING">E</result>
+ * </resultset>
+ * }</pre>
  *
  *	<h4>Example with Resultset and Simple Output Parameters</h4>
- *  <code><pre>
-	 &lt;resultset&gt;
-		 &lt;result resultNr="1"&gt;
-			 &lt;fielddefinition&gt;
-				&lt;field name="FIELDNAME"
-						  type="columnType"
-						  columnDisplaySize=""
-						  precision=""
-						  scale=""
-						  isCurrency=""
-						  columnTypeName=""
-						  columnClassName=""/&gt;
-				 &lt;field ...../&gt;
- 		     &lt;/fielddefinition&gt;
-			 &lt;rowset&gt;
-				 &lt;row number="0"&gt;
-					 &lt;field name="TKEY"&gt;MSG-ID&lt;/field&gt;
-					 &lt;field name="TCHAR"&gt;E&lt;/field&gt;
-					 &lt;field name="TMESSAGE"&gt;MESSAGE-CONTENTS&lt;/field&gt;
-					 &lt;field name="TCLOB" null="true"/&gt;
-					 &lt;field name="TBLOB" null="true"/&gt;
-				 &lt;/row&gt;
-                 &lt;row number="1" ...../&gt;
-			 &lt;/rowset&gt;
-		 &lt;/result&gt;
-		 &lt;result param="count" type="INTEGER"&gt;5&lt;/result&gt;
-	 &lt;/resultset&gt;
- *  </pre></code>
+ * <pre>{@code
+ * <resultset>
+ * 		 <result resultNr="1">
+ * 			 <fielddefinition>
+ * 				<field name="FIELDNAME"
+ * 						  type="columnType"
+ * 						  columnDisplaySize=""
+ * 						  precision=""
+ * 						  scale=""
+ * 						  isCurrency=""
+ * 						  columnTypeName=""
+ * 						  columnClassName=""/>
+ * 				 <field ...../>
+*  		     </fielddefinition>
+ * 			 <rowset>
+ * 				 <row number="0">
+ * 					 <field name="TKEY">MSG-ID</field>
+ * 					 <field name="TCHAR">E</field>
+ * 					 <field name="TMESSAGE">MESSAGE-CONTENTS</field>
+ * 					 <field name="TCLOB" null="true"/>
+ * 					 <field name="TBLOB" null="true"/>
+ * 				 </row>
+ *                  <row number="1" ...../>
+ * 			 </rowset>
+ * 		 </result>
+ * 		 <result param="count" type="INTEGER">5</result>
+ * </resultset>
+ * }</pre>
  *
  *	<h4>Example with Simple and Cursor Output Parameters</h4>
- *	<code><pre>
-	&lt;resultset&gt;
-		&lt;result param="count" type="INTEGER"&gt;5&lt;/result&gt;
-		&lt;result param="cursor1" type="LIST"&gt;
-			 &lt;fielddefinition&gt;
-				&lt;field name="FIELDNAME"
-						  type="columnType"
-						  columnDisplaySize=""
-						  precision=""
-						  scale=""
-						  isCurrency=""
-						  columnTypeName=""
-						  columnClassName=""/&gt;
-				 &lt;field ...../&gt;
- 		     &lt;/fielddefinition&gt;
-			&lt;rowset&gt;
-				&lt;row number="0"&gt;
-					&lt;field name="TKEY"&gt;MSG-ID&lt;/field&gt;
-					&lt;field name="TCHAR"&gt;E&lt;/field&gt;
-					&lt;field name="TMESSAGE"&gt;MESSAGE-CONTENTS&lt;/field&gt;
-					&lt;field name="TCLOB" null="true"/&gt;
-					&lt;field name="TBLOB" null="true"/&gt;
-				&lt;/row&gt;
-				&lt;row number="1" ..... /&gt;
-			&lt;/rowset&gt;
-		&lt;/result&gt;
-	&lt;/resultset&gt;
- *	</pre></code>
+ * <pre>{@code
+ * <resultset>
+ * 		<result param="count" type="INTEGER">5</result>
+ * 		<result param="cursor1" type="LIST">
+ * 			 <fielddefinition>
+ * 				<field name="FIELDNAME"
+ * 						  type="columnType"
+ * 						  columnDisplaySize=""
+ * 						  precision=""
+ * 						  scale=""
+ * 						  isCurrency=""
+ * 						  columnTypeName=""
+ * 						  columnClassName=""/>
+ * 				 <field ...../>
+ *  		</fielddefinition>
+ * 			<rowset>
+ * 				<row number="0">
+ * 					<field name="TKEY">MSG-ID</field>
+ * 					<field name="TCHAR">E</field>
+ * 					<field name="TMESSAGE">MESSAGE-CONTENTS</field>
+ * 					<field name="TCLOB" null="true"/>
+ * 					<field name="TBLOB" null="true"/>
+ * 				</row>
+ * 				<row number="1" ..... />
+ * 			</rowset>
+ * 		</result>
+ * 	</resultset>
+ * }</pre>
  * </p>
  * <p><em>NOTE:</em> Support for stored procedures is currently experimental and changes in the currently produced output-format
  * are expected.</p>

--- a/core/src/main/java/org/frankframework/jdbc/XmlQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/XmlQuerySender.java
@@ -49,7 +49,8 @@ import org.w3c.dom.Node;
 
 /**
  * QuerySender that transforms the input message to a query.
- * <br/><code><pre>
+ * <br/>
+ * <pre>{@code
  *  select
  *  delete
  *  insert
@@ -62,14 +63,15 @@ import org.w3c.dom.Node;
  *                                          - formatString [0..1] only applicable for type=datetime, yyyy-MM-dd HH:mm:ss.SSS by default
  *         - where [0..1]
  *         - order [0..1]
- * <br/>
+ *
  *  alter - sequenceName
  *        - startWith
- * <br/>
+ *
  *  sql   - type [0..1] one of {select;ddl;other}, other by default
  *        - query
+ *
+ * }</pre>
  * <br/>
- * </pre></code><br/>
  *
  * @author  Peter Leeuwenburgh
  */

--- a/core/src/main/java/org/frankframework/jms/JmsListenerBase.java
+++ b/core/src/main/java/org/frankframework/jms/JmsListenerBase.java
@@ -432,7 +432,7 @@ public abstract class JmsListenerBase extends JMSFacade implements HasSender, IW
 	}
 
 	/**
-	 * Name of the JMS destination (queue or topic) to use for sending replies. If <code>useReplyTo</code>=<code>true</code>,
+	 * Name of the JMS destination (queue or topic) to use for sending replies. If <code>useReplyTo=true</code>,
 	 * the sender specified reply destination takes precedence over this one.
 	 */
 	public void setReplyDestinationName(String destinationName) {

--- a/core/src/main/java/org/frankframework/jms/JmsSender.java
+++ b/core/src/main/java/org/frankframework/jms/JmsSender.java
@@ -365,7 +365,8 @@ public class JmsSender extends JMSFacade implements ISenderWithParameters {
 	}
 
 	/**
-	 * (Only used when <code>synchronous</code>=<code>true</code> and <code>replyToName</code> is set). Indicates whether the server uses the correlationId from the pipeline, the correlationId from the message or the messageId in the correlationId field of the reply. This requires the sender to have set the correlationId at the time of sending.
+	 * (Only used when <code>synchronous=true</code> and <code>replyToName</code> is set). Indicates whether the server uses the correlationId from the pipeline,
+	 * the correlationId from the message or the messageId in the correlationId field of the reply. This requires the sender to have set the correlationId at the time of sending.
 	 * @ff.default MESSAGEID
 	 */
 	public void setLinkMethod(LinkMethod method) {
@@ -373,7 +374,7 @@ public class JmsSender extends JMSFacade implements ISenderWithParameters {
 	}
 
 	/**
-	 * (Only for <code>synchronous</code>=<code>true</code>). Maximum time in ms to wait for a reply. 0 means no timeout.
+	 * (Only for <code>synchronous=true</code>). Maximum time in ms to wait for a reply. 0 means no timeout.
 	 * @ff.default 5000
 	 */
 	public void setReplyTimeout(int i) {

--- a/core/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
+++ b/core/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
@@ -41,52 +41,43 @@ import org.w3c.dom.Element;
  * </p>
  * <p>
  * <b>example (input):</b>
- * <code>
- * <pre>
- *   &lt;browse&gt;
- *      &lt;jmsRealm&gt;qcf&lt;/jmsRealm&gt;
- *      &lt;destinationName&gt;jms/GetPolicyDetailsRequest&lt;/destinationName&gt;
- *      &lt;destinationType&gt;QUEUE&lt;/destinationType&gt;
- *   &lt;/browse>
- * </pre>
- * </code>
+ * <pre>{@code
+ * <browse>
+ *    <jmsRealm>qcf</jmsRealm>
+ *    <destinationName>jms/ GetPolicyDetailsRequest</destinationName>
+ *    <destinationType>QUEUE</destinationType>
+ * </browse>
+ * }</pre>
  * </p>
- *
- *
  * <p>
  * <b>example (browse output):</b>
- * <code>
- * <pre>
- *   &lt;result&gt;
- *	    &lt;items count="2"&gt;
- *	       &lt;item&gt;
- *	          &lt;timestamp&gt;Thu Nov 20 13:36:31 CET 2014&lt;/timestamp&gt;
- *	          &lt;messageId&gt;ID:LPAB00000003980-61959-1416486781822-3:5:33:1:1&lt;/messageId&gt;
- *	          &lt;correlationId&gt;...&lt;/correlationId&gt;
- *	          &lt;message&gt;&lt;![CDATA[...]]&gt;&lt;/message&gt;
- *	       &lt;/item&gt;
- *	       &lt;item&gt;
- *	          &lt;timestamp&gt;Thu Dec 12 11:59:22 CET 2014&lt;/timestamp&gt;
- *	          &lt;messageId&gt;ID:LPAB00000003980-58359-1721486799722-3:4:19:1:1&lt;/messageId&gt;
- *	          &lt;correlationId&gt;...&lt;/correlationId&gt;
- *	          &lt;message&gt;&lt;![CDATA[...]]&gt;&lt;/message&gt;
- *	       &lt;/item&gt;
- *	    &lt;/items&gt;
- *   &lt;/result&gt;
- * </pre>
- * </code>
+ * <pre>{@code
+ * <result>
+ *   <items count="2">
+ *      <item>
+ *         <timestamp>Thu Nov 20 13:36:31 CET 2014</timestamp>
+ *         <messageId>ID:LPAB00000003980-61959-1416486781822-3:5:33:1:1</messageId>
+ *         <correlationId>...</correlationId>
+ *         <message><![CDATA[...]]></message>
+ *      </item>
+ *      <item>
+ *         <timestamp>Thu Dec 12 11:59:22 CET 2014</timestamp>
+ *         <messageId>ID:LPAB00000003980-58359-1721486799722-3:4:19:1:1</messageId>
+ *         <correlationId>...</correlationId>
+ *         <message><![CDATA[...]]></message>
+ *      </item>
+ * 	 </items>
+ * </result>
+ * }</pre>
  * </p>
  *
  * <p>
  * <b>example (remove output):</b>
- * <code>
- * <pre>
- *   &lt;result&gt;
- *	    &lt;itemsRemoved&gt;2&lt;/itemsRemoved&gt;
- *   &lt;/result&gt;
- * </pre>
- * </code>
- * </p>
+ * <pre>{@code
+ * <result>
+ *     <itemsRemoved>2</itemsRemoved>
+ * </result>
+ * }</pre>
  *
  * @author  Peter Leeuwenburgh
  */

--- a/core/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
+++ b/core/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
@@ -44,7 +44,7 @@ import org.w3c.dom.Element;
  * <pre>{@code
  * <browse>
  *    <jmsRealm>qcf</jmsRealm>
- *    <destinationName>jms/ GetPolicyDetailsRequest</destinationName>
+ *    <destinationName>jms/GetPolicyDetailsRequest</destinationName>
  *    <destinationType>QUEUE</destinationType>
  * </browse>
  * }</pre>

--- a/core/src/main/java/org/frankframework/ldap/LdapSender.java
+++ b/core/src/main/java/org/frankframework/ldap/LdapSender.java
@@ -65,40 +65,36 @@ import org.frankframework.util.XmlEncodingUtils;
  *
  * <h2>example</h2>
  * Consider the following configuration example:
- * <code>
- * <pre>
- *   &lt;sender
- *        className="org.frankframework.ldap.LdapSender"
- *        ldapProviderURL="ldap://servername:389/o=ing"
- *        operation="read"
- *        attributesToReturn="givenName,sn,telephoneNumber" &gt;
- *     &lt;param name="entryName" xpathExpression="entryName" /&gt;
- *   &lt;/sender&gt;
- * </pre>
- * </code>
+ * <pre>{@code
+ * <sender
+ *      className="org.frankframework.ldap.LdapSender"
+ *      ldapProviderURL="ldap://servername:389/o=ing"
+ *      operation="read"
+ *      attributesToReturn="givenName,sn,telephoneNumber" >
+ *     <param name="entryName" xpathExpression="entryName" />
+ * </sender>
+ * }</pre>
  * <br/>
  *
  * This may result in the following output:
- * <code><pre>
- * &lt;ldap&gt;
- *	&lt;entryName&gt;uid=srp,ou=people&lt;/entryName&gt;
- *
- *	&lt;attributes&gt;
- *		&lt;attribute attrID="givenName"&gt;
- *			&lt;value&gt;Jan&lt;/value&gt;
- *		&lt;/attribute&gt;
- *
- *		&lt;attribute attrID="telephoneNumber"&gt;
- *			&lt;value&gt;010 5131123&lt;/value&gt;
- *			&lt;value&gt;06 23456064&lt;/value&gt;
- *		&lt;/attribute&gt;
- *
- *		&lt;attribute attrID="sn"&gt;
- *			&lt;value&gt;Jansen&lt;/value&gt;
- *		&lt;/attribute&gt;
- *	&lt;/attributes&gt;
- * &lt;/ldap&gt;
- *  </pre></code> <br/>
+ * <pre>{@code
+ * <ldap>
+ * 	   <entryName>uid=srp,ou=people</entryName>
+ * 	   <attributes>
+ *         <attribute attrID="givenName">
+ *             <value>Jan</value>
+ *         </attribute>
+ *         <attribute attrID="telephoneNumber">
+ *             <value>010 5131123</value>
+ *             <value>06 23456064</value>
+ *         </attribute>
+ * 	       <attribute attrID="sn">
+ *             <value>Jansen</value>
+ * 	       </attribute>
+ * 	   </attributes>
+ * </ldap>
+ * }</pre>
+ * <br/>
  *
  * Search or Read?
  *
@@ -108,41 +104,44 @@ import org.frankframework.util.XmlEncodingUtils;
  * together with the attributes. If the specified attributes are null or empty all the attributes of all the entries within the
  * specified context are returned.
  *
- * Sample result of a <code>read</code> operation:<br/><code><pre>
- *	&lt;attributes&gt;
- *	    &lt;attribute&gt;
- *	    &lt;attribute name="employeeType" value="Extern"/&gt;
- *	    &lt;attribute name="roomNumber" value="DP 2.13.025"/&gt;
- *	    &lt;attribute name="departmentCode" value="358000"/&gt;
- *	    &lt;attribute name="organizationalHierarchy"&gt;
- *	        &lt;item value="ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	        &lt;item value="ou=OPS&amp;IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	        &lt;item value="ou=000001,ou=OPS&amp;IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	    &lt;/attribute>
- *	    &lt;attribute name="givenName" value="Gerrit"/>
- *	&lt;/attributes&gt;
- *
- * </pre></code> <br/>
- * Sample result of a <code>search</code> operation:<br/><code><pre>
- *	&lt;entries&gt;
- *	 &lt;entry name="uid=srp"&gt;
- *	   &lt;attributes&gt;
- *	    &lt;attribute&gt;
- *	    &lt;attribute name="employeeType" value="Extern"/&gt;
- *	    &lt;attribute name="roomNumber" value="DP 2.13.025"/&gt;
- *	    &lt;attribute name="departmentCode" value="358000"/&gt;
- *	    &lt;attribute name="organizationalHierarchy"&gt;
- *	        &lt;item value="ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	        &lt;item value="ou=OPS&amp;IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	        &lt;item value="ou=000001,ou=OPS&amp;IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/&gt;
- *	    &lt;/attribute>
- *	    &lt;attribute name="givenName" value="Gerrit"/>
- *	   &lt;/attributes&gt;
- *	  &lt;/entry&gt;
- *   &lt;entry&gt; .... &lt;/entry&gt;
- *   .....
- *	&lt;/entries&gt;
- * </pre></code> <br/>
+ * Sample result of a <code>read</code> operation:<br/>
+ * <pre>{@code
+ * <attributes>
+ * 	   <attribute>
+ * 	   <attribute name="employeeType" value="Extern"/>
+ * 	   <attribute name="roomNumber" value="DP 2.13.025"/>
+ * 	   <attribute name="departmentCode" value="358000"/>
+ * 	   <attribute name="organizationalHierarchy">
+ * 	       <item value="ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	       <item value="ou=OPS&IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	       <item value="ou=000001,ou=OPS&IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	   </attribute>
+ * 	   <attribute name="givenName" value="Gerrit"/>
+ * </attributes>
+ * }</pre>
+ * <br/>
+ * Sample result of a <code>search</code> operation:<br/>
+ * <pre>{@code
+ * <entries>
+ * 	   <entry name="uid=srp">
+ * 	       <attributes>
+ * 	           <attribute>
+ * 	           <attribute name="employeeType" value="Extern"/>
+ * 	           <attribute name="roomNumber" value="DP 2.13.025"/>
+ * 	           <attribute name="departmentCode" value="358000"/>
+ * 	           <attribute name="organizationalHierarchy">
+ * 	               <item value="ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	               <item value="ou=OPS&IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	               <item value="ou=000001,ou=OPS&IT,ou=NL,ou=ING-EUR,ou=Group,ou=Organization,o=ing"/>
+ * 	           </attribute>
+ * 	           <attribute name="givenName" value="Gerrit"/>
+ * 	       </attributes>
+ * 	   </entry>
+ *     <entry> .... </entry>
+ *    .....
+ * </entries>
+ * }</pre>
+ * <br/>
  *
  * @ff.parameter entryName Represents entryName (RDN) of interest.
  * @ff.parameter filterExpression Filter expression (handy with searching - see RFC2254).

--- a/core/src/main/java/org/frankframework/monitoring/Monitor.java
+++ b/core/src/main/java/org/frankframework/monitoring/Monitor.java
@@ -41,8 +41,7 @@ import org.frankframework.util.XmlBuilder;
 
 /**
  * <p>Example configuration:</p>
- * <pre><code>
- * {@literal
+ * <pre>{@code
  * <monitor name="Receiver Shutdown" destinations="MONITOR_LOG">
  *    <trigger className="org.frankframework.monitoring.Alarm" severity="WARNING">
  *        <event>Receiver Shutdown</event>
@@ -51,9 +50,8 @@ import org.frankframework.util.XmlBuilder;
  *        <event>Receiver Shutdown</event>
  *    </trigger>
  * </monitor>
- * }
+ * }</pre>
  *
- * </code></pre>
  * @author  Gerrit van Brakel
  * @since   4.9
  *

--- a/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
@@ -755,7 +755,7 @@ public abstract class AbstractParameter implements IConfigurable, IWithParameter
 
 	/**
 	 * Namespace definitions for xpathExpression. Must be in the form of a comma or space separated list of
-	 * <code>prefix=namespaceuri</code>-definitions. One entry can be without a prefix, that will define the default namespace.
+	 * <code>prefix=namespaceuri</code> definitions. One entry can be without a prefix, that will define the default namespace.
 	 */
 	public void setNamespaceDefs(String namespaceDefs) {
 		this.namespaceDefs = namespaceDefs;

--- a/core/src/main/java/org/frankframework/pipes/CompareStringPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/CompareStringPipe.java
@@ -38,18 +38,21 @@ import org.w3c.dom.NodeList;
  * @ff.parameter operand1 The first operand, holds v1. Defaults to input message
  * @ff.parameter operand2 The second operand, holds v2. Defaults to input message
  * @ff.parameter ignorepatterns (optional) contains a xml table with references to substrings which have to be ignored during the comparison. This xml table has the following layout:
- * <br/><code><pre>
- *	&lt;ignores&gt;
- *		&lt;ignore&gt;
- *			&lt;after&gt;...&lt;/after&gt;
- *			&lt;before&gt;...&lt;/before&gt;
- *		&lt;/ignore&gt;
- *		&lt;ignore&gt;
- *			&lt;after&gt;...&lt;/after&gt;
- *			&lt;before&gt;...&lt;/before&gt;
- *		&lt;/ignore&gt;
- *	&lt;/ignores&gt;
- * </pre></code><br/>Substrings between "after" and "before" are ignored
+ * <br/>
+ * <pre>{@code
+ * <ignores>
+ * 	   <ignore>
+ * 	       <after>...</after>
+ * 	       <before>...</before>
+ * 	   </ignore>
+ * 	   <ignore>
+ * 	       <after>...</after>
+ * 	       <before>...</before>
+ * 	   </ignore>
+ * </ignores>
+ * }</pre>
+ * <br/>
+ * Substrings between "after" and "before" are ignored
  *
  * @ff.forward lessthan operand1 &lt; operand2
  * @ff.forward greaterthan operand1 &gt; operand2

--- a/core/src/main/java/org/frankframework/pipes/CrlPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/CrlPipe.java
@@ -40,35 +40,32 @@ import org.frankframework.util.XmlBuilder;
  * The steam is closed after reading.
  *
  * Example configuration:
- * <pre><code>
-	&lt;pipe
-		name="Read issuer"
-		className="org.frankframework.pipes.FilePipe"
-		actions="read"
-		fileName="dir/issuer.cer"
-		preserveInput="true"
-		outputType="stream"
-		storeResultInSessionKey="issuer"
-		&gt;
-		&lt;forward name="success" path="Read CRL" /&gt;
-	&lt;/pipe&gt;
-	&lt;pipe
-		name="Read CRL"
-		className="org.frankframework.pipes.FilePipe"
-		actions="read"
-		fileName="dir/CRL.crl"
-		outputType="stream"
-		&gt;
-		&lt;forward name="success" path="Transform CRL" /&gt;
-	&lt;/pipe&gt;
-	&lt;pipe
-		name="Transform CRL"
-		className="org.frankframework.pipes.CrlPipe"
-		issuerSessionKey="issuer"
-		&gt;
-		&lt;forward name="success" path="EXIT" /&gt;
-	&lt;/pipe&gt;
- * </code></pre>
+ * <pre>{@code
+ * 	<pipe
+ * 		name="Read issuer"
+ * 		className="org.frankframework.pipes.FilePipe"
+ * 		actions="read"
+ * 		fileName="dir/issuer.cer"
+ * 		preserveInput="true"
+ * 		outputType="stream"
+ * 		storeResultInSessionKey="issuer">
+ * 		<forward name="success" path="Read CRL" />
+ * 	</pipe>
+ * 	<pipe
+ * 		name="Read CRL"
+ * 		className="org.frankframework.pipes.FilePipe"
+ * 		actions="read"
+ * 		fileName="dir/CRL.crl"
+ * 		outputType="stream">
+ * 		<forward name="success" path="Transform CRL" />
+ * 	</pipe>
+ * 	<pipe
+ * 		name="Transform CRL"
+ * 		className="org.frankframework.pipes.CrlPipe"
+ * 		issuerSessionKey="issuer">
+ * 		<forward name="success" path="EXIT" />
+ * 	</pipe>
+ * }</pre>
  *
  *
  * @author Miel Hoppenbrouwers

--- a/core/src/main/java/org/frankframework/pipes/MailSenderPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/MailSenderPipe.java
@@ -20,26 +20,29 @@ import org.frankframework.senders.MailSender;
 /**
  * Pipe that sends a mail-message using a {@link MailSender} as its sender.
  * <br/>
- * Sample email.xml:<br/><code><pre>
- *	&lt;email&gt;
- *	    &lt;recipients&gt;
- *	        &lt;recipient&gt;***@natned&lt;/recipient&gt;
- *	        &lt;recipient&gt;***@nn.nl&lt;/recipient&gt;
- *	    &lt;/recipients&gt;
- *	    &lt;from&gt;***@nn.nl&lt;/from&gt;
- *	    &lt;subject&gt;this is the subject&lt;/subject&gt;
- *	    &lt;message&gt;dit is de message&lt;/message&gt;
- *	&lt;/email&gt;
- * </pre></code> <br/>
+ * Sample email.xml:<br/>
+ * <pre>{@code
+ * 	<email>
+ * 	    <recipients>
+ * 	        <recipient>***@natned</recipient>
+ * 	        <recipient>***@nn.nl</recipient>
+ * 	    </recipients>
+ * 	    <from>***@nn.nl</from>
+ * 	    <subject>this is the subject</subject>
+ * 	    <message>dit is de message</message>
+ * 	</email>
+ * }</pre>
+ * <br/>
  * Notice: it must be valid XML. Therefore, especially the message element
  * must be plain text or be wrapped as CDATA.<br/><br/>
- * example:<br/><code><pre>
- * &lt;message&gt;&lt;![CDATA[&lt;h1&gt;This is a HtmlMessage&lt;/h1&gt;]]&gt;&lt;/message&gt;
- * </pre></code><br/>
+ * example:<br/>
+ * <pre>{@code
+ * <message><![CDATA[<h1>This is a HtmlMessage</h1>]]></message>
+ * }</pre>
+ * <br/>
  *
  * @author Johan Verrips
  */
-
 public class MailSenderPipe extends MessageSendingPipe {
 
 	public MailSenderPipe() {

--- a/core/src/main/java/org/frankframework/pipes/PutSystemDateInSession.java
+++ b/core/src/main/java/org/frankframework/pipes/PutSystemDateInSession.java
@@ -172,7 +172,7 @@ public class PutSystemDateInSession extends FixedForwardPipe {
 
 	/**
 	 * Set to a time <i>in milliseconds</i> to create a value that is different to the previous returned value by a PutSystemDateInSession pipe in
-	 * this virtual machine or <code>-1 to disable</code>. The thread will sleep for the specified time before recalculating a new value. Set the
+	 * this virtual machine or <code>-1</code> to disable. The thread will sleep for the specified time before recalculating a new value. Set the
 	 * timezone to a value without Daylight Saving Time (like GMT+1) to prevent this pipe to generate two equal value's when the clock is set back.
 	 * <b>note:</b> When you're looking for a GUID parameter for your XSLT it might be better to use
 	 * &lt;param name=&quot;guid&quot; pattern=&quot;{hostname}_{uid}&quot;/&gt;, see {@link Parameter}.

--- a/core/src/main/java/org/frankframework/pipes/XmlIf.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlIf.java
@@ -204,7 +204,7 @@ public class XmlIf extends AbstractPipe {
 		this.xsltVersion = xsltVersion;
 	}
 
-	/** namespace definitions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. */
+	/** namespace definitions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code> definitions. */
 	public void setNamespaceDefs(String namespaceDefs) {
 		this.namespaceDefs = namespaceDefs;
 	}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -2051,7 +2051,7 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IM
 		chompCharSize = string;
 	}
 
-	/** If set, the character data in this XML element is stored inside a session key and in the message it is replaced by a reference to this session key: {sessionKey: + <code>elementToMoveSessionKey</code> + } */
+	/** If set, the character data in this XML element is stored inside a session key and in the message it is replaced by a reference to this session key: <code>{sessionKey: elementToMoveSessionKey}</code> */
 	public void setElementToMove(String string) {
 		elementToMove = string;
 	}

--- a/core/src/main/java/org/frankframework/scheduler/JobDef.java
+++ b/core/src/main/java/org/frankframework/scheduler/JobDef.java
@@ -69,49 +69,49 @@ import org.springframework.context.ApplicationContext;
  *   <tr>
  *     <td align="left"><code>Seconds</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>0-59</code></td>
+ *     <td align="left">0-59</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * /</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Minutes</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>0-59</code></td>
+ *     <td align="left">0-59</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * /</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Hours</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>0-23</code></td>
+ *     <td align="left">0-23</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * /</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Day-of-month</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>1-31</code></td>
+ *     <td align="left">1-31</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * ? / L C</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Month</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>1-12 or JAN-DEC</code></td>
+ *     <td align="left">1-12 or JAN-DEC</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * /</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Day-of-Week</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>1-7 or SUN-SAT</code></td>
+ *     <td align="left">1-7 or SUN-SAT</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * ? / L C #</code></td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>Year (Optional)</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>empty, 1970-2099</code></td>
+ *     <td align="left">>empty, 1970-2099</td>
  *     <td align="left">&nbsp;</th>
  *     <td align="left"><code>, - * /</code></td>
  *   </tr>
@@ -179,87 +179,87 @@ import org.springframework.context.ApplicationContext;
  *   <tr>
  *     <td align="left"><code>"0 0 12 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 12pm (noon) every day</code></td>
+ *     <td align="left">Fire at 12pm (noon) every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * *"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am every day</code></td>
+ *     <td align="left">Fire at 10:15am every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am every day</code></td>
+ *     <td align="left">Fire at 10:15am every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 * * ? *"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am every day</code></td>
+ *     <td align="left">Fire at 10:15am every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 * * ? 2005"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am every day during the year 2005</code></td>
+ *     <td align="left">Fire at 10:15am every day during the year 2005</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 * 14 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire every minute starting at 2pm and ending at 2:59pm, every day</code></td>
+ *     <td align="left">Fire every minute starting at 2pm and ending at 2:59pm, every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 0/5 14 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire every 5 minutes starting at 2pm and ending at 2:55pm, every day</code></td>
+ *     <td align="left">Fire every 5 minutes starting at 2pm and ending at 2:55pm, every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 0/5 14,18 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire every 5 minutes starting at 2pm and ending at 2:55pm, AND fire every 5 minutes starting at 6pm and ending at 6:55pm, every day</code></td>
+ *     <td align="left">Fire every 5 minutes starting at 2pm and ending at 2:55pm, AND fire every 5 minutes starting at 6pm and ending at 6:55pm, every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 0-5 14 * * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire every minute starting at 2pm and ending at 2:05pm, every day</code></td>
+ *     <td align="left">Fire every minute starting at 2pm and ending at 2:05pm, every day</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 10,44 14 ? 3 WED"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 2:10pm and at 2:44pm every Wednesday in the month of March.</code></td>
+ *     <td align="left">Fire at 2:10pm and at 2:44pm every Wednesday in the month of March.</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * MON-FRI"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am every Monday, Tuesday, Wednesday, Thursday and Friday</code></td>
+ *     <td align="left">Fire at 10:15am every Monday, Tuesday, Wednesday, Thursday and Friday</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 15 * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on the 15th day of every month</code></td>
+ *     <td align="left">Fire at 10:15am on the 15th day of every month</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 L * ?"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on the last day of every month</code></td>
+ *     <td align="left">Fire at 10:15am on the last day of every month</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * 6L"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on the last Friday of every month</code></td>
+ *     <td align="left">Fire at 10:15am on the last Friday of every month</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * 6L"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on the last Friday of every month</code></td>
+ *     <td align="left">Fire at 10:15am on the last Friday of every month</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * 6L 2002-2005"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on every last friday of every month during the years 2002, 2003, 2004 and 2005</code></td>
+ *     <td align="left">Fire at 10:15am on every last friday of every month during the years 2002, 2003, 2004 and 2005</td>
  *   </tr>
  *   <tr>
  *     <td align="left"><code>"0 15 10 ? * 6#3"</code></td>
  *     <td align="left">&nbsp;</th>
- *     <td align="left"><code>Fire at 10:15am on the third Friday of every month</code></td>
+ *     <td align="left">Fire at 10:15am on the third Friday of every month</td>
  *   </tr>
  * </table>
  * </p>

--- a/core/src/main/java/org/frankframework/scheduler/job/IJob.java
+++ b/core/src/main/java/org/frankframework/scheduler/job/IJob.java
@@ -44,7 +44,7 @@ public interface IJob extends IConfigurable {
 
 	/**
 	 * CRON expression that determines the frequency of execution.
-	 * Can <code>not</code> be used in combination with Interval.
+	 * Can <b>not</b> be used in combination with Interval.
 	 */
 	public void setCronExpression(String cronExpression);
 	public String getCronExpression();

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -143,91 +143,91 @@ import nl.nn.adapterframework.dispatcher.DispatcherManager;
  *
  * <h4>Example of Existing Configuration</h4>
  * The existing configuration might look like this in the calling adapter:
- * <pre><code>
- * &lt;module&gt;
- * 	&lt;adapter name="Adapter A"&gt;
- *   &lt;receiver name="Adapter A Receiver" &gt;
- *    &lt;listener name="Adapter A Listener"
- *        className="org.frankframework..." etc/&gt;
- *   &lt;/receiver&gt;
- * 	 &lt;pipeline firstPipe="..."&gt;
- * 	  &lt;pipe name="send" className="org.frankframework.pipes.SenderPipe"&gt;
- * 	   &lt;sender className="org.frankframework.senders.IbisJavaSender"
- * 	       serviceName="service-Adapter-B" /&gt;
- *     &lt;forward name="success" path="..." /&gt;
- * 	  &lt;/pipe&gt;
- *   &lt;/pipeline&gt;
- * 	&lt;/adapter&gt;
- * &lt;/module&gt;
- * </code></pre>
+ * <pre>{@code
+ * <module>
+ *     <adapter name="Adapter A">
+ *         <receiver name="Adapter A Receiver">
+ *             <listener name="Adapter A Listener"
+ *                 className="org.frankframework..." etc/>
+ *         </receiver>
+ *  	   <pipeline firstPipe="...">
+ *  	       <pipe name="send" className="org.frankframework.pipes.SenderPipe">
+ *  	           <sender className="org.frankframework.senders.IbisJavaSender"
+ *  	               serviceName="service-Adapter-B" />
+ *                 <forward name="success" path="..." />
+ *  	       </pipe>
+ *         </pipeline>
+ *     </adapter>
+ * </module>
+ * }</pre>
  *
  * Or like using the modern XML XSD and an IbisLocalSender instead:
- * <pre><code>
- *  &lt;Module&gt;
- *   &lt;Adapter name="Adapter A"&gt;
- *    &lt;Receiver name="Adapter A Receiver"&gt;
- *        ... Listener setup and other configuration
- *    &lt;/Receiver&gt;
- *    &lt;Pipeline&gt;
- *     &lt;SenderPipe name="send"&gt;
- *      &lt;IbisLocalSender name="call Adapter B"
- *          javaListener="Adapter B Listener"/&gt;
- *      &lt;Forward name="success" path="EXIT" /&gt;
- *     &lt;/SenderPipe&gt;
- *    &lt;/Pipeline&gt;
- *   &lt;/Adapter&gt;
- *  &lt;/Module&gt;
- * </code></pre>
+ * <pre>{@code
+ * <Module>
+ *     <Adapter name="Adapter A">
+ *         <Receiver name="Adapter A Receiver">
+ *             ... Listener setup and other configuration
+ *         </Receiver>
+ *         <Pipeline>
+ *             <SenderPipe name="send">
+ *                 <IbisLocalSender name="call Adapter B"
+ *                     javaListener="Adapter B Listener"/>
+ *                 <Forward name="success" path="EXIT" />
+ *             </SenderPipe>
+ *         </Pipeline>
+ *     </Adapter>
+ * </Module>
+ * }</pre>
  *
  * In the receiving adapter B the listener would have been configured like this:
- * <pre><code>
- * &lt;Module&gt;
- *  &lt;Adapter name="adapter B"&gt;
- *   &lt;Receiver name="Receiver B"&gt;
- *    &lt;JavaListener name="Adapter B Listener" serviceName="service-Adapter-B"/&gt;
- *   &lt;/Receiver&gt;
- *   &lt;Pipeline&gt;
- *       ...
- *   &lt;/Pipeline&gt;
- *  &lt;/Adapter&gt;
- * &lt;/Module&gt;
- * </code></pre>
+ * <pre>{@code
+ * <Module>
+ *     <Adapter name="adapter B">
+ *         <Receiver name="Receiver B">
+ *             <JavaListener name="Adapter B Listener" serviceName="service-Adapter-B"/>
+ *         </Receiver>
+ *         <Pipeline>
+ *             ...
+ *         </Pipeline>
+ *     </Adapter>
+ * </Module>
+ * }</pre>
  * <p/>
  *
  * <h4>Rewritten Example Configuration With FrankSender</h4>
  * This example shows the most simple way of using the FrankSender to call another adapter with least amount of overhead.
  *
- * <pre><code>
- *  &lt;Module&gt;
- *   &lt;Adapter name="Adapter A"&gt;
- *    &lt;Receiver name="Adapter A Receiver"&gt;
- *        ... Listener setup and other configuration
- *    &lt;/Receiver&gt;
- *    &lt;Pipeline&gt;
- *     &lt;SenderPipe name="send"&gt;
- *      &lt;!-- when scope="ADAPTER", then target is directly the name of the adapter you want to call --&gt;
- *      &lt;FrankSender name="call Adapter C"
- *          scope="ADAPTER"
- *          target="adapter B"
- *      /&gt;
- *      &lt;Forward name="success" path="EXIT" /&gt;
- *     &lt;/SenderPipe&gt;
- *    &lt;/Pipeline&gt;
- *   &lt;/Adapter&gt;
- *
- *   &lt;Adapter name="adapter B"&gt;
- *    &lt;!-- No receiver needed for FrankSender in this scenario --&gt;
- *    &lt;Pipeline&gt;
- *       ... Exits, Pipes etc
- *    &lt;/Pipeline&gt;
- *   &lt;/Adapter&gt;
- *  &lt;/Module&gt;
- * </code></pre>
+ * <pre>{@code
+ * <Module>
+ *     <Adapter name="Adapter A">
+ *         <Receiver name="Adapter A Receiver">
+ *             ... Listener setup and other configuration
+ *         </Receiver>
+ *         <Pipeline>
+ *             <SenderPipe name="send">
+ *                 <!-- when scope="ADAPTER", then target is directly the name of the adapter you want to call -->
+ *                 <FrankSender name="call Adapter C"
+ *                     scope="ADAPTER"
+ *                     target="adapter B"
+ *                 />
+ *                 <Forward name="success" path="EXIT" />
+ *             </SenderPipe>
+ *         </Pipeline>
+ *     </Adapter>
+ *     <Adapter name="adapter B">
+ *         <!-- No receiver needed for FrankSender in this scenario -->
+ *         <Pipeline>
+ *             ... Exits, Pipes etc
+ *         </Pipeline>
+ *     </Adapter>
+ * </Module>
+ * }</pre>
  *
  * <h4>Rewritten Example Configuration With FrankSender and FrankListener</h4>
  * This example shows why you might want to call the other adapter via the FrankListener. This adds a bit more overhead to the call
  * of the sub-adapter for the extra error-handling done by the target receiver.
  *
+ * <pre>{@code}</pre>
  * <pre><code>
  *  &lt;Module&gt;
  *   &lt;Adapter name="Adapter A"&gt;

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -227,42 +227,41 @@ import nl.nn.adapterframework.dispatcher.DispatcherManager;
  * This example shows why you might want to call the other adapter via the FrankListener. This adds a bit more overhead to the call
  * of the sub-adapter for the extra error-handling done by the target receiver.
  *
- * <pre>{@code}</pre>
- * <pre><code>
- *  &lt;Module&gt;
- *   &lt;Adapter name="Adapter A"&gt;
- *    &lt;Receiver name="Adapter A Receiver"&gt;
- *        ... Listener setup and other configuration
- *    &lt;/Receiver&gt;
- *    &lt;Pipeline&gt;
- *     &lt;SenderPipe name="send"&gt;
- *      &lt;!-- when scope="LISTENER", then target is directly the name of the FrankListener in the adapter you want to call --&gt;
- *      &lt;FrankSender
- *           scope="LISTENER"
- *           target="Adapter B Listener"/&gt;
- *       &lt;Forward name="success" path="EXIT" /&gt;
- *     &lt;/SenderPipe&gt;
- *    &lt;/Pipeline&gt;
- *   &lt;/Adapter&gt;
- *  &lt;Adapter name="adapter B"&gt;
- *   &lt;!-- Messages will only be sent to the error storage if:
- *        - The target receiver is not transactional, and has maxTries="0", or
- *        - The target receiver is transaction, and the Sender is set up to retry sending on error
- *        For internal adapters, sending / receiving with retries might not make sense so the example does not show that.
- *   --&gt;
- *   &lt;Receiver name="Receiver B" maxRetries="0" transactionAttribute="NotSupported"&gt;
- *    &lt;!-- Listener name is optional, defaults to Adapter name --&gt;
- *    &lt;FrankListener name="Adapter B Listener"/&gt;
- *    &lt;!-- This adapter now has an error storage -- without Receiver and FrankListener the sub-adapter couldn't have that --&gt;
- *    &lt;JdbcErrorStorage slotId="Adapter B - Errors" /&gt;
- *   &lt;/Receiver&gt;
- *   &lt;!-- If transactions are required, set transaction-attribute on the Pipeline --&gt;
- *   &lt;Pipeline transactionAttribute="RequiresNew"&gt;
- *       ... Exits, Pipes etc
- *   &lt;/Pipeline&gt;
- *  &lt;/Adapter&gt;
- *  &lt;/Module&gt;
- * </code></pre>
+ * <pre>{@code
+ * <Module>
+ *    <Adapter name="Adapter A">
+ *        <Receiver name="Adapter A Receiver">
+ *         ... Listener setup and other configuration
+ * 		  </Receiver>
+ * 		  <Pipeline>
+ *            <SenderPipe name="send">
+ *                <!-- when scope="LISTENER", then target is directly the name of the FrankListener in the adapter you want to call -->
+ *                <FrankSender
+ *                    scope="LISTENER"
+ *                    target="Adapter B Listener"/>
+ *                <Forward name="success" path="EXIT" />
+ *            </SenderPipe>
+ *        </Pipeline>
+ *     </Adapter>
+ *     <Adapter name="adapter B">
+ *         <!-- Messages will only be sent to the error storage if:
+ *             - The target receiver is not transactional, and has maxTries="0", or
+ *             - The target receiver is transaction, and the Sender is set up to retry sending on error
+ *             For internal adapters, sending / receiving with retries might not make sense so the example does not show that.
+ *         -->
+ *         <Receiver name="Receiver B" maxRetries="0" transactionAttribute="NotSupported">
+ *             <!-- Listener name is optional, defaults to Adapter name -->
+ *             <FrankListener name="Adapter B Listener"/>
+ *                 <!-- This adapter now has an error storage -- without Receiver and FrankListener the sub-adapter couldn't have that -->
+ *             <JdbcErrorStorage slotId="Adapter B - Errors" />
+ *         </Receiver>
+ *         <!-- If transactions are required, set transaction-attribute on the Pipeline -->
+ *         <Pipeline transactionAttribute="RequiresNew">
+ *             ... Exits, Pipes etc
+ *         </Pipeline>
+ *    </Adapter>
+ * </Module>
+ * }</pre>
  *
  * @ff.parameter {@code scope} Determine scope dynamically at runtime. If the parameter value is empty, fall back to the scope configured via the attribute, or the default scope {@code ADAPTER}.
  * @ff.parameter {@code target} Determine target dynamically at runtime. If the parameter value is empty, fall back to the target configured via the attribute.

--- a/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
@@ -335,7 +335,7 @@ public class IbisLocalSender extends SenderWithParametersBase implements HasPhys
 	}
 
 	/**
-	 * If set <code>false</code>, the call is made asynchronously. This implies isolated=<code>true</code>
+	 * If set <code>false</code>, the call is made asynchronously. This implies <code>isolated=true</code>
 	 * @ff.default true
 	 */
 	public void setSynchronous(boolean b) {

--- a/core/src/main/java/org/frankframework/senders/JsonXsltSender.java
+++ b/core/src/main/java/org/frankframework/senders/JsonXsltSender.java
@@ -88,13 +88,11 @@ public class JsonXsltSender extends XsltSender {
 	}
 
 	/**
-	 * Namespace definitions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions
+	 * Namespace definitions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code> definitions
 	 * @ff.default j=http://www.w3.org/2013/XSL/json
 	 */
 	@Override
 	public void setNamespaceDefs(String namespaceDefs) {
 		super.setNamespaceDefs(namespaceDefs);
 	}
-
-
 }

--- a/core/src/main/java/org/frankframework/senders/MailSender.java
+++ b/core/src/main/java/org/frankframework/senders/MailSender.java
@@ -52,33 +52,33 @@ import lombok.Setter;
  * {@link ISender sender} that sends a mail specified by an XML message.
  * <p>
  * Sample email.xml:
- * <code><pre>
- *    &lt;email&gt;
- *       &lt;recipients&gt;
- *          &lt;recipient type="to"&gt;***@hotmail.com&lt;/recipient&gt;
- *          &lt;recipient type="cc"&gt;***@gmail.com&lt;/recipient&gt;
- *       &lt;/recipients&gt;
- *       &lt;from name="*** ***"&gt;***@yahoo.com&lt;/from&gt;
- *       &lt;subject&gt;This is the subject&lt;/subject&gt;
- *       &lt;threadTopic&gt;subject&lt;/threadTopic&gt;
- *       &lt;message&gt;This is the message&lt;/message&gt;
- *       &lt;messageType&gt;text/plain&lt;/messageType&gt;&lt;!-- Optional --&gt;
- *       &lt;messageBase64&gt;false&lt;/messageBase64&gt;&lt;!-- Optional --&gt;
- *       &lt;charset&gt;UTF-8&lt;/charset&gt;&lt;!-- Optional --&gt;
- *       &lt;attachments&gt;
- *          &lt;attachment name="filename1.txt"&gt;This is the first attachment&lt;/attachment&gt;
- *          &lt;attachment name="filename2.pdf" base64="true"&gt;JVBERi0xLjQKCjIgMCBvYmoKPDwvVHlwZS9YT2JqZWN0L1N1YnR5cGUvSW1...vSW5mbyA5IDAgUgo+PgpzdGFydHhyZWYKMzQxNDY2CiUlRU9GCg==&lt;/attachment&gt;
- *          &lt;attachment name="filename3.pdf" url="file:/c:/filename3.pdf"/&gt;
- *          &lt;attachment name="filename4.pdf" sessionKey="fileContent"/&gt;
- *       &lt;/attachments&gt;&lt;!-- Optional --&gt;
- *   &lt;/email&gt;
- * </pre></code>
+ * <pre>{@code
+ * <email>
+ *     <recipients>
+ *         <recipient type="to">***@hotmail.com</recipient>
+ *         <recipient type="cc">***@gmail.com</recipient>
+ *     </recipients>
+ *     <from name="*** ***">***@yahoo.com</from>
+ *     <subject>This is the subject</subject>
+ *     <threadTopic>subject</threadTopic>
+ *     <message>This is the message</message>
+ *     <messageType>text/plain</messageType><!-- Optional -->
+ *     <messageBase64>false</messageBase64><!-- Optional -->
+ *     <charset>UTF-8</charset><!-- Optional -->
+ *     <attachments>
+ *         <attachment name="filename1.txt">This is the first attachment</attachment>
+ *         <attachment name="filename2.pdf" base64="true">JVBERi0xLjQKCjIgMCBvYmoKPDwvVHlwZS9YT2JqZWN0L1N1YnR5cGUvSW1...vSW5mbyA5IDAgUgo+PgpzdGFydHhyZWYKMzQxNDY2CiUlRU9GCg==</attachment>
+ *         <attachment name="filename3.pdf" url="file:/c:/filename3.pdf"/>
+ *         <attachment name="filename4.pdf" sessionKey="fileContent"/>
+ *     </attachments><!-- Optional -->
+ * </email>
+ * }</pre>
  * </p><p>
  * Notice: the XML message must be valid XML. Therefore, especially the message element
  * must be plain text or be wrapped as CDATA. Example:
- * <code><pre>
- *    &lt;message&gt;&lt;![CDATA[&lt;h1&gt;This is a HtmlMessage&lt;/h1&gt;]]&gt;&lt;/message&gt;
- * </pre></code>
+ * <pre>{@code
+ * <message><![CDATA[<h1>This is a HtmlMessage</h1>]]></message>
+ * }</pre>
  * </p><p>
  * The <code>sessionKey</code> attribute for attachment can contain an inputstream or a string. Other types are not supported at this moment.
  * </p><p>

--- a/core/src/main/java/org/frankframework/senders/ReconnectSenderWrapper.java
+++ b/core/src/main/java/org/frankframework/senders/ReconnectSenderWrapper.java
@@ -31,13 +31,13 @@ import lombok.Setter;
  * This prevents (long) open connections inside Senders and possible connection failures.
  *
  * <b>Example:</b>
- * <pre><code>
- *   &lt;SenderPipe&gt;
- *     &lt;ReconnectSenderWrapper&gt;
- *        &lt;EchoSender myAttribute="myValue" /&gt;
- *     &lt;/ReconnectSenderWrapper&gt;
- *   &lt;/SenderPipe&gt;
- * </code></pre>
+ * <pre>{@code
+ * <SenderPipe>
+ *     <ReconnectSenderWrapper>
+ *         <EchoSender myAttribute="myValue" />
+ *     </ReconnectSenderWrapper>
+ * </SenderPipe>
+ * }</pre>
  * </p>
  *
  * @author  Niels Meijer

--- a/core/src/main/java/org/frankframework/util/AppConstants.java
+++ b/core/src/main/java/org/frankframework/util/AppConstants.java
@@ -188,7 +188,7 @@ public final class AppConstants extends PropertyLoader {
 	/**
 	 * Load the contents of a properties file.
 	 * <p>Optionally, this may be a comma-separated list of files to load, e.g.
-	 * <code><pre>log4j2.properties,deploymentspecifics.properties</pre></code>
+	 * <code>log4j2.properties,deploymentspecifics.properties</code>
 	 * which will cause both files to be loaded in the listed order.
 	 * </p>
 	 */

--- a/core/src/main/java/org/frankframework/util/DB2XMLWriter.java
+++ b/core/src/main/java/org/frankframework/util/DB2XMLWriter.java
@@ -42,34 +42,33 @@ import jakarta.annotation.Nullable;
 /**
  * Transforms a java.sql.Resultset to a XML stream.
  * Example of a result:
- * <code><pre>
- * &lt;result&gt;
-	&lt;fielddefinition&gt;
-		&lt;field name="FIELDNAME"
-		          type="columnType"
-		          columnDisplaySize=""
-		          precision=""
-		          scale=""
-		          isCurrency=""
-		          columnTypeName=""
-		          columnClassName=""/&gt;
-		 &lt;field ...../&gt;
-	&lt;/fielddefinition&gt;
-	&lt;rowset&gt;
-		&lt;row number="1"&gt;
-			&lt;field name="FIELDNAME"&gt;value&lt;/field&gt;
-			&lt;field name="FIELDNAME" null="true" &gt;&lt;/field&gt;
-			&lt;field name="FIELDNAME"&gt;value&lt;/field&gt;
-			&lt;field name="FIELDNAME"&gt;value&lt;/field&gt;
-		&lt;/row&gt;
-	&lt;/rowset&gt;
-&lt;/result&gt;
-</pre></code>
+ * <pre>{@code
+ * <result>
+ *     <fielddefinition>
+ *         <field name="FIELDNAME"
+ *             type="columnType"
+ *             columnDisplaySize=""
+ *             precision=""
+ *             scale=""
+ *             isCurrency=""
+ *             columnTypeName=""
+ *             columnClassName=""/>
+ *         <field ...../>
+ *     </fielddefinition>
+ *     <rowset>
+ *         <row number="1">
+ *             <field name="FIELDNAME">value</field>
+ *             <field name="FIELDNAME" null="true" ></field>
+ *             <field name="FIELDNAME">value</field>
+ *             <field name="FIELDNAME">value</field>
+ *         </row>
+ *     </rowset>
+ * </result>
+ * }</pre>
  * Note: that the fieldname and columntype are always capital case!
  *
  * @author Johan Verrips
  **/
-
 public class DB2XMLWriter {
 	protected static Logger log = LogUtil.getLogger(DB2XMLWriter.class);
 

--- a/core/src/main/java/org/frankframework/util/DB2XMLWriter.java
+++ b/core/src/main/java/org/frankframework/util/DB2XMLWriter.java
@@ -58,7 +58,7 @@ import jakarta.annotation.Nullable;
  *     <rowset>
  *         <row number="1">
  *             <field name="FIELDNAME">value</field>
- *             <field name="FIELDNAME" null="true" ></field>
+ *             <field name="FIELDNAME" null="true"></field>
  *             <field name="FIELDNAME">value</field>
  *             <field name="FIELDNAME">value</field>
  *         </row>

--- a/core/src/main/java/org/frankframework/util/WildCardFilter.java
+++ b/core/src/main/java/org/frankframework/util/WildCardFilter.java
@@ -23,11 +23,12 @@ import java.util.Vector;
 /**
  * Implementation of a FilenameFilter to support wildcards. <br/>
  * <b>use:</b><br/>
- * <code><pre>
+ * <pre>{@code
  * WildCardFilter filter = new WildCardFilter("*.java");
  * File currDir = new File(".");
  * String files[] = currDir.list(filter);
- * </pre></code> <br/>
+ * }</pre>
+ * <br/>
  * Examples:
  * <ul>
  * <li>*.java</li>
@@ -37,7 +38,6 @@ import java.util.Vector;
  *
  * @author Johan Verrips IOS
  **/
-
 public class WildCardFilter implements FilenameFilter {
 
 	String wildPattern = null;

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/config/SecurityChainConfigurer.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/config/SecurityChainConfigurer.java
@@ -59,15 +59,16 @@ import lombok.extern.log4j.Log4j2;
  * 
  * When running standalone this Filter will need to be added manually, by either a bean definition or by using the {@link AbstractSecurityWebApplicationInitializer}.
  * 
- * <pre><code>
+ * <pre>{@code
  * public FilterRegistrationBean<DelegatingFilterProxy> securityFilterChainRegistration() {
- * 	DelegatingFilterProxy delegatingFilterProxy = new DelegatingFilterProxy();
- * 	delegatingFilterProxy.setTargetBeanName(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME);
- * 	FilterRegistrationBean<DelegatingFilterProxy> registrationBean = new FilterRegistrationBean<>(delegatingFilterProxy);
- * 	registrationBean.addUrlPatterns("/*");
- * 	return registrationBean;
+ * 	   DelegatingFilterProxy delegatingFilterProxy = new DelegatingFilterProxy();
+ * 	   delegatingFilterProxy.setTargetBeanName(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME);
+ * 	   FilterRegistrationBean<DelegatingFilterProxy> registrationBean = new FilterRegistrationBean<>(delegatingFilterProxy);
+ * 	   registrationBean.addUrlPatterns("/*");
+ *
+ * 	   return registrationBean;
  * }
- * </code></pre>
+ * }</pre>
  */
 @Log4j2
 @Configuration

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
@@ -39,9 +39,9 @@ import org.xml.sax.SAXException;
  * <br/>
  * Example request:<br/>
  * <pre>{@code
- * <soap:Envelope xmlns:soap="http:// schemas. xmlsoap. org/ soap/ envelope/">
+ * <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  *  	<soap:Header>
- *  		<bis:MessageHeader xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  		<bis:MessageHeader xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2">
  *  			<bis:From>
  *  				<bis:Id>PolicyConversion_01_ServiceAgents_01</bis:Id>
  *  			</bis:From>
@@ -53,7 +53,7 @@ import org.xml.sax.SAXException;
  *  		</bis:MessageHeader>
  *  	</soap:Header>
  * 		<soap:Body>
- *  		<pcr:GetRequest xmlns:pcr="http:// www. ing. com/ nl/ pcretail/ ts/ migrationauditdata_01">
+ *  		<pcr:GetRequest xmlns:pcr="http://www.ing.com/nl/pcretail/ts/migrationauditdata_01">
  *  			<pcr:PolicyDetails>
  *  				<pcr:RVS_PARTY_ID>1790257</pcr:RVS_PARTY_ID>
  *  				<pcr:RVS_POLICY_NUMBER>10000050</pcr:RVS_POLICY_NUMBER>
@@ -68,9 +68,9 @@ import org.xml.sax.SAXException;
  * <br/>
  * Example reply:<br/>
  * <pre>{@code
- * <soap:Envelope xmlns:soap="http:// schemas. xmlsoap. org/ soap/ envelope/">
+ * <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  *  	<soap:Header>
- *  		<bis:MessageHeader xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  		<bis:MessageHeader xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2">
  *  			<bis:From>
  *  				<bis:Id>IJA_DB4CONV</bis:Id>
  *  			</bis:From>
@@ -83,9 +83,9 @@ import org.xml.sax.SAXException;
  *  		</bis:MessageHeader>
  *  	</soap:Header>
  *  	<soap:Body>
- *  		<GetResponse xmlns="http:// www. ing. com/ nl/ pcretail/ ts/ migrationcasedata_01">
+ *  		<GetResponse xmlns="http://www.ing.com/nl/pcretail/ts/migrationcasedata_01">
  *  			<CaseData>...</CaseData>
- *  			<bis:Result xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  			<bis:Result xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2">
  *  				<bis:Status>OK</bis:Status>
  *  			</bis:Result>
  *  		</GetResponse>
@@ -97,7 +97,7 @@ import org.xml.sax.SAXException;
  * <br/>
  * Example element Result in case of an error reply:<br/>
  * <pre>{@code
- * <bis:Result xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ * <bis:Result xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2">
  *  	<bis:Status>ERROR</bis:Status>
  *  	<bis:ErrorList>
  *  		<bis:Error>

--- a/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/bis/BisJmsListener.java
@@ -37,85 +37,91 @@ import org.xml.sax.SAXException;
 /**
  * Bis (Business Integration Services) extension of JmsListener.
  * <br/>
- * Example request:<br/><code><pre>
- *	&lt;soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"&gt;
- *		&lt;soap:Header&gt;
- *			&lt;bis:MessageHeader xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2"&gt;
- *				&lt;bis:From&gt;
- *					&lt;bis:Id&gt;PolicyConversion_01_ServiceAgents_01&lt;/bis:Id&gt;
- *				&lt;/bis:From&gt;
- *				&lt;bis:HeaderFields&gt;
- *					&lt;bis:ConversationId&gt;1790257_10000050_04&lt;/bis:ConversationId&gt;
- *					&lt;bis:MessageId&gt;1790257&lt;/bis:MessageId&gt;
- *					&lt;bis:Timestamp&gt;2011-03-02T10:26:31.464+01:00&lt;/bis:Timestamp&gt;
- *				&lt;/bis:HeaderFields&gt;
- *			&lt;/bis:MessageHeader&gt;
- *		&lt;/soap:Header&gt;
- *		&lt;soap:Body&gt;
- *			<i>&lt;pcr:GetRequest xmlns:pcr="http://www.ing.com/nl/pcretail/ts/migrationauditdata_01"&gt;
- *				&lt;pcr:PolicyDetails&gt;
- *					&lt;pcr:RVS_PARTY_ID&gt;1790257&lt;/pcr:RVS_PARTY_ID&gt;
- *					&lt;pcr:RVS_POLICY_NUMBER&gt;10000050&lt;/pcr:RVS_POLICY_NUMBER&gt;
- *					&lt;pcr:RVS_BRANCH_CODE&gt;04&lt;/pcr:RVS_BRANCH_CODE&gt;
- *				&lt;/pcr:PolicyDetails&gt;
- *			&lt;/pcr:GetRequest&gt;</i>
- *		&lt;/soap:Body&gt;
- *	&lt;/soap:Envelope&gt;
- * </pre></code><br/>
+ * Example request:<br/>
+ * <pre>{@code
+ * <soap:Envelope xmlns:soap="http:// schemas. xmlsoap. org/ soap/ envelope/">
+ *  	<soap:Header>
+ *  		<bis:MessageHeader xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  			<bis:From>
+ *  				<bis:Id>PolicyConversion_01_ServiceAgents_01</bis:Id>
+ *  			</bis:From>
+ *  			<bis:HeaderFields>
+ *  				<bis:ConversationId>1790257_10000050_04</bis:ConversationId>
+ *  				<bis:MessageId>1790257</bis:MessageId>
+ *  				<bis:Timestamp>2011-03-02T10:26:31.464+01:00</bis:Timestamp>
+ *  			</bis:HeaderFields>
+ *  		</bis:MessageHeader>
+ *  	</soap:Header>
+ * 		<soap:Body>
+ *  		<pcr:GetRequest xmlns:pcr="http:// www. ing. com/ nl/ pcretail/ ts/ migrationauditdata_01">
+ *  			<pcr:PolicyDetails>
+ *  				<pcr:RVS_PARTY_ID>1790257</pcr:RVS_PARTY_ID>
+ *  				<pcr:RVS_POLICY_NUMBER>10000050</pcr:RVS_POLICY_NUMBER>
+ *  				<pcr:RVS_BRANCH_CODE>04</pcr:RVS_BRANCH_CODE>
+ *  			</pcr:PolicyDetails>
+ *  		</pcr:GetRequest>
+ *  	</soap:Body>
+ * </soap:Envelope>
+ * }</pre>
+ * <br/>
  * The element MessageHeader in the soap header is mandatory.
  * <br/>
- * Example reply:<br/><code><pre>
- *	&lt;soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"&gt;
- *		&lt;soap:Header&gt;
- *			&lt;bis:MessageHeader xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2"&gt;
- *				&lt;bis:From&gt;
- *					&lt;bis:Id&gt;IJA_DB4CONV&lt;/bis:Id&gt;
- *				&lt;/bis:From&gt;
- *				&lt;bis:HeaderFields&gt;
- *					&lt;bis:ConversationId&gt;1790257_10000050_04&lt;/bis:ConversationId&gt;
- *					&lt;bis:MessageId&gt;rn09ce_0a3b8d2d--33192359_12e588118c1_-612f&lt;/bis:MessageId&gt;
- *					&lt;bis:ExternalRefToMessageId&gt;1790257&lt;/bis:ExternalRefToMessageId&gt;
- *					&lt;bis:Timestamp&gt;2011-03-02T10:26:31&lt;/bis:Timestamp&gt;
- *				&lt;/bis:HeaderFields&gt;
- *			&lt;/bis:MessageHeader&gt;
- *		&lt;/soap:Header&gt;
- *		&lt;soap:Body&gt;
- *			<i>&lt;GetResponse xmlns="http://www.ing.com/nl/pcretail/ts/migrationcasedata_01"&gt;</i>
- *				<i>&lt;CaseData&gt;...&lt;/CaseData&gt;</i>
- *				&lt;bis:Result xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2"&gt;
- *					&lt;bis:Status&gt;OK&lt;/bis:Status&gt;
- *				&lt;/bis:Result&gt;
- *			<i>&lt;/GetResponse&gt;</i>
- *		&lt;/soap:Body&gt;
- *	&lt;/soap:Envelope&gt;
- * </pre></code><br/>
+ * Example reply:<br/>
+ * <pre>{@code
+ * <soap:Envelope xmlns:soap="http:// schemas. xmlsoap. org/ soap/ envelope/">
+ *  	<soap:Header>
+ *  		<bis:MessageHeader xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  			<bis:From>
+ *  				<bis:Id>IJA_DB4CONV</bis:Id>
+ *  			</bis:From>
+ *  			<bis:HeaderFields>
+ *  				<bis:ConversationId>1790257_10000050_04</bis:ConversationId>
+ *  				<bis:MessageId>rn09ce_0a3b8d2d--33192359_12e588118c1_-612f</bis:MessageId>
+ *  				<bis:ExternalRefToMessageId>1790257</bis:ExternalRefToMessageId>
+ *  				<bis:Timestamp>2011-03-02T10:26:31</bis:Timestamp>
+ *  			</bis:HeaderFields>
+ *  		</bis:MessageHeader>
+ *  	</soap:Header>
+ *  	<soap:Body>
+ *  		<GetResponse xmlns="http:// www. ing. com/ nl/ pcretail/ ts/ migrationcasedata_01">
+ *  			<CaseData>...</CaseData>
+ *  			<bis:Result xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  				<bis:Status>OK</bis:Status>
+ *  			</bis:Result>
+ *  		</GetResponse>
+ *  	</soap:Body>
+ * </soap:Envelope>
+ * }</pre>
+ * <br/>
  * The elements MessageHeader in the soap header and Result in the soap body are mandatory.
  * <br/>
- * Example element Result in case of an error reply:<br/><code><pre>
- *	&lt;bis:Result xmlns:bis="http://www.ing.com/CSP/XSD/General/Message_2"&gt;
- *		&lt;bis:Status&gt;ERROR&lt;/bis:Status&gt;
- *		&lt;bis:ErrorList&gt;
- *			&lt;bis:Error&gt;
- *				&lt;bis:Code&gt;ERR6003&lt;/bis:Code&gt;
- *				&lt;bis:Reason&gt;Invalid Request Message&lt;/bis:Reason&gt;
- *				&lt;bis:Service&gt;
- *					&lt;bis:Name&gt;migrationauditdata_01&lt;/bis:Name&gt;
- *					&lt;bis:Context&gt;1&lt;/bis:Context&gt;
- *					&lt;bis:Action&gt;
- *						&lt;bis:Name&gt;SetPolicyDetails_Action&lt;/bis:Name&gt;
- *						&lt;bis:Version&gt;1&lt;/bis:Version&gt;
- *					&lt;/bis:Action&gt;
- *				&lt;/bis:Service&gt;
- *				&lt;bis:DetailList&gt;
- *					&lt;bis:Detail&gt;
- *						&lt;bis:Code/&gt;
- *						&lt;bis:Text&gt;Pipe [Validate tibco request] msgId [Test Tool correlation id] got invalid xml according to schema [....&lt;/bis:Text&gt;
- *					&lt;/bis:Detail&gt;
- *				&lt;/bis:DetailList&gt;
- *			&lt;/bis:Error&gt;
- *		&lt;/bis:ErrorList&gt;
- *	&lt;/bis:Result&gt;
- * </pre></code><br/>
+ * Example element Result in case of an error reply:<br/>
+ * <pre>{@code
+ * <bis:Result xmlns:bis="http:// www. ing. com/ CSP/ XSD/ General/ Message_2">
+ *  	<bis:Status>ERROR</bis:Status>
+ *  	<bis:ErrorList>
+ *  		<bis:Error>
+ *  			<bis:Code>ERR6003</bis:Code>
+ *  			<bis:Reason>Invalid Request Message</bis:Reason>
+ *  			<bis:Service>
+ *  				<bis:Name>migrationauditdata_01</bis:Name>
+ *  				<bis:Context>1</bis:Context>
+ *  				<bis:Action>
+ *  					<bis:Name>SetPolicyDetails_Action</bis:Name>
+ *  					<bis:Version>1</bis:Version>
+ *  				</bis:Action>
+ *  			</bis:Service>
+ *  			<bis:DetailList>
+ *  				<bis:Detail>
+ *  					<bis:Code/>
+ *  					<bis:Text>Pipe [Validate tibco request] msgId [Test Tool correlation id] got invalid xml according to schema [....</bis:Text>
+ *  				</bis:Detail>
+ *  			</bis:DetailList>
+ *  		</bis:Error>
+ *  	</bis:ErrorList>
+ * </bis:Result>
+ * }</pre>
+ * <br/>
  * <p><b>Configuration:</b>
  * <table border="1">
  * <tr><th>attributes</th><th>description</th><th>default</th></tr>

--- a/nn-specials/src/main/java/org/frankframework/extensions/rekenbox/Adios2XmlPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/rekenbox/Adios2XmlPipe.java
@@ -49,15 +49,15 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * <p>
  * Sample xml:<br/>
- * <pre><code>
- * &lt;adios rekenbox="L76HB150"&gt;
- *     &lt;rubriek naam="BER_VERZ_CD" waarde="COMBIFLEX_BELEGGING" /&gt;
- *     &lt;rubriek naam="INBR_CD" waarde="NIEUWE_VERZEKERING" /&gt;
- *     &lt;rubriek naam="PENS_DT_BEP_CD"  waarde="DT_UIT_PENS_LFT" /&gt;
- *     &lt;rubriek nummer="313" naam="AS_OPSL_PRD_TRM_PRM" index="3" recordnr="74" record="VUT_VERZEKERING" waarde="52.34" /&gt;
- * ...
- * &lt;/adios&gt;
- * </code></pre>
+ * <pre>{@code
+ * <adios rekenbox="L76HB150">
+ *     <rubriek naam="BER_VERZ_CD" waarde="COMBIFLEX_BELEGGING" />
+ *     <rubriek naam="INBR_CD" waarde="NIEUWE_VERZEKERING" />
+ *     <rubriek naam="PENS_DT_BEP_CD"  waarde="DT_UIT_PENS_LFT" />
+ *     <rubriek nummer="313" naam="AS_OPSL_PRD_TRM_PRM" index="3" recordnr="74" record="VUT_VERZEKERING" waarde="52.34" />
+ *     ...
+ * </adios>
+ * }</pre>
  * <br/>
  * For input, a 'naam' or a 'nummer'-attribute must be specified. If both are specified, their match is checked.
  * On output, 'nummer', 'naam' and 'waarde'-attributes are always present in each rubriek-element.

--- a/nn-specials/src/main/java/org/frankframework/extensions/rekenbox/LabelFormat.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/rekenbox/LabelFormat.java
@@ -33,19 +33,21 @@ import org.frankframework.util.XmlUtils;
  * Transforms between ascii and an XML representation.
  *
  * <p>
- * Sample xml:<br/><code><pre>
- * 	&lt;CALCBOXMESSAGE&gt;
-		&lt;OPDRACHT&gt;
-			&lt;OPDRACHTSOORT&gt;ONTTREK_RISICO_EN_KOSTEN&lt;/OPDRACHTSOORT&gt;
-			&lt;BASISRENDEMENTSOORT&gt;NVT&lt;/BASISRENDEMENTSOORT&gt;
-			&lt;BEDRAG&gt;625&lt;/BEDRAG&gt;
-			&lt;DATUM&gt;20071201&lt;/DATUM&gt;
+ * Sample xml:<br/>
+ * <pre>{@code
+ * <CALCBOXMESSAGE>
+ * 		<OPDRACHT>
+ * 		    <OPDRACHTSOORT>ONTTREK_RISICO_EN_KOSTEN</OPDRACHTSOORT>
+ * 		    <BASISRENDEMENTSOORT>NVT</BASISRENDEMENTSOORT>
+ * 		    <BEDRAG>625</BEDRAG>
+ * 		    <DATUM>20071201</DATUM>
+ *     ...
+ * </CALCBOXMESSAGE>
+ * }</pre>
+ * <br/>
  *
- *          ...
- * 	&lt;/CALCBOXMESSAGE&gt;
- * </pre></code> <br/>
- *
- * Sample ascii:<br/><code><pre>
+ * Sample ascii:<br/>
+ * <pre>{@code
  * 	OPDRACHT : #SAMENGESTELD
  * 	OPDRACHT.OPDRACHTSOORT :ONTTREK_RISICO_EN_KOSTEN
  * 	OPDRACHT.BASISRENDEMENTSOORT :NVT
@@ -54,7 +56,7 @@ import org.frankframework.util.XmlUtils;
  *
  *          ...
  * 	EINDEREKENVERZOEK :EINDE
- * </pre></code>
+ * }</pre>
  * </p>
  *
  * <p><b>Configuration:</b>

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
@@ -49,9 +49,9 @@ import org.frankframework.util.StringUtil;
  *
  * <p>
  * Default redirect url is as follows:
- * <code><pre>
+ * <pre>{@code
  * {baseUrl}/-servlet-name-/oauth2/code/{registrationId}
- * </pre></code>
+ * }</pre>
  * <p>
  * The redirect url has been modified to match the servlet path and is deduced from the default
  * {@link OAuth2LoginAuthenticationFilter#DEFAULT_FILTER_PROCESSES_URI}.

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/YmlFileAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/YmlFileAuthenticator.java
@@ -39,14 +39,14 @@ import lombok.Setter;
  * users.password [string] Set the password of the user
  * users.roles [array] Set the roles of the user. Options: `IbisTester`, `IbisDataAdmin`, `IbisAdmin`, `IbisWebService`, `IbisObserver`
  * e.g.
- * <pre><code>
+ * <pre>{@code
  * users:
  *   - username: Tester
  *     password: ChangeMe!
  *     roles:
  *       - IbisTester
  *       - IbisObserver
- * </code></pre>
+ * }</pre>
  */
 public class YmlFileAuthenticator extends ServletAuthenticatorBase {
 


### PR DESCRIPTION
This are only changes in the javadoc. Mostly changing pre code to pre {@code} /pre syntax. 