### PR TITLE
Add metrics to time the processing of the adapter

### DIFF
--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import io.micrometer.core.instrument.DistributionSummary;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -1216,7 +1217,8 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IM
 						log.debug("{} activating TimeoutGuard with transactionTimeout [{}]s", logPrefix, getTransactionTimeout());
 						tg.activateGuard(getTransactionTimeout());
 
-						pipeLineResult = adapter.processMessageWithExceptions(messageId, compactedMessage, session);
+						Timer timer = configurationMetrics.createTimer(this, FrankMeterType.RECEIVER_PROCESSING_DURATION);
+						pipeLineResult = timer.recordCallable(() -> adapter.processMessageWithExceptions(messageId, compactedMessage, session));
 
 						session.setExitState(pipeLineResult);
 						result=pipeLineResult.getResult();

--- a/core/src/main/java/org/frankframework/statistics/FrankMeterType.java
+++ b/core/src/main/java/org/frankframework/statistics/FrankMeterType.java
@@ -34,11 +34,11 @@ public enum FrankMeterType {
 	PIPELINE_PROCESSED("frank.pipeline.messagesProcessed", Meter.Type.COUNTER),
 	PIPELINE_IN_PROCESS("frank.pipeline.messagesInProcess", Meter.Type.GAUGE),
 
-
 	RECEIVER_DURATION("frank.receiver.duration", Meter.Type.DISTRIBUTION_SUMMARY, FrankMeterType.TIME_UNIT),
 	RECEIVER_RECEIVED("frank.receiver.messagesReceived", Meter.Type.COUNTER),
 	RECEIVER_REJECTED("frank.receiver.messagesRejected", Meter.Type.COUNTER),
-	RECEIVER_RETRIED("frank.receiver.messagesRetried", Meter.Type.COUNTER);
+	RECEIVER_RETRIED("frank.receiver.messagesRetried", Meter.Type.COUNTER),
+	RECEIVER_PROCESSING_DURATION("frank.receiver.processingDuration", Meter.Type.TIMER, FrankMeterType.TIME_UNIT);
 
 	public static final String TIME_UNIT = "ms";
 	public static final String SIZE_UNIT = "B";

--- a/core/src/main/java/org/frankframework/statistics/MetricsInitializer.java
+++ b/core/src/main/java/org/frankframework/statistics/MetricsInitializer.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.frankframework.core.Adapter;
@@ -104,6 +105,10 @@ public class MetricsInitializer implements InitializingBean, DisposableBean, App
 	public DistributionSummary createThreadBasedDistributionSummary(Receiver<?> receiver, FrankMeterType type, int threadNumber) {
 		List<Tag> tags = getTags(receiver, receiver.getName(), Collections.singletonList(Tag.of("thread", ""+threadNumber)));
 		return createDistributionSummary(type, tags);
+	}
+
+	public Timer createTimer(@Nonnull IConfigurationAware frankElement, FrankMeterType frankMeterType) {
+		return Timer.builder(frankMeterType.getMeterName()).tags(getTags(frankElement, frankElement.getName(), null)).register(meterRegistry);
 	}
 
 	public Gauge createGauge(@Nonnull Adapter frankElement, @Nonnull FrankMeterType type, Supplier<Number> numberSupplier) {


### PR DESCRIPTION
Ik heb geprobeerd dit af te leiden van https://github.com/frankframework/frankframework/pull/4554 - maar ik heb het idee dat dat niet meer volledig toepasbaar is icm micrometer. Ik heb nu, naar aanleiding van ons overleg, de call die de `Receiver` doet gewrapt met een timer. Dit lijkt te doen wat ik verwacht, de tijd wordt netjes vastgelegd (bv met een breakpoint in een van de pipes) en komt terug in de prometheus output.

@nielsm5 Zou je eens kunnen kijken of dit een beetje is wat je bedoelde?