### PR TITLE
Fix maven build warnings (mostly usage of deprecated methods)

### DIFF
--- a/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
+++ b/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
@@ -18,8 +18,12 @@ package org.frankframework.batch;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.springframework.context.ApplicationContext;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.IWithParameters;
@@ -30,10 +34,6 @@ import org.frankframework.parameters.ParameterList;
 import org.frankframework.util.ClassUtils;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.StringUtil;
-import org.springframework.context.ApplicationContext;
-
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Abstract class that contains functionality for parsing the field values from a
@@ -43,6 +43,7 @@ import lombok.Setter;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public abstract class AbstractRecordHandler implements IRecordHandler, IWithParameters {
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();

--- a/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
+++ b/batch/src/main/java/org/frankframework/batch/AbstractRecordHandler.java
@@ -43,7 +43,6 @@ import org.frankframework.util.StringUtil;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public abstract class AbstractRecordHandler implements IRecordHandler, IWithParameters {
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();

--- a/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
+++ b/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
@@ -23,8 +23,9 @@ import java.io.InputStream;
 
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.core.PipeLineSession;
+
 import org.frankframework.core.IPipe;
+import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.stream.Message;
@@ -44,6 +45,7 @@ import org.frankframework.util.FileUtils;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class BatchFileTransformerPipe extends StreamTransformerPipe {
 
 	private @Getter String move2dirAfterTransform;

--- a/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
+++ b/batch/src/main/java/org/frankframework/batch/BatchFileTransformerPipe.java
@@ -45,7 +45,6 @@ import org.frankframework.util.FileUtils;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class BatchFileTransformerPipe extends StreamTransformerPipe {
 
 	private @Getter String move2dirAfterTransform;

--- a/batch/src/main/java/org/frankframework/batch/FieldPositionRecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/FieldPositionRecordHandlerManager.java
@@ -27,7 +27,6 @@ import org.frankframework.core.PipeLineSession;
  * @author John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class FieldPositionRecordHandlerManager extends RecordHandlerManager {
 
 	private @Getter int fieldNr;

--- a/batch/src/main/java/org/frankframework/batch/FieldPositionRecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/FieldPositionRecordHandlerManager.java
@@ -16,6 +16,7 @@
 package org.frankframework.batch;
 
 import lombok.Getter;
+
 import org.frankframework.core.PipeLineSession;
 
 /**
@@ -23,10 +24,10 @@ import org.frankframework.core.PipeLineSession;
  * position in a record. The fields in the record are separated by a separator.
  * The value of the specified field is taken as key in the flow-table.
  *
- *
  * @author John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class FieldPositionRecordHandlerManager extends RecordHandlerManager {
 
 	private @Getter int fieldNr;

--- a/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
@@ -30,7 +30,6 @@ import org.frankframework.core.PipeLineSession;
  * @author John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class FixedPositionRecordHandlerManager extends RecordHandlerManager {
 
 	private @Getter int startPosition;

--- a/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
@@ -18,6 +18,7 @@ package org.frankframework.batch;
 import java.util.Map;
 
 import lombok.Getter;
+
 import org.frankframework.core.PipeLineSession;
 
 /**
@@ -29,6 +30,7 @@ import org.frankframework.core.PipeLineSession;
  * @author John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class FixedPositionRecordHandlerManager extends RecordHandlerManager {
 
 	private @Getter int startPosition;

--- a/batch/src/main/java/org/frankframework/batch/RecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordHandlerManager.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import lombok.Getter;
 import org.apache.logging.log4j.Logger;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.util.LogUtil;
@@ -32,6 +33,7 @@ import org.frankframework.util.LogUtil;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class RecordHandlerManager implements IRecordHandlerManager {
 	protected Logger log = LogUtil.getLogger(this);
 

--- a/batch/src/main/java/org/frankframework/batch/RecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordHandlerManager.java
@@ -33,7 +33,6 @@ import org.frankframework.util.LogUtil;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class RecordHandlerManager implements IRecordHandlerManager {
 	protected Logger log = LogUtil.getLogger(this);
 

--- a/batch/src/main/java/org/frankframework/batch/RecordHandlingFlow.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordHandlingFlow.java
@@ -30,11 +30,9 @@ import org.frankframework.util.LogUtil;
  * The flow contains the handlers to handle records of a specific type.
  * Each flow is registered to a manager using the recordHandlerManagerRef.
  *
- *
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 @FrankDocGroup(FrankDocGroupValue.BATCH)
 public final class RecordHandlingFlow {
 	protected Logger log = LogUtil.getLogger(this);

--- a/batch/src/main/java/org/frankframework/batch/RecordHandlingFlow.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordHandlingFlow.java
@@ -17,14 +17,14 @@ package org.frankframework.batch;
 
 import java.util.Map;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.doc.FrankDocGroup;
 import org.frankframework.doc.FrankDocGroupValue;
 import org.frankframework.util.LogUtil;
-
-import lombok.Getter;
 
 /**
  * The flow contains the handlers to handle records of a specific type.
@@ -34,6 +34,7 @@ import lombok.Getter;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 @FrankDocGroup(FrankDocGroupValue.BATCH)
 public final class RecordHandlingFlow {
 	protected Logger log = LogUtil.getLogger(this);

--- a/batch/src/main/java/org/frankframework/batch/RecordTransformer.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordTransformer.java
@@ -37,7 +37,6 @@ import org.frankframework.util.StringUtil;
 /**
  * Translate a record using an outputFields description.
  *
- *
  * The {@link #setOutputFields(String) outputFields} description can contain the following functions:
  *
  * <table border="1">
@@ -58,7 +57,6 @@ import org.frankframework.util.StringUtil;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class RecordTransformer extends AbstractRecordHandler {
 
 	private String outputSeparator;

--- a/batch/src/main/java/org/frankframework/batch/RecordTransformer.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordTransformer.java
@@ -29,6 +29,7 @@ import java.util.StringTokenizer;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.util.StringUtil;
@@ -57,6 +58,7 @@ import org.frankframework.util.StringUtil;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class RecordTransformer extends AbstractRecordHandler {
 
 	private String outputSeparator;

--- a/batch/src/main/java/org/frankframework/batch/RecordXml2Sender.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordXml2Sender.java
@@ -18,6 +18,7 @@ package org.frankframework.batch;
 import java.util.List;
 
 import lombok.Getter;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.ISender;
 import org.frankframework.core.ISenderWithParameters;
@@ -34,6 +35,7 @@ import org.frankframework.util.ClassUtils;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class RecordXml2Sender extends RecordXmlTransformer {
 
 	private @Getter ISender sender = null;

--- a/batch/src/main/java/org/frankframework/batch/RecordXml2Sender.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordXml2Sender.java
@@ -35,7 +35,6 @@ import org.frankframework.util.ClassUtils;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class RecordXml2Sender extends RecordXmlTransformer {
 
 	private @Getter ISender sender = null;

--- a/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
@@ -19,9 +19,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.parameters.ParameterList;
@@ -35,10 +35,10 @@ import org.frankframework.util.XmlBuilder;
 /**
  * Encapsulates a record in XML, optionally translates it using XSLT or XPath.
  *
- *
  * @author  John Dekker / Gerrit van Brakel
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class RecordXmlTransformer extends AbstractRecordHandler {
 
 	private @Getter String rootTag="record";

--- a/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
+++ b/batch/src/main/java/org/frankframework/batch/RecordXmlTransformer.java
@@ -38,7 +38,6 @@ import org.frankframework.util.XmlBuilder;
  * @author  John Dekker / Gerrit van Brakel
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class RecordXmlTransformer extends AbstractRecordHandler {
 
 	private @Getter String rootTag="record";

--- a/batch/src/main/java/org/frankframework/batch/Result2Filewriter.java
+++ b/batch/src/main/java/org/frankframework/batch/Result2Filewriter.java
@@ -34,7 +34,6 @@ import org.frankframework.util.FileUtils;
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class Result2Filewriter extends ResultWriter {
 
 	private @Getter String outputDirectory;

--- a/batch/src/main/java/org/frankframework/batch/Result2Filewriter.java
+++ b/batch/src/main/java/org/frankframework/batch/Result2Filewriter.java
@@ -22,20 +22,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import lombok.Getter;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.util.FileUtils;
-
 
 /**
  * Resulthandler that writes the transformed record to a file.
  *
- *
  * @author  John Dekker
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class Result2Filewriter extends ResultWriter {
 
 	private @Getter String outputDirectory;

--- a/batch/src/main/java/org/frankframework/batch/Result2StringWriter.java
+++ b/batch/src/main/java/org/frankframework/batch/Result2StringWriter.java
@@ -28,6 +28,7 @@ import org.frankframework.core.PipeLineSession;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class Result2StringWriter extends ResultWriter {
 
 	@Override

--- a/batch/src/main/java/org/frankframework/batch/Result2StringWriter.java
+++ b/batch/src/main/java/org/frankframework/batch/Result2StringWriter.java
@@ -20,7 +20,6 @@ import java.io.Writer;
 
 import org.frankframework.core.PipeLineSession;
 
-
 /**
  * Resulthandler that writes the transformed record to a String, that is passed to the next Pipe literally.
  *
@@ -28,7 +27,6 @@ import org.frankframework.core.PipeLineSession;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class Result2StringWriter extends ResultWriter {
 
 	@Override

--- a/batch/src/main/java/org/frankframework/batch/ResultBlock2Sender.java
+++ b/batch/src/main/java/org/frankframework/batch/ResultBlock2Sender.java
@@ -39,7 +39,6 @@ import org.frankframework.util.ClassUtils;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 public class ResultBlock2Sender extends Result2StringWriter {
 
 	private @Getter ISender sender = null;

--- a/batch/src/main/java/org/frankframework/batch/ResultBlock2Sender.java
+++ b/batch/src/main/java/org/frankframework/batch/ResultBlock2Sender.java
@@ -19,9 +19,9 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import lombok.Getter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.ISender;
 import org.frankframework.core.ISenderWithParameters;
@@ -39,6 +39,7 @@ import org.frankframework.util.ClassUtils;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 public class ResultBlock2Sender extends Result2StringWriter {
 
 	private @Getter ISender sender = null;

--- a/batch/src/main/java/org/frankframework/batch/StreamTransformerPipe.java
+++ b/batch/src/main/java/org/frankframework/batch/StreamTransformerPipe.java
@@ -54,7 +54,6 @@ import org.frankframework.util.StreamUtil;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
-@Deprecated
 @ElementType(ElementTypes.TRANSLATOR)
 public class StreamTransformerPipe extends FixedForwardPipe {
 

--- a/batch/src/main/java/org/frankframework/batch/StreamTransformerPipe.java
+++ b/batch/src/main/java/org/frankframework/batch/StreamTransformerPipe.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.SuppressKeys;
@@ -53,6 +54,7 @@ import org.frankframework.util.StreamUtil;
  * @since   4.7
  * @deprecated Warning: non-maintained functionality.
  */
+@Deprecated
 @ElementType(ElementTypes.TRANSLATOR)
 public class StreamTransformerPipe extends FixedForwardPipe {
 

--- a/core/src/test/java/org/frankframework/compression/TestZipWriterPipe.java
+++ b/core/src/test/java/org/frankframework/compression/TestZipWriterPipe.java
@@ -12,6 +12,11 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.util.MimeType;
+
 import org.frankframework.collection.Collection;
 import org.frankframework.collection.CollectorPipeBase.Action;
 import org.frankframework.collection.TestCollector;
@@ -25,9 +30,6 @@ import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
 import org.frankframework.testutil.ParameterBuilder;
 import org.frankframework.util.StreamUtil;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.util.MimeType;
 
 public class TestZipWriterPipe extends PipeTestBase<ZipWriterPipe> {
 
@@ -60,7 +62,7 @@ public class TestZipWriterPipe extends PipeTestBase<ZipWriterPipe> {
 
 	@Test
 	void testChangeCollectionName() throws Exception {
-		pipe.setZipWriterHandle("test123");
+		pipe.setCollectionName("test123");
 		pipe.setAction(Action.OPEN);
 		configureAndStartPipe();
 		assertEquals("test123", pipe.getCollectionName());

--- a/core/src/test/java/org/frankframework/core/PipeLineTest.java
+++ b/core/src/test/java/org/frankframework/core/PipeLineTest.java
@@ -6,16 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
+import org.hamcrest.core.StringEndsWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLine.ExitState;
 import org.frankframework.pipes.AbstractPipe;
 import org.frankframework.pipes.EchoPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.TestConfiguration;
-import org.hamcrest.core.StringEndsWith;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation") //Part of the tests!
 public class PipeLineTest {
@@ -38,7 +39,7 @@ public class PipeLineTest {
 		PipeLine pipeline = new PipeLine();
 		pipeline.setApplicationContext(configuration);
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("success");
+		exit.setName("success");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.registerPipeLineExit(exit);
@@ -66,7 +67,7 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.configure();
@@ -96,15 +97,15 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit errorExit = new PipeLineExit();
-		errorExit.setPath("error");
+		errorExit.setName("error");
 		errorExit.setState(ExitState.ERROR);
 		pipeline.registerPipeLineExit(errorExit);
 		PipeLineExit successExit = new PipeLineExit();
-		successExit.setPath("exit");
+		successExit.setName("exit");
 		successExit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(successExit);
 		PipeLineExit successExit2 = new PipeLineExit();
-		successExit2.setPath("exit2");
+		successExit2.setName("exit2");
 		successExit2.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(successExit2);
 
@@ -138,7 +139,7 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.configure();
@@ -173,7 +174,7 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.configure();
@@ -204,7 +205,7 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("special exit name");
+		exit.setName("special exit name");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.configure();
@@ -243,7 +244,7 @@ public class PipeLineTest {
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 		pipeline.configure();

--- a/core/src/test/java/org/frankframework/http/HttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/HttpSenderTest.java
@@ -26,6 +26,9 @@ import static org.mockito.Mockito.spy;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
 
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
@@ -38,8 +41,6 @@ import org.frankframework.stream.MessageContext;
 import org.frankframework.stream.UrlMessage;
 import org.frankframework.testutil.ParameterBuilder;
 import org.frankframework.testutil.TestFileUtils;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 
 public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 
@@ -700,7 +701,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		PipeLineSession pls = new PipeLineSession(session);
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 		sender.setFirstBodyPartName("request");
 
 		String xmlMultipart = """
@@ -722,7 +722,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 	}
 
 	@Test
-	public void multipartithoutFirstBodyPartName() throws Throwable {
+	public void multipartWithoutFirstBodyPartName() throws Throwable {
 		sender = getSender();
 		Message input = new Message("<xml>input</xml>");
 
@@ -756,7 +756,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		PipeLineSession pls = new PipeLineSession(session);
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 
 		String xmlMultipart = """
 				<parts><part type="file" name="document.pdf" \
@@ -817,7 +816,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		Message input = new Message("<xml>input</xml>");
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 		sender.setFirstBodyPartName("request");
 		sender.setPostType(PostType.MTOM);
 		sender.setMtomContentTransferEncoding("base64");
@@ -887,7 +885,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		Message input = new Message("<xml>input</xml>");
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 		sender.setFirstBodyPartName("request");
 		sender.setPostType(PostType.MTOM);
 		sender.setMtomContentTransferEncoding("base64");
@@ -954,7 +951,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		PipeLineSession pls = new PipeLineSession(session);
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 		sender.setFirstBodyPartName("request");
 
 		String xmlMultipart = """
@@ -987,7 +983,6 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		PipeLineSession pls = new PipeLineSession(session);
 
 		sender.setMethodType(HttpMethod.POST);
-		sender.setParamsInUrl(false);
 		sender.setFirstBodyPartName("request");
 		sender.setParametersToSkipWhenEmpty("empty-param");
 

--- a/core/src/test/java/org/frankframework/http/WebServiceSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/WebServiceSenderTest.java
@@ -20,12 +20,13 @@ import static org.mockito.Mockito.spy;
 
 import java.io.ByteArrayInputStream;
 
+import org.junit.jupiter.api.Test;
+
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.http.HttpSenderBase.HttpMethod;
 import org.frankframework.parameters.Parameter;
 import org.frankframework.stream.Message;
-import org.junit.jupiter.api.Test;
 
 public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 
@@ -83,7 +84,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-			sender.setParamsInUrl(false);
+			//sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -115,7 +116,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-			sender.setParamsInUrl(false);
+//			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -149,7 +150,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-			sender.setParamsInUrl(false);
+//			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -181,7 +182,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 		try {
 			PipeLineSession pls = new PipeLineSession(session);
 
-			sender.setParamsInUrl(false);
+//			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("file");
 			sender.setPostType(HttpSender.PostType.FORMDATA);
 			sender.setAllowSelfSignedCertificates(true);

--- a/core/src/test/java/org/frankframework/http/WebServiceSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/WebServiceSenderTest.java
@@ -84,7 +84,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-			//sender.setParamsInUrl(false);
+			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -116,7 +116,7 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-//			sender.setParamsInUrl(false);
+			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -150,7 +150,6 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 			PipeLineSession pls = new PipeLineSession(session);
 
 			sender.setMethodType(HttpMethod.POST);
-//			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("request");
 
 			String xmlMultipart = """
@@ -182,7 +181,6 @@ public class WebServiceSenderTest extends HttpSenderTestBase<WebServiceSender> {
 		try {
 			PipeLineSession pls = new PipeLineSession(session);
 
-//			sender.setParamsInUrl(false);
 			sender.setFirstBodyPartName("file");
 			sender.setPostType(HttpSender.PostType.FORMDATA);
 			sender.setAllowSelfSignedCertificates(true);

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationUtils;
 import org.frankframework.core.ParameterException;
@@ -52,8 +55,6 @@ import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.util.DateFormatUtils;
 import org.frankframework.util.XmlUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 
 public class ParameterTest {
 
@@ -1066,7 +1067,7 @@ public class ParameterTest {
 			pipeline.addPipe(pipe2);
 
 			PipeLineExit exit = new PipeLineExit();
-			exit.setPath("exit");
+			exit.setName("exit");
 			exit.setState(ExitState.SUCCESS);
 			pipeline.registerPipeLineExit(exit);
 			pipeline.configure();

--- a/core/src/test/java/org/frankframework/pipes/ChecksumPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ChecksumPipeTest.java
@@ -18,6 +18,7 @@ import org.frankframework.pipes.hash.Algorithm;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.TestFileUtils;
 
+
 public class ChecksumPipeTest extends PipeTestBase<ChecksumPipe> {
 
 	@Override

--- a/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
+++ b/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
 
+import org.junit.jupiter.api.Test;
+
 import org.frankframework.core.Adapter;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeLine;
@@ -17,7 +19,6 @@ import org.frankframework.pipes.XmlValidator;
 import org.frankframework.testutil.TestAssertions;
 import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TestFileUtils;
-import org.junit.jupiter.api.Test;
 
 public class WsdlGeneratorTest {
 
@@ -31,7 +32,7 @@ public class WsdlGeneratorTest {
 		pipeline.addPipe(pipe);
 
 		PipeLineExit exit = new PipeLineExit();
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 

--- a/nn-specials/src/main/java/org/frankframework/errormessageformatters/Y01ErrorMessageFormatter.java
+++ b/nn-specials/src/main/java/org/frankframework/errormessageformatters/Y01ErrorMessageFormatter.java
@@ -27,6 +27,7 @@ import org.frankframework.util.DateFormatUtils;
  *
  * @author Johan Verrips IOS
  */
+@Deprecated
 public class Y01ErrorMessageFormatter extends ErrorMessageFormatter {
 	private final String applicationName = AppConstants.getInstance().getProperty("application.name");
 	private final String applicationVersion = AppConstants.getInstance().getProperty("application.version");

--- a/nn-specials/src/test/java/org/frankframework/core/TestDirectWrapperPipePipeLine.java
+++ b/nn-specials/src/test/java/org/frankframework/core/TestDirectWrapperPipePipeLine.java
@@ -53,7 +53,7 @@ public class TestDirectWrapperPipePipeLine {
 		pipeline.addPipe(echoPipe);
 
 		PipeLineExit exit = configuration.createBean(PipeLineExit.class);
-		exit.setPath("exit");
+		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
 		pipeline.registerPipeLineExit(exit);
 


### PR DESCRIPTION
Fix a number of (easily fixable) maven build warnings. 
* Added `@Deprecated` annotation on classes already using '@deprecated' in the javadoc.
* Changed method calls to use the non-deprecated variant.