### PR TITLE
Improve test for changes that may come in Log4J 2.25

### DIFF
--- a/core/src/test/java/org/frankframework/management/bus/BusExceptionTest.java
+++ b/core/src/test/java/org/frankframework/management/bus/BusExceptionTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.apache.logging.log4j.Level;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.testutil.TestAppender;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import org.apache.logging.log4j.Level;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.testutil.TestAppender;
 
 class BusExceptionTest {
 
@@ -44,11 +46,11 @@ class BusExceptionTest {
 			assertEquals(expectedLogLevel.name(), level, "["+level+"] did not match the expected log level ["+expectedLogLevel+"]");
 
 			//Check log message
-			assertEquals("outer exception", message);
+			assertEquals("outer exception", message.trim());
 
 			//Check log exception
 			if(exception != null) {
-				assertEquals("org.frankframework.configuration.ConfigurationException" + expectedLogMessage, exception);
+				assertEquals("org.frankframework.configuration.ConfigurationException" + expectedLogMessage, exception.trim());
 			}
 		}
 	}


### PR DESCRIPTION
Log4J2 2.25 will add some formatting changes that may add newlines before and/or after Exception messages.

By trimming the strings we do not depend on the presence or absence of such newlines.