### PR TITLE
Fix invalid element name in SaxElementBuilder

### DIFF
--- a/commons/src/main/java/org/frankframework/util/HttpUtils.java
+++ b/commons/src/main/java/org/frankframework/util/HttpUtils.java
@@ -55,7 +55,7 @@ public class HttpUtils {
 		Enumeration<String> paramnames = request.getParameterNames();
 		while (paramnames.hasMoreElements()) {
 			String paramname = StringEscapeUtils.escapeJava(paramnames.nextElement());
-			String paramvalue = request.getParameter(paramname);
+			String paramvalue = StringEscapeUtils.escapeJava(request.getParameter(paramname));
 			if (StringUtils.isNotEmpty(paramvalue)) {
 				if (result.length() > 0) {
 					result = result + ",";

--- a/core/src/main/java/org/frankframework/pipes/CsvParserPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/CsvParserPipe.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Map.Entry;
 
+import lombok.Getter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -31,12 +32,9 @@ import org.frankframework.doc.ElementType;
 import org.frankframework.doc.ElementType.ElementTypes;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageBuilder;
-import org.frankframework.util.XmlEncodingUtils;
 import org.frankframework.xml.SaxDocumentBuilder;
 import org.frankframework.xml.SaxElementBuilder;
 import org.xml.sax.SAXException;
-
-import lombok.Getter;
 
 /**
  * Reads a message in CSV format, and turns it into XML.
@@ -117,10 +115,10 @@ public class CsvParserPipe extends FixedForwardPipe {
 
 	private void processCsvRecord(final CSVRecord csvRecord, final SaxDocumentBuilder document) throws PipeRunException {
 		try (SaxElementBuilder element = document.startElement("record")) {
-			for(Entry<String,String> entry: csvRecord.toMap().entrySet()) {
-				String key = XmlEncodingUtils.stripNonValidXmlCharacters(entry.getKey().replace(' ', '_'), false);
-				if(getHeaderCase() != null) {
-					key = getHeaderCase()==HeaderCase.LOWERCASE ? key.toLowerCase() : key.toUpperCase();
+			for (Entry<String,String> entry: csvRecord.toMap().entrySet()) {
+				String key = entry.getKey();
+				if (getHeaderCase() != null) {
+					key = getHeaderCase() == HeaderCase.LOWERCASE ? key.toLowerCase() : key.toUpperCase();
 				}
 				element.addElement(key, entry.getValue());
 			}

--- a/core/src/main/java/org/frankframework/util/XmlBuilder.java
+++ b/core/src/main/java/org/frankframework/util/XmlBuilder.java
@@ -58,7 +58,7 @@ public class XmlBuilder {
 	private List<String> cdata;
 
 	public XmlBuilder(String tagName) {
-		root = tagName;
+		root = XmlUtils.cleanseElementName(tagName);
 	}
 
 	public static XmlBuilder create(String tagName) {

--- a/core/src/main/java/org/frankframework/xml/SaxElementBuilder.java
+++ b/core/src/main/java/org/frankframework/xml/SaxElementBuilder.java
@@ -60,7 +60,7 @@ public class SaxElementBuilder implements AutoCloseable {
 
 	private SaxElementBuilder(String elementName, ContentHandler handler, SaxElementBuilder parent) {
 		this.handler = handler;
-		this.elementName = elementName;
+		this.elementName = XmlUtils.cleanseElementName(elementName);
 		this.parent = parent;
 		if (elementName!=null) {
 			attributes = new AttributesImpl();

--- a/core/src/main/java/org/frankframework/xml/SaxElementBuilder.java
+++ b/core/src/main/java/org/frankframework/xml/SaxElementBuilder.java
@@ -126,12 +126,14 @@ public class SaxElementBuilder implements AutoCloseable {
 	}
 
 	public SaxElementBuilder startElement(String elementName) throws SAXException {
-		if (elementName==null) {
+		String cleanElementName = XmlUtils.cleanseElementName(elementName);
+
+		if (cleanElementName==null) {
 			promotedToObject = true;
 			return this;
 		}
 		writePendingStartElement();
-		return new SaxElementBuilder(elementName, handler, this);
+		return new SaxElementBuilder(cleanElementName, handler, this);
 	}
 
 	public void addElement(String elementName) throws SAXException {

--- a/core/src/test/java/org/frankframework/pipes/CsvParserPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CsvParserPipeTest.java
@@ -7,14 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
 
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.core.PipeStartException;
 import org.frankframework.pipes.CsvParserPipe.HeaderCase;
 import org.frankframework.stream.UrlMessage;
 import org.frankframework.testutil.TestFileUtils;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 
 public class CsvParserPipeTest extends PipeTestBase<CsvParserPipe> {
 
@@ -72,6 +73,17 @@ public class CsvParserPipeTest extends PipeTestBase<CsvParserPipe> {
 
 		PipeRunResult prr = doPipe(csv);
 		assertXmlEquals(expected,prr.getResult().asString());
+	}
+
+	@Test
+	public void testFieldNamesWithInvalidElementName() throws Exception {
+		pipe.setFieldNames("naam,woonplaats+postcode,land");
+		configureAndStartPipe();
+		String csv = "Frank,Rotterdam+3014GT,Frankland\nFrank2,Rotterdam+1234AB,Nederland";
+		String expected = "<csv><record><naam>Frank</naam><woonplaats_postcode>Rotterdam+3014GT</woonplaats_postcode><land>Frankland</land></record><record><naam>Frank2</naam><woonplaats_postcode>Rotterdam+1234AB</woonplaats_postcode><land>Nederland</land></record></csv>";
+
+		PipeRunResult prr = doPipe(csv);
+		assertXmlEquals(expected, prr.getResult().asString());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/pipes/CsvParserPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CsvParserPipeTest.java
@@ -9,6 +9,8 @@ import java.net.URL;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeRunResult;
@@ -75,9 +77,10 @@ public class CsvParserPipeTest extends PipeTestBase<CsvParserPipe> {
 		assertXmlEquals(expected,prr.getResult().asString());
 	}
 
-	@Test
-	public void testFieldNamesWithInvalidElementName() throws Exception {
-		pipe.setFieldNames("naam,woonplaats+postcode,land");
+	@ParameterizedTest
+	@ValueSource(strings = {"naam,woonplaats+postcode,land", "naam,woonplaats postcode,land"})
+	public void testFieldNamesWithInvalidElementName(String fieldNames) throws Exception {
+		pipe.setFieldNames(fieldNames);
 		configureAndStartPipe();
 		String csv = "Frank,Rotterdam+3014GT,Frankland\nFrank2,Rotterdam+1234AB,Nederland";
 		String expected = "<csv><record><naam>Frank</naam><woonplaats_postcode>Rotterdam+3014GT</woonplaats_postcode><land>Frankland</land></record><record><naam>Frank2</naam><woonplaats_postcode>Rotterdam+1234AB</woonplaats_postcode><land>Nederland</land></record></csv>";


### PR DESCRIPTION
The SaxElementBuilder didn't check element names for invalid values. Fixed the last Sonar security issue from #7277  as well