### PR TITLE
Don't show exit state in ladybug when it's 0

### DIFF
--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -628,7 +628,7 @@ public class Adapter implements IManagable, HasStatistics, NamedBean {
 			decNumOfMessagesInProcess(duration, processingSuccess);
 			Objects.requireNonNull(result, "'result' should never be NULL here, programming error.");
 			ThreadContext.put(LogUtil.MDC_EXIT_STATE_KEY, result.getState().name());
-			if (result.getExitCode() != 0) {
+			if (result.getExitCode() != null) {
 				ThreadContext.put(LogUtil.MDC_EXIT_CODE_KEY, Integer.toString(result.getExitCode()));
 			}
 			ThreadContext.put("pipeline.duration", msgLogHumanReadable ? Misc.getAge(startTime) : Long.toString(duration));

--- a/core/src/main/java/org/frankframework/core/PipeLineExit.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineExit.java
@@ -38,7 +38,7 @@ public class PipeLineExit implements IForwardTarget {
 
 	private @Getter String name;
 	private @Getter ExitState state;
-	private @Getter int exitCode = 0;
+	private @Getter int exitCode = 0; // this should be NULL
 	private @Getter String responseRoot;
 	private @Getter boolean emptyResult = false;
 	private @Getter boolean skipValidation = false;

--- a/core/src/main/java/org/frankframework/core/PipeLineResult.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020, 2022-2023 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020, 2022-2024 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class PipeLineResult {
 
 	private @Setter Message result;
 	private @Setter ExitState state;
-	private @Getter @Setter int exitCode;
+	private @Getter Integer exitCode;
 
 	public boolean isSuccessful() {
 		return getState()==ExitState.SUCCESS;
@@ -51,6 +51,12 @@ public class PipeLineResult {
 
 	public @Nonnull ExitState getState() {
 		return state;
+	}
+
+	public void setExitCode(int exitCode) {
+		if(exitCode > 0) {
+			this.exitCode = exitCode;
+		}
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -94,9 +94,11 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 		super(t);
 	}
 
-	public void setExitState(PipeLine.ExitState state, int code) {
+	public void setExitState(PipeLine.ExitState state, Integer code) {
 		put(EXIT_STATE_CONTEXT_KEY, state);
-		put(EXIT_CODE_CONTEXT_KEY, Integer.toString(code));
+		if(code != null) {
+			put(EXIT_CODE_CONTEXT_KEY, Integer.toString(code));
+		}
 	}
 
 	public void setExitState(PipeLineResult pipeLineResult) {

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -1230,8 +1230,8 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IM
 						}
 						errorMessage += "]";
 
-						int status = pipeLineResult.getExitCode();
-						if(status > 0) {
+						Integer status = pipeLineResult.getExitCode();
+						if(status != null) {
 							errorMessage += ", exitcode ["+status+"]";
 						}
 

--- a/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
@@ -16,6 +16,7 @@
 package org.frankframework.senders;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 import jakarta.annotation.Nonnull;
 import lombok.Getter;
@@ -139,7 +140,7 @@ public class IbisJavaSender extends SenderWithParametersBase implements HasPhysi
 			}
 			ExitState exitState = (ExitState) subAdapterSession.remove(PipeLineSession.EXIT_STATE_CONTEXT_KEY);
 			Object exitCode = subAdapterSession.remove(PipeLineSession.EXIT_CODE_CONTEXT_KEY);
-			String forwardName = exitCode != null ? exitCode.toString() : null;
+			String forwardName = Objects.toString(exitCode, null);
 			return new SenderResult(exitState == null || exitState == ExitState.SUCCESS, new Message(result), "exitState=" + exitState, forwardName);
 		}
 	}

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/Debugger.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/Debugger.java
@@ -105,11 +105,6 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, Applicat
 	}
 
 	@Override
-	public Object pipelineSessionKey(String correlationId, String sessionKey, Object sessionValue) {
-		return testTool.inputpoint(correlationId, null, "SessionKey " + sessionKey, sessionValue);
-	}
-
-	@Override
 	public Message pipelineOutput(PipeLine pipeLine, String correlationId, Message output) {
 		return testTool.endpoint(correlationId, pipeLine.getClass().getName(), getName(pipeLine), output);
 	}
@@ -248,8 +243,22 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, Applicat
 	}
 
 	@Override
-	public Object storeInSessionKey(String correlationId, String sessionKey, Object result) {
-		return testTool.outputpoint(correlationId, null, "SessionKey " + sessionKey, result);
+	public Object sessionOutputPoint(String correlationId, String sessionKey, Object result) {
+		String name = "SessionKey " + sessionKey;
+		if(sessionKey.startsWith(PipeLineSession.SYSTEM_MANAGED_RESOURCE_PREFIX)) {
+			name = "SystemKey " + sessionKey;
+		}
+
+		return testTool.outputpoint(correlationId, null, name, result);
+	}
+
+	@Override
+	public Object sessionInputPoint(String correlationId, String sessionKey, Object result) {
+		String name = "SessionKey " + sessionKey;
+		if(sessionKey.startsWith(PipeLineSession.SYSTEM_MANAGED_RESOURCE_PREFIX)) {
+			name = "SystemKey " + sessionKey;
+		}
+		return testTool.inputpoint(correlationId, null, name, result);
 	}
 
 	@Override

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/IbisDebugger.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/IbisDebugger.java
@@ -39,8 +39,6 @@ public interface IbisDebugger {
 	public Message pipelineAbort(PipeLine pipeLine, String correlationId, Message output);
 	public Throwable pipelineAbort(PipeLine pipeLine, String correlationId, Throwable throwable);
 
-	public Object pipelineSessionKey(String correlationId, String sessionKey, Object sessionValue);
-
 	public <T> T pipeInput(PipeLine pipeLine, IPipe pipe, String correlationId, T input);
 	public <T> T pipeOutput(PipeLine pipeLine, IPipe pipe, String correlationId, T output);
 	public Throwable pipeAbort(PipeLine pipeLine, IPipe pipe, String correlationId, Throwable throwable);
@@ -62,7 +60,10 @@ public interface IbisDebugger {
 	public Object getInputFromSessionKey(String correlationId, String sessionKey, Object sessionValue);
 	public Object getInputFromFixedValue(String correlationId, Object fixedValue);
 	public Object getEmptyInputReplacement(String correlationId, Object replacementValue);
-	public Object storeInSessionKey(String correlationId, String sessionKey, Object result);
+
+	public Object sessionOutputPoint(String correlationId, String sessionKey, Object result);
+	public Object sessionInputPoint(String correlationId, String sessionKey, Object result);
+
 	public Message preserveInput(String correlationId, Message input);
 
 	public Object parameterResolvedTo(IParameter parameter, String correlationId, Object value);

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/IbisDebuggerAdvice.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/IbisDebuggerAdvice.java
@@ -108,7 +108,7 @@ public class IbisDebuggerAdvice implements InitializingBean, ThreadLifeCycleEven
 		while (iterator.hasNext()) {
 			String sessionKey = iterator.next();
 			Object sessionValue = session.get(sessionKey);
-			sessionValue = ibisDebugger.pipelineSessionKey(correlationId, sessionKey, sessionValue);
+			sessionValue = ibisDebugger.sessionInputPoint(correlationId, sessionKey, sessionValue);
 			session.put(sessionKey, sessionValue);
 		}
 		PipeLineResult pipeLineResult = null;
@@ -121,7 +121,7 @@ public class IbisDebuggerAdvice implements InitializingBean, ThreadLifeCycleEven
 			throw ibisDebugger.pipelineAbort(pipeLine, correlationId, throwable);
 		}
 		ibisDebugger.showOutputValue(correlationId, "exitState", pipeLineResult.getState().name());
-		if (pipeLineResult.getExitCode()!=0) {
+		if (pipeLineResult.getExitCode() != null) {
 			ibisDebugger.showOutputValue(correlationId, "exitCode", Integer.toString(pipeLineResult.getExitCode()));
 		}
 

--- a/ladybug/src/main/java/org/frankframework/ibistesttool/PipeLineSessionDebugger.java
+++ b/ladybug/src/main/java/org/frankframework/ibistesttool/PipeLineSessionDebugger.java
@@ -62,13 +62,13 @@ public class PipeLineSessionDebugger implements MethodHandler {
 	}
 
 	private Object getMessage(String name) {
-		Object value = pipeLineSession.getMessage(name);
-		ibisDebugger.showInputValue(pipeLineSession.getCorrelationId(), "SessionKey "+name, value);
+		Message value = pipeLineSession.getMessage(name);
+		ibisDebugger.sessionInputPoint(pipeLineSession.getCorrelationId(), name, value);
 		return value;
 	}
 
 	private Object put(final String name, final Object originalValue) {
-		Object newValue = ibisDebugger.storeInSessionKey(pipeLineSession.getCorrelationId(), name, originalValue);
+		Object newValue = ibisDebugger.sessionOutputPoint(pipeLineSession.getCorrelationId(), name, originalValue);
 		if (newValue != originalValue && newValue instanceof Message message) {
 			// If a session key is stubbed with a stream and this session key is not used (stream is not read) it will
 			// keep the report in progress (waiting for the stream to be read, captured and closed).


### PR DESCRIPTION
Also made it visible that not all sessionkeys are 'normal' keys:
![image](https://github.com/user-attachments/assets/4efedb8a-5652-45af-aaf9-49f4cba8ad54)
(SessionKey vs SystemKey)