### PR TITLE
Add ff-info tags to point out the default value of trimSpaces

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/DirectQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/DirectQuerySender.java
@@ -36,6 +36,7 @@ import org.frankframework.util.ClassUtils;
  * QuerySender that interprets the input message as a query, possibly with attributes.
  * Messages are expected to contain sql-text.
  *
+ * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @ff.parameters All parameters present are applied to the query to be executed.
  *
  * @author  Gerrit van Brakel

--- a/core/src/main/java/org/frankframework/jdbc/FixedQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/FixedQuerySender.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
@@ -34,6 +35,7 @@ import org.frankframework.util.DB2XMLWriter;
  *
  * <p><b>NOTE:</b> See {@link DB2XMLWriter} for ResultSet!</p>
  *
+ * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @ff.parameters All parameters present are applied to the query to be executed.
  *
  * @author  Gerrit van Brakel

--- a/core/src/main/java/org/frankframework/jdbc/FixedQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/FixedQuerySender.java
@@ -33,8 +33,7 @@ import org.frankframework.util.DB2XMLWriter;
 /**
  * QuerySender that assumes a fixed query, possibly with attributes.
  *
- * <p><b>NOTE:</b> See {@link DB2XMLWriter} for ResultSet!</p>
- *
+ * @ff.info See {@link DB2XMLWriter} for ResultSet!
  * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @ff.parameters All parameters present are applied to the query to be executed.
  *

--- a/core/src/main/java/org/frankframework/jdbc/ResultSet2FileSender.java
+++ b/core/src/main/java/org/frankframework/jdbc/ResultSet2FileSender.java
@@ -27,7 +27,9 @@ import java.util.Date;
 
 import jakarta.annotation.Nonnull;
 
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.ParameterException;
 import org.frankframework.core.PipeLineSession;
@@ -37,11 +39,10 @@ import org.frankframework.dbms.JdbcException;
 import org.frankframework.stream.Message;
 import org.frankframework.util.JdbcUtil;
 
-import lombok.Getter;
-
 /**
  * QuerySender that writes each row in a ResultSet to a file.
  *
+ * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @author  Peter Leeuwenburgh
  */
 public class ResultSet2FileSender extends FixedQuerySender {

--- a/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
@@ -30,7 +30,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jakarta.jms.JMSException;
+
 import org.apache.commons.lang3.StringUtils;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.SuppressKeys;
@@ -45,8 +48,6 @@ import org.frankframework.pipes.Base64Pipe;
 import org.frankframework.stream.Message;
 import org.frankframework.util.DB2XMLWriter;
 import org.frankframework.util.JdbcUtil;
-
-import jakarta.jms.JMSException;
 
 /**
  * StoredProcedureQuerySender is used to send stored procedure queries and retrieve the result.
@@ -144,6 +145,7 @@ import jakarta.jms.JMSException;
  * <p><em>NOTE:</em> Support for stored procedures is currently experimental and changes in the currently produced output-format
  * are expected.</p>
  *
+ * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @ff.parameters All parameters present are applied to the query to be executed.
  *
  * @since 7.9

--- a/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
@@ -142,9 +142,7 @@ import org.frankframework.util.JdbcUtil;
  * 	</resultset>
  * }</pre>
  * </p>
- * <p><em>NOTE:</em> Support for stored procedures is currently experimental and changes in the currently produced output-format
- * are expected.</p>
- *
+ * @ff.info Support for stored procedures is currently experimental and changes in the currently produced output-format are expected.
  * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @ff.parameters All parameters present are applied to the query to be executed.
  *

--- a/core/src/main/java/org/frankframework/jdbc/XmlQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/XmlQuerySender.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
@@ -44,8 +47,6 @@ import org.frankframework.util.DomBuilderException;
 import org.frankframework.util.JdbcUtil;
 import org.frankframework.util.StringUtil;
 import org.frankframework.util.XmlUtils;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 /**
  * QuerySender that transforms the input message to a query.
@@ -73,6 +74,7 @@ import org.w3c.dom.Node;
  * }</pre>
  * <br/>
  *
+ * @ff.info Please note that the default value of {@code trimSpaces} is {@literal true}
  * @author  Peter Leeuwenburgh
  */
 public class XmlQuerySender extends DirectQuerySender {

--- a/core/src/test/java/org/frankframework/testutil/mock/FixedQuerySenderMock.java
+++ b/core/src/test/java/org/frankframework/testutil/mock/FixedQuerySenderMock.java
@@ -13,20 +13,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.dbms.JdbcException;
 import org.frankframework.jdbc.FixedQuerySender;
 import org.frankframework.jdbc.datasource.TransactionalDbmsSupportAwareDataSourceProxy;
 import org.frankframework.testutil.TestConfiguration;
-import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 /**
  * Enables the ability to provide a mockable FixedQuerySender. In some places a new QuerySender is created to execute (custom) statements.
  * This allows the result to be mocked.
  *
- * @See {@link TestConfiguration#mockQuery(String, ResultSet)}
- *
+ * @see TestConfiguration#mockQuery(String, ResultSet)
  * @author Niels Meijer
  */
 public class FixedQuerySenderMock extends FixedQuerySender {


### PR DESCRIPTION
Ik heb alvast de nieuwe notatie gehanteerd zoals gespecificeerd in https://github.com/frankframework/frank-doc/issues/210 - of is dat te vroeg?