### PR TITLE
Fix NPE when Ladybug rerun cannot find config

### DIFF
--- a/console/war/src/main/java/org/frankframework/console/runner/ConsoleStandaloneInitializer.java
+++ b/console/war/src/main/java/org/frankframework/console/runner/ConsoleStandaloneInitializer.java
@@ -63,7 +63,8 @@ public class ConsoleStandaloneInitializer {
 	}
 
 	/**
-	 * When the application fails to start up, trigger a shutdown, else Tomcat will work without any application deployed to it.
+	 * When the application fails to start up, trigger a shutdown.
+	 * If this is not done the SpringBoot Tomcat instance will continue to work without any application deployed to it.
 	 */
 	private static class FailedInitializationMonitor implements ApplicationListener<ApplicationFailedEvent> {
 

--- a/console/war/src/main/resources/application.properties
+++ b/console/war/src/main/resources/application.properties
@@ -49,8 +49,8 @@ csrf.cookie.path=
 #application.security.testtool.authentication.password=Nimda
 
 ## Example to enable the DatabaseStorage and configure the jdbc endpoint.
-spring.profiles.active=ladybug.database
-ladybug.jdbc.driver=org.postgresql.Driver
-ladybug.jdbc.url=jdbc:postgresql://localhost:5432/testiaf
-ladybug.jdbc.username=testiaf_user
-ladybug.jdbc.password=testiaf_user00
+#spring.profiles.active=ladybug.database
+#ladybug.jdbc.driver=org.postgresql.Driver
+#ladybug.jdbc.url=jdbc:postgresql://localhost:5432/testiaf
+#ladybug.jdbc.username=testiaf_user
+#ladybug.jdbc.password=testiaf_user00

--- a/console/war/src/main/resources/application.properties
+++ b/console/war/src/main/resources/application.properties
@@ -11,6 +11,11 @@ logging.level.org.springframework=WARN
 logging.level.org.frankframework.management.gateway=DEBUG
 logging.level.com.hazelcast=WARN
 
+## Ladybug Loggers
+logging.level.nl.nn.testtool=WARN
+logging.level.liquibase=WARN
+logging.level.org.apache.cxf=WARN
+
 #Spring WEB's hidden(?) mappings logger, see LogDelegateFactory#getHiddenLog(...)
 logging.level._org.springframework.web.servlet.HandlerMapping.Mappings=WARN
 
@@ -19,26 +24,33 @@ logging.level.com.microsoft.sqlserver=WARN
 
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5p %c - %msg%n
 
-# Application defaults
+## Application defaults
 spring.jmx.enabled=false
 server.port=8080
 
 management.gateway.outbound.class=org.frankframework.management.gateway.HazelcastOutboundGateway
 management.gateway.http.outbound.endpoint=http://localhost/iaf-test/iaf/management
 
-# list the console on the server root.
+## list the console on the server root.
 servlet.IAF-GUI.urlMapping=/*
 
-# Cross Site Request Forgery protection
+## Cross Site Request Forgery protection
 csrf.enabled=true
 csrf.cookie.path=
 
 ## Enables authentication for the Frank!Console
 #application.security.console.authentication.type=IN_MEMORY
-#application.security.console.authentication.username=Admin1
+#application.security.console.authentication.username=Admin
 #application.security.console.authentication.password=Nimda
 
 ## Enables authentication for the Ladybug (if present)
 #application.security.testtool.authentication.type=IN_MEMORY
-#application.security.testtool.authentication.username=Admin2
+#application.security.testtool.authentication.username=Admin
 #application.security.testtool.authentication.password=Nimda
+
+## Example to enable the DatabaseStorage and configure the jdbc endpoint.
+spring.profiles.active=ladybug.database
+ladybug.jdbc.driver=org.postgresql.Driver
+ladybug.jdbc.url=jdbc:postgresql://localhost:5432/testiaf
+ladybug.jdbc.username=testiaf_user
+ladybug.jdbc.password=testiaf_user00

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -102,8 +102,10 @@ public class LadybugDebugger implements Debugger, ApplicationListener<DebuggerSt
 		if (i > 0) {
 			String configName = name.substring(0, i);
 			Configuration config = ibisManager.getConfiguration(configName);
-			String adapterName = name.substring(i + 1);
-			return config.getRegisteredAdapter(adapterName);
+			if (config != null) {
+				String adapterName = name.substring(i + 1);
+				return config.getRegisteredAdapter(adapterName);
+			}
 		}
 
 		List<Adapter> adapters = getRegisteredAdapters();

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -106,12 +106,12 @@ public class LadybugDebugger implements Debugger, ApplicationListener<DebuggerSt
 			String configName = name.substring(0, i);
 			Configuration config = ibisManager.getConfiguration(configName);
 			if (config == null) {
-				throw new IllegalStateException("Configuration ["+configName+"] does not exist.");
+				throw new IllegalArgumentException("Configuration ["+configName+"] does not exist.");
 			}
 			String adapterName = name.substring(i + 1);
 			Adapter adapter = config.getRegisteredAdapter(adapterName);
 			if (adapter == null) {
-				throw new IllegalStateException("Adapter ["+adapterName+"] does not exist in configuration ["+configName+"].");
+				throw new IllegalArgumentException("Adapter ["+adapterName+"] does not exist in configuration ["+configName+"].");
 			}
 			return adapter;
 		}
@@ -122,7 +122,7 @@ public class LadybugDebugger implements Debugger, ApplicationListener<DebuggerSt
 				return adapter;
 			}
 		}
-		throw new IllegalStateException("Adapter ["+name+"] not found.");
+		throw new IllegalArgumentException("Adapter ["+name+"] not found.");
 	}
 
 	@Override

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -237,7 +237,7 @@ public class LadybugDebugger implements Debugger, ApplicationListener<DebuggerSt
 		if (rerun) {
 			Checkpoint originalEndpoint = testtool.getOriginalEndpointOrAbortpointForCurrentLevel(correlationId);
 			if (originalEndpoint == null) {
-//				stub = stub(getCheckpointNameForINamedObject(checkpointNamePrefix, namedObject), true, getDefaultStubStrategy());
+				// stub = stub(getCheckpointNameForINamedObject(checkpointNamePrefix, namedObject), true, getDefaultStubStrategy());
 				// TODO zou ook gewoon het orginele report kunnen gebruiken (via opslaan in iets als inRerun) of inRerun ook via testtool doen?
 				Report reportInProgress = testtool.getReportInProgress(correlationId);
 				return stub(getCheckpointNameForINamedObject(checkpointNamePrefix, namedObject), true, (reportInProgress==null?null:reportInProgress.getStubStrategy()));

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/runner/LadybugWarInitializer.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/runner/LadybugWarInitializer.java
@@ -103,16 +103,20 @@ public class LadybugWarInitializer extends SpringBootServletInitializer {
 		List<String> profiles = new ArrayList<>(2);
 		if(StringUtils.isBlank(dataSourceName)) {
 			profiles.add("ladybug.file");
-			if(dtapIsLoc(properties)) {
-				profiles.add("ladybug.xml");
-			}
 		} else {
 			profiles.add("ladybug.database");
+		}
+		if(dtapIsLoc(properties)) {
+			profiles.add("ladybug.xml");
 		}
 		APPLICATION_LOG.debug("Using Ladybug profiles {}", profiles);
 		return profiles;
 	}
 
+	/**
+	 * When using a local environment the Test-tab storage location can/should be read from the project.
+	 * This allows users to store their test results in Git for easy compares (rerun).
+	 */
 	private boolean dtapIsLoc(AppConstants properties) {
 		String dtapStage = properties.getProperty("dtap.stage", "").toLowerCase();
 		return "loc".equals(dtapStage) || "xxx".equals(dtapStage) || dtapStage.isEmpty();

--- a/ladybug/debugger/src/main/resources/springIbisTestTool.xml
+++ b/ladybug/debugger/src/main/resources/springIbisTestTool.xml
@@ -98,15 +98,6 @@
 		</bean>
 	</beans>
 
-	<!-- XML only for the test-tab storage -->
-	<beans profile="ladybug.xml">
-		<bean name="testStorage" class="nl.nn.testtool.storage.xml.XmlStorage" autowire="byName">
-			<property name="name" value="XmlTestStorage"/>
-			<property name="metadataFile" value="${ibistesttool.directory}/${instance.name.lc}/metadata.xml"/>
-			<property name="reportsFolder" value="${ibistesttool.directory}/${instance.name.lc}"/>
-		</bean>
-	</beans>
-
 	<beans profile="ladybug.database">
 		<bean name="dataSourceName" class="java.lang.String">
 			<constructor-arg value="${ladybug.jdbc.datasource:}"/>
@@ -158,6 +149,15 @@
 			<property name="timeout" value="60"/>
 			<property name="interval" value="5"/>
 			<property name="dataSource" ref="ladybugDataSource"/>
+		</bean>
+	</beans>
+
+	<!-- XML only for the test-tab storage. Configured last so it can overwrite either the File or Database Storage. -->
+	<beans profile="ladybug.xml">
+		<bean name="testStorage" class="nl.nn.testtool.storage.xml.XmlStorage" autowire="byName">
+			<property name="name" value="XmlTestStorage"/>
+			<property name="metadataFile" value="${log.dir}/testtool4${instance.name.lc}.metadata.xml"/><!-- cache file -->
+			<property name="reportsFolder" value="${ibistesttool.directory}"/><!-- contains the reports, may be stored in Git -->
 		</bean>
 	</beans>
 </beans>

--- a/ladybug/rerunner/src/main/java/org/frankframework/ladybug/SpringBusRerunner.java
+++ b/ladybug/rerunner/src/main/java/org/frankframework/ladybug/SpringBusRerunner.java
@@ -144,10 +144,8 @@ public class SpringBusRerunner implements Rerunner {
 
 	private String processRequest(Message<String> request) {
 		try {
-			Message<?> message = getGateway().sendSyncMessage(request);
-			if (message == null) {
-				return "did not receive a reply from backend node";
-			}
+			getGateway().sendSyncMessage(request);
+			// Nothing is done with the response at the moment
 		} catch (BusException e) {
 			return "Exception processing rerun: " + e.getMessage();
 		}

--- a/ladybug/rerunner/src/main/resources/testtool.properties
+++ b/ladybug/rerunner/src/main/resources/testtool.properties
@@ -34,9 +34,3 @@ ladybug.directory=${java.io.tmpdir}/ladybug
 #ladybug.jdbc.url=jdbc:oracle:thin:@localhost:1521:XE
 #ladybug.jdbc.username=testiaf_user
 #ladybug.jdbc.password=testiaf_user00
-
-
-## LOGGERS
-logging.level.nl.nn.testtool=WARN
-logging.level.liquibase=WARN
-logging.level.org.apache.cxf=WARN


### PR DESCRIPTION
- Fix NPE when Ladybug rerun cannot find config
- Stop application when an error occurs during startup
- Change default property locations
- Allow XML storage to be stored on disk even when using DatabaseStorage
- Change exception messages when adapter or config cannot be find while in rerun
- Change whitespace in comment and solve Sonar issue