### PR TITLE
Improve build speed

### DIFF
--- a/console/frontend/pom.xml
+++ b/console/frontend/pom.xml
@@ -98,6 +98,40 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.glassfish.copyright</groupId>
+				<artifactId>glassfish-copyright-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>Check-CopyRight-Notice</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>verify-code-style</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-lib-ban</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>enforce-classpath-lib-ban</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -139,78 +173,9 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.glassfish.copyright</groupId>
-					<artifactId>glassfish-copyright-maven-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>Check-CopyRight-Notice</id>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-checkstyle-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>verify-code-style</id>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-enforcer-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>enforce-lib-ban</id>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-						<execution>
-							<id>enforce-classpath-lib-ban</id>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<configuration>
-						<skip>true</skip>
-					</configuration>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>license.skip</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.glassfish.copyright</groupId>
-						<artifactId>glassfish-copyright-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>Check-CopyRight-Notice</id>
-								<phase>none</phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<reporting>
 		<plugins>
 			<plugin>

--- a/console/frontend/pom.xml
+++ b/console/frontend/pom.xml
@@ -191,6 +191,26 @@
 		</pluginManagement>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>license.skip</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.glassfish.copyright</groupId>
+						<artifactId>glassfish-copyright-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>Check-CopyRight-Notice</id>
+								<phase>none</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<reporting>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Allows you to omit copyright checking for the frontend of the console. Use command `mvn -DskipTests -Plicense.skip install` to also skip running the unit tests.