### PR TITLE
Remove component annotation from console frontend servlet

### DIFF
--- a/console/frontend/src/main/java/org/frankframework/console/ConsoleFrontend.java
+++ b/console/frontend/src/main/java/org/frankframework/console/ConsoleFrontend.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2023 - 2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,24 +22,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.frankframework.util.ClassUtils;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.context.annotation.Scope;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
-import org.springframework.util.ResourceUtils;
-
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.util.ResourceUtils;
+
+import org.frankframework.util.ClassUtils;
 
 /**
  * Contains the component annotation so it will be picked up by the core (SpringEnvironmentContext.xml).
@@ -50,8 +48,6 @@ import lombok.extern.log4j.Log4j2;
  * @author Niels Meijer
  */
 @Log4j2
-@Component
-@Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
 public class ConsoleFrontend extends HttpServlet implements EnvironmentAware, InitializingBean {
 
 	private static final long serialVersionUID = 1L;

--- a/core/src/main/java/org/frankframework/pipes/Base64Pipe.java
+++ b/core/src/main/java/org/frankframework/pipes/Base64Pipe.java
@@ -79,7 +79,7 @@ public class Base64Pipe extends FixedForwardPipe {
 
 	@Override
 	public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
-		boolean directionEncode = getDirection()==Direction.ENCODE;//TRUE encode - FALSE decode
+		boolean directionEncode = getDirection() == Direction.ENCODE;// TRUE encode - FALSE decode
 
 		InputStream binaryInputStream;
 		try {


### PR DESCRIPTION
Due to the component-scan picking up the annotations twice the console frontend was loaded in without a servlet-path, causing it to listen to all endpoints.