### PR TITLE
docs: Update Docker.md to specify new default files and directories

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -49,7 +49,6 @@ Linux:
 docker run -p 80:8080 \
 	-e dtap.stage=LOC \
 	-v ./example/src/main/resources:/opt/frank/resources \
-	-v ./example/src/main/webapp/META-INF/context.xml:/usr/local/tomcat/conf/Catalina/localhost/ROOT.xml \
 	--name Frank2Example \
 	nexus.frankframework.org/frankframework:latest
 ```
@@ -86,39 +85,40 @@ The image contains the following directories:
 
 The image also contains the following files:
 
-| file                                               | description                                          | notes                                                                                                                                                                    |
-|----------------------------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| /usr/local/tomcat/conf/Catalina/localhost/ROOT.xml | mount/copy of your context.xml                       | Use hostname `host.docker.internal` to get to the host machine for local testing. Changing this file will require a new instance to be started, it cannot be reloaded    |
-| /usr/local/tomcat/conf/server.xml                  | mount/copy of your server.xml                        | Contains the default server.xml of Tomcat, replace to secure your application                                                                                            |
-| /usr/local/tomcat/conf/catalina.properties         | Server properties, contains default framework values | Do not replace this file, use [Environment variables](#Environment-variables) or append to the file, see [Dockerfile](docker/appserver/Tomcat/Dockerfile) for an example |
+| file                                       | description                                          | notes                                                                                                                                                                    |
+|--------------------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| /opt/frank/resources/resources.yml         | mount/copy of your resources.yml                     | Use hostname `host.docker.internal` to get to the host machine for local testing. Changing this file will require a new instance to be started, it cannot be reloaded    |
+| /usr/local/tomcat/conf/server.xml          | mount/copy of your server.xml                        | Contains the default server.xml of Tomcat, replace to secure your application                                                                                            |
+| /usr/local/tomcat/conf/catalina.properties | Server properties, contains default framework values | Do not replace this file, use [Environment variables](#Environment-variables) or append to the file, see [Dockerfile](docker/appserver/Tomcat/Dockerfile) for an example |
 
 ## Logging
 
 Generated log files are stored in `/usr/local/tomcat/logs`.
+
+In some cases you might want to change the log appenders, for example to log to stdout. Refer to the [Frank!Framework Manual: Custom Logging](https://frank-manual.readthedocs.io/en/latest/deploying/customLogging.html#custom-logging) for more information.
 
 ## Environment variables
 
 Environment variables can be used to set properties. Environment variables have the highest precedence and override
 application properties set in .property files supplied by Tomcat, resources and configurations.
 
-Environment variables can also be used to replace properties set inside Tomcat configuration files such as `server.xml` and `context.xml`.
+Environment variables can also be used to replace properties set inside Tomcat configuration files such as `resources.yml` and `server.xml`.
 
-Do not use environment variables for secrets!
+Do not use environment variables for secrets! See [Secrets](#Secrets) for more information.
 
 ## Health and readiness
 
-The health and readiness of the container can be monitored by polling the `/iaf/api/server/health` API endpoint. This
-will return a HTTP statuscode of 200 if all adapters are running and a HTTP statuscode of 503 if there are adapters in a
-non-running state.
+The health and readiness of the container can be monitored by polling the `/iaf/api/server/health` API endpoint. This endpoint will return a HTTP statuscode of 200 if the configurations are loaded and a HTTP statuscode of 503 if there are configurations in a non-running state.
+If you want to check the health of the adapters, you can poll the `/iaf/api/configurations/{configuration}/adapters/{name}/health` endpoint. This endpoint will return a HTTP statuscode of 200 if the adapter is running and a HTTP statuscode of 503 if the adapter is in a non-running state.
 
 ## Considerations
 
-The images are based on Tomcat, all restrictions and considerations that apply to Tomcat also apply to using the
+The Frank!Framework image is based on Tomcat, all restrictions and considerations that apply to Tomcat also apply to using the provided images.
 provided images.
 
 ### HTTPS and authentication
 
-Frank!Applications use HTTPS and require authentication unless `dtap.stage=LOC`, but the default server.xml of Tomcat is
+Frank!Framework Applications use HTTPS and require authentication unless `dtap.stage=LOC`, but the default server.xml of Tomcat is
 not configured for inbound HTTPS traffic and user authentication. To configure this, the server.xml file will need to be
 replaced by either building your own image or mounting it at runtime.
 
@@ -126,7 +126,7 @@ replaced by either building your own image or mounting it at runtime.
 
 Special consideration should be taken with secrets. As described on
 the [Tomcat website](https://cwiki.apache.org/confluence/display/TOMCAT/Password), secrets are stored in plain text in
-the container. To use secrets in your Tomcat and Frank!Application configuration, you can take the following steps:
+the container. To use secrets in your Tomcat and Frank!Framework Application configuration, you can take the following steps:
 
 - In your configuration, use the authAlias attribute with value `${<secret-name>}`
 - In cases where you need to use username or password separately (such as the Tomcat context.xml), you can set the

--- a/Docker.md
+++ b/Docker.md
@@ -102,7 +102,7 @@ In some cases you might want to change the log appenders, for example to log to 
 Environment variables can be used to set properties. Environment variables have the highest precedence and override
 application properties set in .property files supplied by Tomcat, resources and configurations.
 
-Environment variables can also be used to replace properties set inside Tomcat configuration files such as `resources.yml` and `server.xml`.
+Though you probably do not need to touch these file, because of the CredentialProvider, environment variables can also be used to replace properties set inside Tomcat specific configuration files such as `server.xml` and `context.xml`.
 
 Do not use environment variables for secrets! See [Secrets](#Secrets) for more information.
 


### PR DESCRIPTION
Removed the mention of previous context.xml file and updated descriptions for
current default files and directories in the Docker image. Also added a note
about logging appenders and updated references to environment variables in the
documentation.