### PR TITLE
Minor startup performance improvement by caching results of XSD compare

### DIFF
--- a/core/src/main/java/org/frankframework/validation/IXSD.java
+++ b/core/src/main/java/org/frankframework/validation/IXSD.java
@@ -15,9 +15,11 @@
 */
 package org.frankframework.validation;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import org.frankframework.core.IScopeProvider;
@@ -33,6 +35,10 @@ public interface IXSD extends Schema, Comparable<IXSD> {
 	boolean isAddNamespaceToSchema();
 	List<String> getRootTags();
 	Set<String> getImportedNamespaces();
+
+	@Nonnull
+	String asString() throws IOException;
+
 	@Nullable
 	IXSD getImportParent();
 

--- a/core/src/main/java/org/frankframework/validation/IXSD.java
+++ b/core/src/main/java/org/frankframework/validation/IXSD.java
@@ -58,5 +58,5 @@ public interface IXSD extends Schema, Comparable<IXSD> {
 
 	IScopeProvider getScopeProvider();
 
-	int compareToByContents(IXSD x);
+	int compareToByContents(IXSD other);
 }

--- a/core/src/main/java/org/frankframework/validation/XSD.java
+++ b/core/src/main/java/org/frankframework/validation/XSD.java
@@ -42,6 +42,7 @@ import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import lombok.Getter;
@@ -270,12 +271,18 @@ public abstract class XSD implements IXSD {
 				return cacheCompareContentsResult(other, 0);
 			}
 			// When "diff" says they're different we still need to order them for the "compareTo" result, so we make strings and compare the strings.
-			int compareResult = StreamUtil.readerToString(getReader(), "\n", false).compareTo(StreamUtil.readerToString(other.getReader(), "\n", false));
+			int compareResult = asString().compareTo(other.asString());
 			return cacheCompareContentsResult(other, compareResult);
 		} catch (Exception e) {
 			LOG.warn("Exception during XSD compare", e);
 			return 1;
 		}
+	}
+
+	@Nonnull
+	@Override
+	public String asString() throws IOException {
+		return StreamUtil.readerToString(getReader(), "\n", false);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/validation/XSD.java
+++ b/core/src/main/java/org/frankframework/validation/XSD.java
@@ -281,11 +281,13 @@ public abstract class XSD implements IXSD {
 	/**
 	 * The operation {@link #compareToByContents(IXSD)} is quite expensive, and sometimes we compare the very same XSD documents
 	 * multiple times. Caching the results gives a minor speedup on startup of the framework.
-	 * <br/>
+	 * <p>
 	 * The cache is keyed by the {@link System#identityHashCode} of the other XSD against which the comparison was made and stores the previous content-comparison result.
 	 * The corresponding cache of the other XSD is also updated, keyed by our own identityHashCode. The identityHashCode is chosen because it's fast, and because
 	 * it is guaranteed to be different for instances which might otherwise calculate the same {@link #hashCode()}.
 	 * <br/>
+	 * The cache is updated both for this instance, and for other.
+	 * </p>
 	 * @param other The other XSD against which comparison has been made.
 	 * @param compareResult Result of the {@link #compareToByContents(IXSD)} operation
 	 * @return Returns the value of {@code compareResult} parameter for more fluent use of this method.

--- a/core/src/main/java/org/frankframework/validation/XSD.java
+++ b/core/src/main/java/org/frankframework/validation/XSD.java
@@ -243,8 +243,7 @@ public abstract class XSD implements IXSD {
 	}
 
 	@Override
-	public int compareTo(IXSD other) { // CompareTo is required for WSDL generation
-		if (other == null) return 1;
+	public int compareTo(@Nonnull IXSD other) { // CompareTo is required for WSDL generation
 		if (this == other) return 0;
 		if (namespace != null && other.getNamespace() != null) {
 			int c = namespace.compareTo(other.getNamespace());
@@ -258,7 +257,7 @@ public abstract class XSD implements IXSD {
 	}
 
 	@Override
-	public int compareToByContents(IXSD other) {
+	public int compareToByContents(@Nonnull IXSD other) {
 		Integer cachedResult = compareByContentsCache.get(System.identityHashCode(other));
 		if (cachedResult != null) {
 			return cachedResult;
@@ -279,9 +278,8 @@ public abstract class XSD implements IXSD {
 		}
 	}
 
-	@Nonnull
 	@Override
-	public String asString() throws IOException {
+	public @Nonnull String asString() throws IOException {
 		return StreamUtil.readerToString(getReader(), "\n", false);
 	}
 

--- a/core/src/main/java/org/frankframework/validation/xsd/ResourceXsd.java
+++ b/core/src/main/java/org/frankframework/validation/xsd/ResourceXsd.java
@@ -68,10 +68,10 @@ public class ResourceXsd extends XSD {
 	}
 
 	@Override
-	public int compareToByReferenceOrContents(IXSD x) {
-		if (x instanceof ResourceXsd) {
-			return getSystemId().compareTo(x.getSystemId());
+	public int compareToByReferenceOrContents(IXSD other) {
+		if (other instanceof ResourceXsd) {
+			return getSystemId().compareTo(other.getSystemId());
 		}
-		return compareToByContents(x);
+		return compareToByContents(other);
 	}
 }

--- a/core/src/main/java/org/frankframework/validation/xsd/StringXsd.java
+++ b/core/src/main/java/org/frankframework/validation/xsd/StringXsd.java
@@ -21,6 +21,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+
 import org.frankframework.validation.XSD;
 
 /**
@@ -37,4 +39,8 @@ public class StringXsd extends XSD {
 		return new StringReader(schemaContentsWriter.toString());
 	}
 
+	@Override
+	public @NotNull String asString() throws IOException {
+		return schemaContentsWriter.toString();
+	}
 }

--- a/core/src/main/java/org/frankframework/validation/xsd/StringXsd.java
+++ b/core/src/main/java/org/frankframework/validation/xsd/StringXsd.java
@@ -20,8 +20,9 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import jakarta.annotation.Nonnull;
+
 import lombok.Setter;
-import org.jetbrains.annotations.NotNull;
 
 import org.frankframework.validation.XSD;
 
@@ -40,7 +41,7 @@ public class StringXsd extends XSD {
 	}
 
 	@Override
-	public @NotNull String asString() throws IOException {
+	public @Nonnull String asString() throws IOException {
 		return schemaContentsWriter.toString();
 	}
 }

--- a/core/src/main/java/org/frankframework/validation/xsd/WsdlXsd.java
+++ b/core/src/main/java/org/frankframework/validation/xsd/WsdlXsd.java
@@ -48,13 +48,13 @@ public class WsdlXsd extends ResourceXsd {
 	}
 
 	@Override
-	public int compareToByReferenceOrContents(IXSD x) {
+	public int compareToByReferenceOrContents(IXSD other) {
 		// Compare XSD content to prevent copies of the same XSD showing up
 		// more than once in the WSDL. For example the
 		// CommonMessageHeader.xsd used by the EsbSoapValidator will
 		// normally also be imported by the XSD for the business response
 		// message (for the Result part).
-		return compareToByContents(x);
+		return compareToByContents(other);
 	}
 
 }


### PR DESCRIPTION
Comparing XSD by content is expensive. Do it less often.

The benefit is not huge so feel free to close without applying if you prefer.