### PR TITLE
Two more copyright-excludes

### DIFF
--- a/copyrightExcludeFile.txt
+++ b/copyrightExcludeFile.txt
@@ -88,3 +88,5 @@ mvnw.cmd
 license-mappings.xml
 NOTICE
 site.webmanifest
+.patch
+.http


### PR DESCRIPTION
Two file types that don't need a copyright but when I create them locally for tests, maven breaks on them.