### PR TITLE
Fix copy paste error in AOP config

### DIFF
--- a/ladybug/src/main/resources/springIbisDebuggerAdvice.xml
+++ b/ladybug/src/main/resources/springIbisDebuggerAdvice.xml
@@ -33,7 +33,7 @@
 					args(pipeLine, messageId, message, pipeLineSession, ..)
 					"
 				method="debugPipeLineInputOutputAbort"
-				arg-names="pipeLine, correlationId, message, pipeLineSession"
+				arg-names="pipeLine, messageId, message, pipeLineSession"
 			/>
 			<aop:around
 				pointcut=


### PR DESCRIPTION
(cherry picked from commit d2e109749fe4c177aa3c8e3321cb425f75f5f448)