### PR TITLE
Deprecate throwException and success forward for ExceptionPipe

### DIFF
--- a/core/src/main/java/org/frankframework/pipes/ExceptionPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/ExceptionPipe.java
@@ -19,22 +19,36 @@ import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarning;
+import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.doc.ElementType;
 import org.frankframework.doc.ElementType.ElementTypes;
+import org.frankframework.doc.Forward;
 import org.frankframework.stream.Message;
 
 /**
  * Pipe that throws an exception, based on the input message.
  *
+ * {@literal success} forward is used when {@literal throwException} is false, {@literal exception} is used otherwise.
+ *
  * @author  Gerrit van Brakel
  */
 @ElementType(ElementTypes.ERRORHANDLING)
-public class ExceptionPipe extends FixedForwardPipe {
+@Forward(name = "success", description = "success Forward is deprecated and will be removed. Invoked when {@literal throwException} is false")
+public class ExceptionPipe extends AbstractPipe {
 
 	private boolean throwException = true;
+	private PipeForward successForward;
+
+	@Override
+	public void configure() throws ConfigurationException {
+		super.configure();
+		successForward = findForward(PipeForward.SUCCESS_FORWARD_NAME);
+	}
 
 	@Override
 	public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
@@ -52,7 +66,8 @@ public class ExceptionPipe extends FixedForwardPipe {
 			throw new PipeRunException(this, errorMessage);
 		}
 		log.error(errorMessage);
-		return new PipeRunResult(getSuccessForward(), errorMessage);
+
+		return new PipeRunResult(successForward, errorMessage);
 	}
 
 
@@ -60,6 +75,8 @@ public class ExceptionPipe extends FixedForwardPipe {
 	 * When <code>true</code>, a PipeRunException is thrown. Otherwise, the output is only logged as an error (and no rollback is performed).
 	 * @ff.default true
 	 */
+	@Deprecated(forRemoval = true, since = "9.0")
+	@ConfigurationWarning(value = "The {@literal success} forward and {@literal throwException} attribute should not be used anymore")
 	public void setThrowException(boolean b) {
 		throwException = b;
 	}

--- a/core/src/test/java/org/frankframework/pipes/ExceptionPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ExceptionPipeTest.java
@@ -4,7 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeRunException;
+import org.frankframework.core.PipeRunResult;
 import org.frankframework.stream.Message;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -19,27 +22,36 @@ public class ExceptionPipeTest extends PipeTestBase<ExceptionPipe> {
 
 	@Override
 	public ExceptionPipe createPipe() {
-		return new ExceptionPipe();
+		var pipe = new ExceptionPipe();
+
+		pipe.registerForward(new PipeForward("success", "success"));
+
+		return pipe;
 	}
 
 	@Test
 	public void testDoesntThrowException() throws Exception {
 		pipe.setThrowException(false);
-		Message m = new Message("no exception");
-		assertEquals("no exception", doPipe(pipe, m, session).getResult().asString());
+		pipe.configure();
+
+		PipeRunResult result = doPipe(pipe, new Message("no exception"), session);
+		assertEquals("no exception", result.getResult().asString());
+		assertEquals(PipeForward.SUCCESS_FORWARD_NAME, result.getPipeForward().getName());
 	}
 
 	@Test
-	public void throwsExceptionWithoutMessage() {
+	public void throwsExceptionWithoutMessage() throws ConfigurationException {
 		pipe.setThrowException(true);
+		pipe.configure();
 
 		PipeRunException e = assertThrows(PipeRunException.class, ()->doPipe(pipe, "", session));
 		assertThat(e.getMessage(), Matchers.endsWith("ExceptionPipe under test"));
 	}
 
 	@Test
-	public void throwsExceptionWithMessage() {
+	public void throwsExceptionWithMessage() throws ConfigurationException {
 		pipe.setThrowException(true);
+		pipe.configure();
 
 		PipeRunException e = assertThrows(PipeRunException.class, ()->doPipe(pipe, "exception thrown with a custom message", session));
 		assertThat(e.getMessage(), Matchers.endsWith("exception thrown with a custom message"));


### PR DESCRIPTION
Closes #7706 

I think it's best to deprecate the `throwException` attribute and the `success` forward. A ConfigurationException is thrown when an invalid forward is used, so we must be careful when changing or removing forwards. A way to deprecate forwards might be a nice to have aswell?