### PR TITLE
Determine realPath in LarvaTool 

### DIFF
--- a/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
+++ b/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
@@ -30,9 +30,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.IbisContext;
 import org.frankframework.core.Adapter;
@@ -46,11 +51,6 @@ import org.frankframework.util.Misc;
 import org.frankframework.util.RunState;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.XmlUtils;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockServletContext;
-
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class IbisTester {
@@ -88,7 +88,7 @@ public class IbisTester {
 				request.setParameter("scenariosrootdirectory", scenariosRootDir);
 			}
 			Writer writer = new StringWriter();
-			LarvaTool.runScenarios(ibisContext, request, writer, silent, webAppPath);
+			LarvaTool.runScenarios(ibisContext, request, writer, silent);
 			if (scenario == null) {
 				String htmlString = "<html><head/><body>" + writer + "</body></html>";
 				return XmlUtils.toXhtml(new Message(htmlString));

--- a/larva/src/main/java/org/frankframework/larva/LarvaServlet.java
+++ b/larva/src/main/java/org/frankframework/larva/LarvaServlet.java
@@ -23,9 +23,11 @@ import java.net.URL;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.Getter;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
+
 import org.frankframework.core.SenderException;
 import org.frankframework.http.HttpServletBase;
 import org.frankframework.lifecycle.IbisInitializer;
@@ -139,9 +141,8 @@ public class LarvaServlet extends HttpServletBase {
 		resp.setContentType("text/html");
 		writer.append(getTemplate("Larva Test Tool"));
 
-		String realPath = getServletContext().getRealPath("/jsp/"); // Points to a folder in the webapp project
+		LarvaTool.runScenarios(getServletContext(), req, writer);
 
-		LarvaTool.runScenarios(getServletContext(), req, writer, realPath);
 		writer.append("</body></html>");
 		resp.flushBuffer();
 	}

--- a/larva/src/main/java/org/frankframework/larva/LarvaTool.java
+++ b/larva/src/main/java/org/frankframework/larva/LarvaTool.java
@@ -141,12 +141,12 @@ public class LarvaTool {
 	}
 
 	// Invoked by LarvaServlet
-	public static void runScenarios(ServletContext application, HttpServletRequest request, Writer out, String realPath) {
-		runScenarios(getIbisContext(application), request, out, false, realPath);
+	public static void runScenarios(ServletContext application, HttpServletRequest request, Writer out) {
+		runScenarios(getIbisContext(application), request, out, false);
 	}
 
 	// Invoked by the IbisTester class
-	public static void runScenarios(IbisContext ibisContext, HttpServletRequest request, Writer out, boolean silent, String realPath) {
+	public static void runScenarios(IbisContext ibisContext, HttpServletRequest request, Writer out, boolean silent) {
 		String paramLogLevel = request.getParameter("loglevel");
 		String paramAutoScroll = request.getParameter("autoscroll");
 		String paramMultiThreaded = request.getParameter("multithreaded");
@@ -164,7 +164,7 @@ public class LarvaTool {
 		String paramScenariosRootDirectory = request.getParameter("scenariosrootdirectory");
 		LarvaTool larvaTool = new LarvaTool();
 		larvaTool.runScenarios(ibisContext, paramLogLevel, paramAutoScroll, paramMultiThreaded, paramExecute, paramWaitBeforeCleanUp, timeout,
-				realPath, paramScenariosRootDirectory, out, silent);
+				paramScenariosRootDirectory, out, silent);
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class LarvaTool {
 	 * 		   positive: number of scenarios that failed
 	 */
 	public int runScenarios(IbisContext ibisContext, String paramLogLevel, String paramAutoScroll, String paramMultithreaded, String paramExecute,
-							String paramWaitBeforeCleanUp, int timeout, String realPath, String paramScenariosRootDirectory, Writer out, boolean silent) {
+							String paramWaitBeforeCleanUp, int timeout, String paramScenariosRootDirectory, Writer out, boolean silent) {
 		config.setTimeout(timeout);
 		config.setSilent(silent);
 		AppConstants appConstants = AppConstants.getInstance();
@@ -204,7 +204,6 @@ public class LarvaTool {
 		List<String> scenariosRootDirectories = new ArrayList<>();
 		List<String> scenariosRootDescriptions = new ArrayList<>();
 		String currentScenariosRootDirectory = initScenariosRootDirectories(
-				realPath,
 				paramScenariosRootDirectory, scenariosRootDirectories,
 				scenariosRootDescriptions);
 		if (scenariosRootDirectories.isEmpty()) {
@@ -809,9 +808,12 @@ public class LarvaTool {
 		}
 	}
 
-	public String initScenariosRootDirectories(String realPath, String paramScenariosRootDirectory, List<String> scenariosRootDirectories, List<String> scenariosRootDescriptions) {
+	public String initScenariosRootDirectories(String paramScenariosRootDirectory, List<String> scenariosRootDirectories, List<String> scenariosRootDescriptions) {
 		AppConstants appConstants = AppConstants.getInstance();
 		String currentScenariosRootDirectory = null;
+
+		String realPath = getParentOfWebappRoot();
+
 		if (realPath == null) {
 			errorMessage("Could not read webapp real path");
 			return null;
@@ -885,6 +887,12 @@ public class LarvaTool {
 			currentScenariosRootDirectory = paramScenariosRootDirectory;
 		}
 		return currentScenariosRootDirectory;
+	}
+
+	private String getParentOfWebappRoot() {
+		String realPath = this.getClass().getResource("/").getPath();
+
+		return new File(realPath).getParent();
 	}
 
 	public List<File> readScenarioFiles(AppConstants appConstants, String scenariosDirectory) {
@@ -1608,11 +1616,9 @@ public class LarvaTool {
 		AppConstants appConstants = AppConstants.getInstance();
 		String windiffCommand = appConstants.getProperty("larva.windiff.command");
 		if (windiffCommand == null) {
-			String realPath = application.getRealPath("/iaf/");
 			List<String> scenariosRootDirectories = new ArrayList<>();
 			List<String> scenariosRootDescriptions = new ArrayList<>();
 			String currentScenariosRootDirectory = initScenariosRootDirectories(
-					realPath,
 					null, scenariosRootDirectories,
 					scenariosRootDescriptions);
 			windiffCommand = currentScenariosRootDirectory + "..\\..\\IbisAlgemeenWasbak\\WinDiff\\WinDiff.Exe";

--- a/larva/src/main/java/org/frankframework/pipes/LarvaPipe.java
+++ b/larva/src/main/java/org/frankframework/pipes/LarvaPipe.java
@@ -23,6 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.IbisContext;
@@ -33,7 +34,6 @@ import org.frankframework.doc.Forward;
 import org.frankframework.larva.LarvaLogLevel;
 import org.frankframework.larva.LarvaTool;
 import org.frankframework.stream.Message;
-import org.frankframework.util.AppConstants;
 
 /**
  * Call Larva Test Tool
@@ -76,12 +76,11 @@ public class LarvaPipe extends FixedForwardPipe {
 	@Override
 	public PipeRunResult doPipe(Message message, PipeLineSession session) {
 		IbisContext ibisContext = getAdapter().getConfiguration().getIbisManager().getIbisContext();
-		String realPath = AppConstants.getInstance().getProperty("webapp.realpath") + "iaf/";
 		List<String> scenariosRootDirectories = new ArrayList<>();
 		List<String> scenariosRootDescriptions = new ArrayList<>();
 		LarvaTool larvaTool = new LarvaTool();
+
 		String currentScenariosRootDirectory = larvaTool.initScenariosRootDirectories(
-				realPath,
 				null, scenariosRootDirectories,
 				scenariosRootDescriptions);
     	String paramExecute = currentScenariosRootDirectory;
@@ -93,7 +92,7 @@ public class LarvaPipe extends FixedForwardPipe {
 		boolean silent = true;
 		LarvaTool.setTimeout(getTimeout());
 		int numScenariosFailed = larvaTool.runScenarios(ibisContext, getLogLevel().getName(), "true", "false", paramExecute,
-				paramWaitBeforeCleanUp, getTimeout(), realPath, currentScenariosRootDirectory, out, silent
+				paramWaitBeforeCleanUp, getTimeout(), currentScenariosRootDirectory, out, silent
 		);
 		PipeForward forward = numScenariosFailed==0 ? getSuccessForward() : failureForward;
 		return new PipeRunResult(forward, out.toString());


### PR DESCRIPTION
Determine realPath in LarvaTool based on getResource, instead of outside it based on the servlet context.

@nielsm5 , ik denk dat dit de juiste plek is. Voor nu even als draft, ik kan iets vergelijkbaars natuurlijk ook aanpassen _buiten_ `LarvaTool`