### PR TITLE
Rename registerXyz digester methods with addXyz

### DIFF
--- a/aspose/src/test/java/org/frankframework/extensions/aspose/pipe/PdfPipeTest.java
+++ b/aspose/src/test/java/org/frankframework/extensions/aspose/pipe/PdfPipeTest.java
@@ -536,7 +536,7 @@ public class PdfPipeTest extends PipeTestBase<PdfPipe> {
 	public void multiThreadedMailWithWordAttachment() throws Exception {
 		pipe.setName("multiThreadedmailWithWordAttachment");
 		pipe.setAction(DocumentAction.CONVERT);
-		pipe.registerForward(new PipeForward("success", "dummy"));
+		pipe.addForward(new PipeForward("success", "dummy"));
 		pipe.configure();
 		pipe.start();
 

--- a/core/src/main/java/org/frankframework/configuration/AdapterManager.java
+++ b/core/src/main/java/org/frankframework/configuration/AdapterManager.java
@@ -61,7 +61,7 @@ public class AdapterManager extends AbstractConfigurableLifecyle implements Appl
 		return 100;
 	}
 
-	public void registerAdapter(Adapter adapter) {
+	public void addAdapter(Adapter adapter) {
 		if(!active.get()) {
 			throw new IllegalStateException("AdapterManager in state [closed] unable to register Adapter ["+adapter.getName()+"]");
 		}

--- a/core/src/main/java/org/frankframework/configuration/Configuration.java
+++ b/core/src/main/java/org/frankframework/configuration/Configuration.java
@@ -364,16 +364,16 @@ public class Configuration extends ClassPathXmlApplicationContext implements ICo
 	/**
 	 * Include the referenced Module in this configuration
 	 */
-	public void registerInclude(Include module) {
+	public void addInclude(Include module) {
 		// method exists to trigger FrankDoc.
 	}
 
 	/**
 	 * Add adapter.
 	 */
-	public void registerAdapter(Adapter adapter) {
+	public void addAdapter(Adapter adapter) {
 		adapter.setConfiguration(this);
-		adapterManager.registerAdapter(adapter);
+		adapterManager.addAdapter(adapter);
 
 		log.debug("Configuration [{}] registered adapter [{}]", this::getName, adapter::toString);
 	}
@@ -509,6 +509,7 @@ public class Configuration extends ClassPathXmlApplicationContext implements ICo
 		// SapSystems self register;
 	}
 
+	// TODO
 	// Dummy setter to allow JmsRealms being added to Configurations via Frank!Config XSD
 	public void setJmsRealms(JmsRealmFactory realm) {
 		// JmsRealm-objects self register in JmsRealmFactory;
@@ -516,8 +517,8 @@ public class Configuration extends ClassPathXmlApplicationContext implements ICo
 
 	// Dummy setter to allow JmsRealms being added to Configurations via Frank!Config XSD
 	@Deprecated
-	public void registerJmsRealm(JmsRealm realm) {
-		JmsRealmFactory.getInstance().registerJmsRealm(realm); // For backwards compatibility to support old ibisdoc xsd
+	public void addJmsRealm(JmsRealm realm) {
+		JmsRealmFactory.getInstance().addJmsRealm(realm); // For backwards compatibility to support old ibisdoc xsd
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/configuration/SharedResources.java
+++ b/core/src/main/java/org/frankframework/configuration/SharedResources.java
@@ -23,7 +23,7 @@ import org.frankframework.http.HttpSession;
 @FrankDocGroup(value = FrankDocGroupValue.OTHER)
 public class SharedResources {
 
-	public void registerSharedResource(SharedResource<?> resource) {
+	public void addSharedResource(SharedResource<?> resource) {
 		//This method only exists for the FrankDoc
 	}
 

--- a/core/src/main/java/org/frankframework/configuration/extensions/SapSystems.java
+++ b/core/src/main/java/org/frankframework/configuration/extensions/SapSystems.java
@@ -21,7 +21,7 @@ import org.frankframework.doc.FrankDocGroupValue;
 @FrankDocGroup(value = FrankDocGroupValue.OTHER)
 public class SapSystems {
 
-	public void registerSapSystem(ISapSystem sapSystem) {
+	public void addSapSystem(ISapSystem sapSystem) {
 		//SapSystems selfRegister, this method only exists for the FrankDoc;
 	}
 

--- a/core/src/main/java/org/frankframework/core/AbstractResponseValidatorWrapper.java
+++ b/core/src/main/java/org/frankframework/core/AbstractResponseValidatorWrapper.java
@@ -70,7 +70,7 @@ public abstract class AbstractResponseValidatorWrapper<V extends ValidatorBase> 
 	}
 
 	@Override
-	public void registerForward(PipeForward forward) {
+	public void addForward(PipeForward forward) {
 		forwards.put(forward.getName(), forward);
 	}
 

--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -174,7 +174,7 @@ public class Adapter implements IManagable, HasStatistics, NamedBean {
 	 * @see PipeLine#configure()
 	 */
 	/*
-	 * This function is called by Configuration.registerAdapter,
+	 * This function is called by Configuration.addAdapter,
 	 * to make configuration information available to the Adapter. <br/><br/>
 	 * This method also performs
 	 * a <code>Pipeline.configurePipes()</code>, as to configure the individual pipes.
@@ -670,7 +670,7 @@ public class Adapter implements IManagable, HasStatistics, NamedBean {
 	 * @ff.mandatory
 	 */
 	@SuppressWarnings("java:S3457") // Cast arguments to String before invocation so that we do not have recursive call to logger when trace-level logging is enabled
-	public void registerReceiver(Receiver<?> receiver) {
+	public void addReceiver(Receiver<?> receiver) {
 		receivers.add(receiver);
 		if (log.isDebugEnabled()) log.debug("Adapter [{}] registered receiver [{}] with properties [{}]", name, receiver.getName(), receiver.toString());
 	}

--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -82,7 +82,7 @@ public interface IPipe extends IConfigurable, IForwardTarget {
 	 * @see PipeLine
 	 * @see PipeForward
 	 */
-	void registerForward(PipeForward forward) throws ConfigurationException;
+	void addForward(PipeForward forward) throws ConfigurationException;
 
 	/**
 	 * Perform necessary action to start the pipe. This method is executed

--- a/core/src/main/java/org/frankframework/core/PipeForwards.java
+++ b/core/src/main/java/org/frankframework/core/PipeForwards.java
@@ -36,7 +36,7 @@ public class PipeForwards {
 	 * Defines what pipe or exit to execute next. When the execution of a pipe is done, the pipe looks up the next pipe or exit to execute.
 	 * See {@link PipeForward Forward} for more information.
 	 */
-	public void registerForward(PipeForward forward) {
+	public void addForward(PipeForward forward) {
 		forwards.add(forward);
 	}
 

--- a/core/src/main/java/org/frankframework/core/PipeLine.java
+++ b/core/src/main/java/org/frankframework/core/PipeLine.java
@@ -189,7 +189,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 			PipeLineExit defaultExit = new PipeLineExit();
 			defaultExit.setName(DEFAULT_SUCCESS_EXIT_NAME);
 			defaultExit.setState(ExitState.SUCCESS);
-			registerPipeLineExit(defaultExit);
+			addPipeLineExit(defaultExit);
 			log.debug("Created default Exit named [{}], state [{}]", defaultExit.getName(), defaultExit.getState());
 		}
 		for (int i=0; i < pipes.size(); i++) {
@@ -206,7 +206,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 						PipeForward pf = new PipeForward();
 						pf.setName(PipeForward.SUCCESS_FORWARD_NAME);
 						pf.setPath(nextPipeName);
-						pipe.registerForward(pf);
+						pipe.addForward(pf);
 					} else {
 						// This is the last pipe, so forwards to a PipeLineExit
 						PipeLineExit plExit = findExitByState(ExitState.SUCCESS)
@@ -217,7 +217,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 						PipeForward pf = new PipeForward();
 						pf.setName(PipeForward.SUCCESS_FORWARD_NAME);
 						pf.setPath(plExit.getName());
-						pipe.registerForward(pf);
+						pipe.addForward(pf);
 					}
 				}
 			}
@@ -294,7 +294,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 	private ConfigurationException configureSpecialPipe(@Nonnull final IPipe pipe, @Nonnull final String name, @Nullable final ConfigurationException configurationException) throws ConfigurationException {
 		PipeForward pf = new PipeForward();
 		pf.setName(PipeForward.SUCCESS_FORWARD_NAME);
-		pipe.registerForward(pf);
+		pipe.addForward(pf);
 		pipe.setName(name);
 
 		try {
@@ -574,7 +574,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 	/** PipeLine exits. If no exits are specified, a default one is created with name={@value #DEFAULT_SUCCESS_EXIT_NAME} and state={@value PipeLine.ExitState#SUCCESS_EXIT_STATE} */
 	public void setPipeLineExits(PipeLineExits exits) {
 		for(PipeLineExit exit:exits.getExits()) {
-			registerPipeLineExit(exit);
+			addPipeLineExit(exit);
 		}
 	}
 
@@ -582,7 +582,7 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 	 * PipeLine exits.
 	 */
 	@Deprecated
-	public void registerPipeLineExit(PipeLineExit exit) {
+	public void addPipeLineExit(PipeLineExit exit) {
 		if (pipeLineExits.containsKey(exit.getName())) {
 			ConfigurationWarnings.add(this, log, "exit named ["+exit.getName()+"] already exists");
 		}
@@ -603,12 +603,12 @@ public class PipeLine extends TransactionAttributes implements ICacheEnabled<Str
 	 */
 	public void setGlobalForwards(PipeForwards forwards){
 		for(PipeForward forward: forwards.getForwards()) {
-			registerForward(forward);
+			addForward(forward);
 		}
 	}
 
 	@Deprecated
-	public void registerForward(PipeForward forward) {
+	public void addForward(PipeForward forward) {
 		globalForwards.put(forward.getName(), forward);
 		log.debug("registered global PipeForward {}", forward);
 	}

--- a/core/src/main/java/org/frankframework/core/PipeLineExits.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineExits.java
@@ -53,7 +53,7 @@ public class PipeLineExits {
 	 * PipeLine exits.
 	 * @ff.mandatory
 	 */
-	public void registerPipeLineExit(PipeLineExit exit) {
+	public void addPipeLineExit(PipeLineExit exit) {
 		exits.add(exit);
 	}
 }

--- a/core/src/main/java/org/frankframework/jms/JmsRealmFactory.java
+++ b/core/src/main/java/org/frankframework/jms/JmsRealmFactory.java
@@ -113,7 +113,7 @@ public class JmsRealmFactory {
 	/**
 	 * Register a Realm
 	 */
-	public void registerJmsRealm(JmsRealm jmsRealm) {
+	public void addJmsRealm(JmsRealm jmsRealm) {
 		String realmName = jmsRealm.getRealmName();
 		if(jmsRealms.containsKey(realmName)) {
 			log.warn("overwriting JmsRealm [{}]. Realm with name [{}] already exists", jmsRealm, realmName);

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/Monitoring.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/Monitoring.java
@@ -121,7 +121,7 @@ public class Monitoring extends BusEndpointBase {
 			monitor = getMonitor(mm, name);
 			ITrigger trigger = SpringUtils.createBean(mm.getApplicationContext(), Trigger.class);
 			updateTrigger(trigger, message);
-			monitor.registerTrigger(trigger);
+			monitor.addTrigger(trigger);
 		} else {
 			monitor = SpringUtils.createBean(getApplicationContext(), Monitor.class);
 			updateMonitor(monitor, message);
@@ -211,7 +211,7 @@ public class Monitoring extends BusEndpointBase {
 			for(String adapter : dto.getAdapters()) {
 				AdapterFilter adapterFilter = new AdapterFilter();
 				adapterFilter.setAdapter(adapter);
-				trigger.registerAdapterFilter(adapterFilter);
+				trigger.addAdapterFilter(adapterFilter);
 			}
 		} else if(SourceFiltering.SOURCE == dto.getFilter()) {
 			for(Map.Entry<String, List<String>> entry : dto.getSources().entrySet()) {
@@ -220,7 +220,7 @@ public class Monitoring extends BusEndpointBase {
 				for(String subObject : entry.getValue()) {
 					adapterFilter.registerSubObject(subObject);
 				}
-				trigger.registerAdapterFilter(adapterFilter);
+				trigger.addAdapterFilter(adapterFilter);
 			}
 		}
 	}

--- a/core/src/main/java/org/frankframework/monitoring/ITrigger.java
+++ b/core/src/main/java/org/frankframework/monitoring/ITrigger.java
@@ -56,7 +56,7 @@ public interface ITrigger extends LazyLoadingEventListener<FireMonitorEvent>, Di
 	void setPeriod(int i);
 	int getPeriod();
 
-	void registerAdapterFilter(AdapterFilter af);
+	void addAdapterFilter(AdapterFilter af);
 	Map<String, AdapterFilter> getAdapterFilters();
 	void clearAdapterFilters();
 

--- a/core/src/main/java/org/frankframework/monitoring/Monitor.java
+++ b/core/src/main/java/org/frankframework/monitoring/Monitor.java
@@ -222,7 +222,7 @@ public class Monitor implements IConfigurable, DisposableBean {
 		}
 	}
 
-	public void registerTrigger(ITrigger trigger) {
+	public void addTrigger(ITrigger trigger) {
 		trigger.setMonitor(this);
 		triggers.add(trigger);
 	}

--- a/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
@@ -83,7 +83,7 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 		return "Manager@"+this.hashCode();
 	}
 
-	public void registerDestination(IMonitorDestination monitorAdapter) {
+	public void addDestination(IMonitorDestination monitorAdapter) {
 		destinations.put(monitorAdapter.getName(), monitorAdapter);
 	}
 	public IMonitorDestination getDestination(String name) {

--- a/core/src/main/java/org/frankframework/monitoring/Trigger.java
+++ b/core/src/main/java/org/frankframework/monitoring/Trigger.java
@@ -240,18 +240,18 @@ public class Trigger implements ITrigger {
 		setSourceFiltering(SourceFiltering.NONE);
 	}
 
+	public boolean isFilterOnLowerLevelObjects() {
+		return sourceFiltering == SourceFiltering.SOURCE;
+	}
+
 	@Override
-	public void registerAdapterFilter(AdapterFilter af) {
+	public void addAdapterFilter(AdapterFilter af) {
 		adapterFilters.put(af.getAdapter(),af);
 		if(af.isFilteringToLowerLevelObjects()) {
 			setSourceFiltering(SourceFiltering.SOURCE);
 		} else if (getSourceFiltering() == SourceFiltering.NONE) {
 			setSourceFiltering(SourceFiltering.ADAPTER);
 		}
-	}
-
-	public boolean isFilterOnLowerLevelObjects() {
-		return sourceFiltering == SourceFiltering.SOURCE;
 	}
 	public boolean isFilterOnAdapters() {
 		return sourceFiltering == SourceFiltering.ADAPTER;

--- a/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
@@ -245,7 +245,7 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 
 	/** Forwards are used to determine the next Pipe to execute in the Pipeline */
 	@Override
-	public void registerForward(PipeForward forward) {
+	public void addForward(PipeForward forward) {
 		registeredForwards.add(forward);
 	}
 

--- a/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
@@ -301,7 +301,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender {
 	private void configureElement(@Nonnull final IPipe pipe) throws ConfigurationException {
 		PipeForward pf = new PipeForward();
 		pf.setName(PipeForward.SUCCESS_FORWARD_NAME);
-		pipe.registerForward(pf);
+		pipe.addForward(pf);
 		configure(pipe);
 	}
 

--- a/core/src/main/java/org/frankframework/senders/JavascriptSender.java
+++ b/core/src/main/java/org/frankframework/senders/JavascriptSender.java
@@ -183,8 +183,8 @@ public class JavascriptSender extends SenderSeries {
 
 	@Optional
 	@Override
-	public void registerSender(ISender sender) {
-		super.registerSender(sender);
+	public void addSender(ISender sender) {
+		super.addSender(sender);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/senders/ParallelSenders.java
+++ b/core/src/main/java/org/frankframework/senders/ParallelSenders.java
@@ -164,8 +164,8 @@ public class ParallelSenders extends SenderSeries {
 
 	/** one or more specifications of senders. Each will receive the same input message, to be processed in parallel */
 	@Override
-	public void registerSender(ISender sender) {
-		super.registerSender(sender);
+	public void addSender(ISender sender) {
+		super.addSender(sender);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/senders/SenderSeries.java
+++ b/core/src/main/java/org/frankframework/senders/SenderSeries.java
@@ -114,16 +114,16 @@ public class SenderSeries extends SenderWrapperBase {
 
 
 
-	@Deprecated // replaced by registerSender, to allow for multiple senders in XSD. Method must be present, as it is used by Digester
+	@Deprecated // replaced by setSender, to allow for multiple senders in XSD. Method must be present, as it is used by Digester
 	public final void setSender(ISender sender) {
-		registerSender(sender);
+		addSender(sender);
 	}
 
 	/**
 	 * one or more specifications of senders that will be executed one after another. Each sender will get the result of the preceding one as input.
 	 * @ff.mandatory
 	 */
-	public void registerSender(ISender sender) {
+	public void addSender(ISender sender) {
 		senderList.add(sender);
 		setSynchronous(sender.isSynchronous()); // set synchronous to isSynchronous of the last Sender added
 	}

--- a/core/src/main/resources/digester-rules.xml
+++ b/core/src/main/resources/digester-rules.xml
@@ -5,26 +5,26 @@
 
 	<rule pattern="configuration" factory="null"/>
 
-	<rule pattern="*/include" registerMethod="registerInclude" beanClass="org.frankframework.configuration.Include" />
+	<rule pattern="*/include" registerMethod="addInclude" beanClass="org.frankframework.configuration.Include" />
 
 	<rule pattern="configuration/jmsRealms" registerMethod="setJmsRealms" factory="org.frankframework.configuration.digester.JmsRealmsFactory"/>
-	<rule pattern="*/jmsRealm" registerMethod="registerJmsRealm" beanClass="org.frankframework.jms.JmsRealm"/>
+	<rule pattern="*/jmsRealm" registerMethod="addJmsRealm" beanClass="org.frankframework.jms.JmsRealm"/>
 
 	<rule pattern="configuration/sharedResources" registerMethod="setSharedResources" beanClass="org.frankframework.configuration.SharedResources" />
-	<rule pattern="*/sharedResources/sharedResource" registerMethod="registerSharedResource" factory="org.frankframework.configuration.digester.SharedResourceFactory"/>
+	<rule pattern="*/sharedResources/sharedResource" registerMethod="addSharedResource" factory="org.frankframework.configuration.digester.SharedResourceFactory"/>
 	<rule pattern="*/sharedResources/httpSession" registerMethod="addHttpSession" factory="org.frankframework.configuration.digester.SharedResourceFactory"/> <!-- Hack to make the frankdoc look nice -->
 
 	<rule pattern="configuration/sapSystems" registerMethod="setSapSystems" beanClass="org.frankframework.configuration.extensions.SapSystems"/>
-	<rule pattern="*/sapSystem" registerMethod="registerSapSystem" beanClass="org.frankframework.extensions.sap.extensions.SapSystem" selfRegisterMethod="registerItem"/>
+	<rule pattern="*/sapSystem" registerMethod="addSapSystem" beanClass="org.frankframework.extensions.sap.extensions.SapSystem" selfRegisterMethod="registerItem"/>
 
-	<rule pattern="*/adapter" registerMethod="registerAdapter" beanClass="org.frankframework.core.Adapter"/>
+	<rule pattern="*/adapter" registerMethod="addAdapter" beanClass="org.frankframework.core.Adapter"/>
 	<rule pattern="*/adapter/pipeline" registerMethod="setPipeLine" beanClass="org.frankframework.core.PipeLine"/>
 	<rule pattern="*/errorMessageFormatter" registerMethod="setErrorMessageFormatter" beanClass="org.frankframework.errormessageformatters.XslErrorMessageFormatter"/>
 
-	<rule pattern="*/receiver" registerMethod="registerReceiver" beanClass="org.frankframework.receivers.Receiver"/>
+	<rule pattern="*/receiver" registerMethod="addReceiver" beanClass="org.frankframework.receivers.Receiver"/>
 	<!-- Also applied for monitors -->
 	<rule pattern="*/sender" registerMethod="setSender" beanClass="org.frankframework.core.ISender" />
-	<rule pattern="*/sender" registerMethod="registerSender" beanClass="org.frankframework.core.ISender" /> <!-- to tell FrankDoc about multiplicity of SenderSeries and ParallelSenders. Duplicate pattern will be suppressed by core digester -->
+	<rule pattern="*/sender" registerMethod="addSender" beanClass="org.frankframework.core.ISender" /> <!-- to tell FrankDoc about multiplicity of SenderSeries and ParallelSenders. Duplicate pattern will be suppressed by core digester -->
 	<rule pattern="*/listener" factory="org.frankframework.configuration.digester.ListenerFactory" registerMethod="setListener"/>
 	<rule pattern="*/errorSender" registerMethod="setErrorSender" beanClass="org.frankframework.core.ISender"/>
 	<rule pattern="*/messageLog" registerMethod="setMessageLog"/>
@@ -34,16 +34,16 @@
 	<rule pattern="*/inputWrapper" registerMethod="setInputWrapper"/>
 	<rule pattern="*/outputWrapper" registerMethod="setOutputWrapper"/>
 
-	<rule pattern="*/pipe" registerMethod="addPipe" paramtype="org.frankframework.core.IPipe" beanClass="org.frankframework.pipes.SenderPipe"/>
+	<rule pattern="*/pipe" registerMethod="addPipe" beanClass="org.frankframework.pipes.SenderPipe"/>
 
 	<!-- forward element is on the pipeline / global-forward as well as on the pipe element -->
 	<rule pattern="*/globalForwards" registerMethod="setGlobalForwards"/>
-	<rule pattern="*/forward" registerMethod="registerForward" beanClass="org.frankframework.core.PipeForward"/>
+	<rule pattern="*/forward" registerMethod="addForward" beanClass="org.frankframework.core.PipeForward"/>
 	<rule pattern="*/child" registerMethod="registerChild"/>
 	<rule pattern="*/outputFields" registerMethod="registerOutputFields"/>
 	<rule pattern="*/inputFields" registerMethod="registerInputFields"/>
 	<rule pattern="*/exits" registerMethod="setPipeLineExits"/>
-	<rule pattern="*/exit" registerMethod="registerPipeLineExit" beanClass="org.frankframework.core.PipeLineExit"/>
+	<rule pattern="*/exit" registerMethod="addPipeLineExit" beanClass="org.frankframework.core.PipeLineExit"/>
 
 	<rule pattern="configuration/scheduler" registerMethod="setScheduleManager"/>
 	<rule pattern="*/job" factory="org.frankframework.configuration.digester.JobFactory" registerMethod="registerScheduledJob"/>
@@ -63,13 +63,13 @@
 	<!-- Digester rules for monitoring -->
 	<rule pattern="configuration/monitoring" registerMethod="setMonitoring" factory="org.frankframework.monitoring.MonitoringFactory"/>
 
-	<rule pattern="*/destination" registerMethod="registerDestination" beanClass="org.frankframework.monitoring.IMonitorAdapter"/>
+	<rule pattern="*/destination" registerMethod="addDestination" beanClass="org.frankframework.monitoring.IMonitorAdapter"/>
 
 	<rule pattern="*/monitor" registerMethod="addMonitor" beanClass="org.frankframework.monitoring.Monitor"/>
 
-	<rule pattern="*/monitor/trigger" registerMethod="registerTrigger" beanClass="org.frankframework.monitoring.Trigger"/>
+	<rule pattern="*/monitor/trigger" registerMethod="addTrigger" beanClass="org.frankframework.monitoring.Trigger"/>
 	<rule pattern="*/monitor/trigger/event" registerTextMethod="addEventCode"/>
 
-	<rule pattern="*/adapterfilter" registerMethod="registerAdapterFilter" beanClass="org.frankframework.monitoring.AdapterFilter"/>
+	<rule pattern="*/adapterfilter" registerMethod="addAdapterFilter" beanClass="org.frankframework.monitoring.AdapterFilter"/>
 	<rule pattern="*/adapterfilter/source" registerTextMethod="registerSubObject"/>
 </digester-rules>

--- a/core/src/test/java/org/frankframework/align/TestXmlSchema2JsonSchema.java
+++ b/core/src/test/java/org/frankframework/align/TestXmlSchema2JsonSchema.java
@@ -44,7 +44,7 @@ public class TestXmlSchema2JsonSchema extends AlignTestBase {
 		String jsonString = getTestFile(inputFile + (skipJsonRootElements ? "-compact" : "-full") + ".json");
 
 		Json2XmlValidator validator = new Json2XmlValidator();
-		validator.registerForward(new PipeForward("success", null));
+		validator.addForward(new PipeForward("success", null));
 		validator.setThrowException(true);
 		if (StringUtils.isNotEmpty(namespace)) {
 			validator.setSchemaLocation(namespace + " " + BASEDIR + schemaFile);

--- a/core/src/test/java/org/frankframework/configuration/AutoConfiguringAdapterManager.java
+++ b/core/src/test/java/org/frankframework/configuration/AutoConfiguringAdapterManager.java
@@ -8,8 +8,8 @@ import org.frankframework.core.Adapter;
 public class AutoConfiguringAdapterManager extends AdapterManager {
 
 	@Override
-	public void registerAdapter(Adapter adapter) {
-		super.registerAdapter(adapter);
+	public void addAdapter(Adapter adapter) {
+		super.addAdapter(adapter);
 		try {
 			adapter.configure();
 		} catch (ConfigurationException e) {

--- a/core/src/test/java/org/frankframework/configuration/ClassLoaderManagerTest.java
+++ b/core/src/test/java/org/frankframework/configuration/ClassLoaderManagerTest.java
@@ -126,7 +126,7 @@ public class ClassLoaderManagerTest extends Mockito {
 		JmsRealm jmsRealm = spy(new JmsRealm());
 		jmsRealm.setDatasourceName("fake");
 		jmsRealm.setRealmName("myRealm");
-		JmsRealmFactory.getInstance().registerJmsRealm(jmsRealm);
+		JmsRealmFactory.getInstance().addJmsRealm(jmsRealm);
 		FixedQuerySender fq = mock(FixedQuerySender.class);
 		doReturn(new GenericDbmsSupport()).when(fq).getDbmsSupport();
 

--- a/core/src/test/java/org/frankframework/configuration/classloaders/DatabaseClassLoaderTest.java
+++ b/core/src/test/java/org/frankframework/configuration/classloaders/DatabaseClassLoaderTest.java
@@ -70,7 +70,7 @@ public class DatabaseClassLoaderTest extends ConfigurationClassLoaderTestBase<Da
 		JmsRealm jmsRealm = spy(new JmsRealm());
 		jmsRealm.setDatasourceName("fake");
 		jmsRealm.setRealmName("myRealm");
-		JmsRealmFactory.getInstance().registerJmsRealm(jmsRealm);
+		JmsRealmFactory.getInstance().addJmsRealm(jmsRealm);
 	}
 
 	private void mockDatabase() throws Exception {

--- a/core/src/test/java/org/frankframework/core/AdapterHideRegexTest.java
+++ b/core/src/test/java/org/frankframework/core/AdapterHideRegexTest.java
@@ -113,11 +113,11 @@ public class AdapterHideRegexTest {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName(exitState.name());
 		ple.setState(exitState);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		adapter.setPipeLine(pl);
 
-		adapter.registerReceiver(receiver);
-		configuration.registerAdapter(adapter);
+		adapter.addReceiver(receiver);
+		configuration.addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/core/PipeLineTest.java
+++ b/core/src/test/java/org/frankframework/core/PipeLineTest.java
@@ -50,8 +50,8 @@ public class PipeLineTest {
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("success");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		adapter.setPipeLine(pipeline);
 
 		List<String> warnings = configuration.getConfigurationWarnings().getWarnings();
@@ -78,7 +78,7 @@ public class PipeLineTest {
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		pipeline.configure();
 
 		assertTrue(configuration.getConfigurationWarnings().getWarnings().isEmpty(), "pipe should not cause any configuration warnings");
@@ -108,15 +108,15 @@ public class PipeLineTest {
 		PipeLineExit errorExit = new PipeLineExit();
 		errorExit.setName("error");
 		errorExit.setState(ExitState.ERROR);
-		pipeline.registerPipeLineExit(errorExit);
+		pipeline.addPipeLineExit(errorExit);
 		PipeLineExit successExit = new PipeLineExit();
 		successExit.setName("exit");
 		successExit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(successExit);
+		pipeline.addPipeLineExit(successExit);
 		PipeLineExit successExit2 = new PipeLineExit();
 		successExit2.setName("exit2");
 		successExit2.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(successExit2);
+		pipeline.addPipeLineExit(successExit2);
 
 		// Act
 		pipeline.configure();
@@ -137,20 +137,20 @@ public class PipeLineTest {
 
 		IPipe pipe = configuration.createBean(EchoPipe.class);
 		pipe.setName(pipe.getClass().getSimpleName()+" under test");
-		pipe.registerForward(new PipeForward("success", pipeForwardName));
+		pipe.addForward(new PipeForward("success", pipeForwardName));
 		pipe.setPipeLine(pipeline);
 		pipeline.addPipe(pipe);
 
 		IPipe pipe2 = configuration.createBean(EchoPipe.class);
 		pipe2.setName(pipeForwardName);
-		pipe.registerForward(new PipeForward("success", "exit"));
+		pipe.addForward(new PipeForward("success", "exit"));
 		pipe2.setPipeLine(pipeline);
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		pipeline.configure();
 
 		assertTrue(configuration.getConfigurationWarnings().getWarnings().isEmpty(), "pipe should not cause any configuration warnings");
@@ -168,24 +168,24 @@ public class PipeLineTest {
 
 		EchoPipe pipe = configuration.createBean(EchoPipe.class);
 		pipe.setName(pipe.getClass().getSimpleName()+" under test");
-		pipe.registerForward(new PipeForward("success", pipeForwardName));
-		pipe.registerForward(new PipeForward("success", pipeForwardName));
+		pipe.addForward(new PipeForward("success", pipeForwardName));
+		pipe.addForward(new PipeForward("success", pipeForwardName));
 		pipe.setPipeLine(pipeline);
 		pipeline.addPipe(pipe);
 
 		EchoPipe pipe2 = configuration.createBean(EchoPipe.class);
 		pipe2.setName(pipeForwardName);
-		pipe.registerForward(new PipeForward("success", "exit"));
-		pipe.registerForward(new PipeForward("success", "exit"));
-		pipe.registerForward(new PipeForward("success", "exit"));
-		pipe.registerForward(new PipeForward("success", "exit")); // Surprisingly this doesn't cause any warnings
+		pipe.addForward(new PipeForward("success", "exit"));
+		pipe.addForward(new PipeForward("success", "exit"));
+		pipe.addForward(new PipeForward("success", "exit"));
+		pipe.addForward(new PipeForward("success", "exit")); // Surprisingly this doesn't cause any warnings
 		pipe2.setPipeLine(pipeline);
 		pipeline.addPipe(pipe2);
 
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		pipeline.configure();
 
 		assertEquals(1, configuration.getConfigurationWarnings().getWarnings().size(), "pipes should cause a configuration warning");
@@ -204,7 +204,7 @@ public class PipeLineTest {
 
 		EchoPipe pipe = configuration.createBean(EchoPipe.class);
 		pipe.setName(pipe.getClass().getSimpleName()+" under test");
-		pipe.registerForward(new PipeForward("success", "the next pipe"));
+		pipe.addForward(new PipeForward("success", "the next pipe"));
 		pipe.setPipeLine(pipeline);
 		pipeline.addPipe(pipe);
 
@@ -216,7 +216,7 @@ public class PipeLineTest {
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("special exit name");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		pipeline.configure();
 
 		assertEquals(1, configuration.getConfigurationWarnings().getWarnings().size(), "pipes should cause a configuration warning");
@@ -253,7 +253,7 @@ public class PipeLineTest {
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		pipeline.configure();
 
 		assertTrue(configuration.getConfigurationWarnings().getWarnings().isEmpty(), "pipe should not cause any configuration warnings");

--- a/core/src/test/java/org/frankframework/http/openapi/OpenApiTestBase.java
+++ b/core/src/test/java/org/frankframework/http/openapi/OpenApiTestBase.java
@@ -295,14 +295,14 @@ public class OpenApiTestBase extends Mockito {
 			for (PipeLineExit exit : exits) {
 				exit.setName("success" + exit.getExitCode());
 
-				pipeline.registerPipeLineExit(exit);
+				pipeline.addPipeLineExit(exit);
 			}
 			IPipe pipe = new EchoPipe();
 			pipe.setName("echo");
 			pipeline.addPipe(pipe);
 
 			adapter.setPipeLine(pipeline);
-			adapter.registerReceiver(receiver);
+			adapter.addReceiver(receiver);
 			adapter.configure();
 
 			assertTrue(adapter.configurationSucceeded(), "adapter failed to configure!?");

--- a/core/src/test/java/org/frankframework/http/rest/ApiServiceDispatcherTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiServiceDispatcherTest.java
@@ -273,7 +273,7 @@ public class ApiServiceDispatcherTest {
 		successForward.setName(forwardName);
 		successForward.setPath(forwardName);
 
-		echoPipe.registerForward(successForward);
+		echoPipe.addForward(successForward);
 
 		return echoPipe;
 	}
@@ -291,7 +291,7 @@ public class ApiServiceDispatcherTest {
 		PipeForward pipeForward = new PipeForward();
 		pipeForward.setName(forwardName);
 
-		json2xmlInput.registerForward(pipeForward);
+		json2xmlInput.addForward(pipeForward);
 		return json2xmlInput;
 	}
 
@@ -305,8 +305,8 @@ public class ApiServiceDispatcherTest {
 		failure.setState(PipeLine.ExitState.ERROR);
 
 		PipeLineExits exits = new PipeLineExits();
-		exits.registerPipeLineExit(success);
-		exits.registerPipeLineExit(failure);
+		exits.addPipeLineExit(success);
+		exits.addPipeLineExit(failure);
 		return exits;
 	}
 }

--- a/core/src/test/java/org/frankframework/jdbc/JdbcEnabledPipeTestBase.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcEnabledPipeTestBase.java
@@ -32,14 +32,14 @@ public abstract class JdbcEnabledPipeTestBase<P extends IPipe> {
 		this.env = env;
 		pipe = createPipe();
 		env.autowire(pipe);
-		pipe.registerForward(new PipeForward("success", "exit"));
+		pipe.addForward(new PipeForward("success", "exit"));
 		pipe.setName(pipe.getClass().getSimpleName()+" under test");
 		pipeline = env.createBean(PipeLine.class);
 		pipeline.addPipe(pipe);
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 		adapter = env.createBean(Adapter.class);
 		adapter.setName("TestAdapter-for-".concat(pipe.getClass().getSimpleName()));
 		adapter.setPipeLine(pipeline);

--- a/core/src/test/java/org/frankframework/jms/JmsRealmFactoryTest.java
+++ b/core/src/test/java/org/frankframework/jms/JmsRealmFactoryTest.java
@@ -21,10 +21,10 @@ public class JmsRealmFactoryTest {
 	public void setup() {
 		jmsRealmFactory = JmsRealmFactory.getInstance();
 		jmsRealmFactory.clear();
-		jmsRealmFactory.registerJmsRealm(createRealm("c",false));
-		jmsRealmFactory.registerJmsRealm(createRealm("b",true));
-		jmsRealmFactory.registerJmsRealm(createRealm("d",false));
-		jmsRealmFactory.registerJmsRealm(createRealm("a",true));
+		jmsRealmFactory.addJmsRealm(createRealm("c",false));
+		jmsRealmFactory.addJmsRealm(createRealm("b",true));
+		jmsRealmFactory.addJmsRealm(createRealm("d",false));
+		jmsRealmFactory.addJmsRealm(createRealm("a",true));
 	}
 
 	public JmsRealm createRealm(String name, boolean withDatasourceName) {

--- a/core/src/test/java/org/frankframework/ldap/LdapFindMemberPipeTest.java
+++ b/core/src/test/java/org/frankframework/ldap/LdapFindMemberPipeTest.java
@@ -32,8 +32,8 @@ public class LdapFindMemberPipeTest extends PipeTestBase<LdapFindMemberPipe> {
 	@Override
 	public LdapFindMemberPipe createPipe() throws ConfigurationException {
 		var pipe = spy(new LdapFindMemberPipe());
-		pipe.registerForward(new PipeForward(SUCCESS_FORWARD, SUCCESS_FORWARD));
-		pipe.registerForward(new PipeForward(NOT_FOUND_FORWARD, NOT_FOUND_FORWARD));
+		pipe.addForward(new PipeForward(SUCCESS_FORWARD, SUCCESS_FORWARD));
+		pipe.addForward(new PipeForward(NOT_FOUND_FORWARD, NOT_FOUND_FORWARD));
 
 		return pipe;
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseMessageBrowsers.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseMessageBrowsers.java
@@ -97,7 +97,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 		receiver.setName("ReceiverName");
 		receiver.setListener(listener);
 		doAnswer(p -> { throw new ListenerException("testing message ->"+p.getArgument(0)); }).when(receiver).retryMessage(anyString()); //does not actually test the retry mechanism
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = SpringUtils.createBean(configuration, PipeLine.class);
 		SenderPipe pipe = SpringUtils.createBean(configuration, SenderPipe.class);
 		pipe.setMessageLog(getTransactionalStorage());
@@ -107,7 +107,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 		adapter.setPipeLine(pipeline);
 
 		adapter.configure();
-		getConfiguration().getAdapterManager().registerAdapter(adapter);
+		getConfiguration().getAdapterManager().addAdapter(adapter);
 
 		return adapter;
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseQueue.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseQueue.java
@@ -32,7 +32,7 @@ public class TestBrowseQueue extends BusTestBase {
 		JmsRealm jmsRealm = new JmsRealm();
 		jmsRealm.setRealmName("dummyQCFAddedViaJmsRealm");
 		jmsRealm.setQueueConnectionFactoryName("dummyQCFAddedViaJmsRealm");
-		JmsRealmFactory.getInstance().registerJmsRealm(jmsRealm);
+		JmsRealmFactory.getInstance().addJmsRealm(jmsRealm);
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestConnectionOverview.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestConnectionOverview.java
@@ -40,14 +40,14 @@ public class TestConnectionOverview extends BusTestBase {
 		Receiver<String> receiver = new Receiver<>();
 		receiver.setName("ReceiverName");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = new PipeLine();
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
 		pipe.setName("EchoPipe");
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestHealth.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestHealth.java
@@ -36,14 +36,14 @@ public class TestHealth extends BusTestBase {
 		Receiver<String> receiver = new Receiver<>();
 		receiver.setName("ReceiverName");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = new PipeLine();
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
 		pipe.setName("EchoPipe");
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestInlineStorage.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestInlineStorage.java
@@ -72,7 +72,7 @@ public class TestInlineStorage extends BusTestBase {
 		Receiver<String> receiver = SpringUtils.createBean(configuration, Receiver.class);
 		receiver.setName("ReceiverName");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = SpringUtils.createBean(configuration, PipeLine.class);
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
 		pipe.setName("EchoPipe");
@@ -80,7 +80,7 @@ public class TestInlineStorage extends BusTestBase {
 		adapter.setPipeLine(pipeline);
 
 		adapter.configure();
-		getAdapterManager().registerAdapter(adapter);
+		getAdapterManager().addAdapter(adapter);
 
 		return adapter;
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestManageSchedule.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestManageSchedule.java
@@ -46,14 +46,14 @@ public class TestManageSchedule extends BusTestBase {
 		Receiver<String> receiver = new Receiver<>();
 		receiver.setName("ReceiverName");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = new PipeLine();
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
 		pipe.setName("EchoPipe");
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
@@ -77,10 +77,10 @@ public class TestMonitoring extends BusTestBase {
 		trigger.setThreshold(1337);
 		trigger.setSeverity(Severity.HARMLESS);
 		trigger.setTriggerType(TriggerType.ALARM);
-		trigger.registerAdapterFilter(filter);
+		trigger.addAdapterFilter(filter);
 		trigger.setSourceFiltering(SourceFiltering.ADAPTER);
 		trigger.addEventCode(TEST_TRIGGER_EVENT_NAME);
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 		manager.addMonitor(monitor);
 		IMonitorDestination ima = new IMonitorDestination() {
 			private @Getter @Setter String name = "mockDestination";
@@ -100,7 +100,7 @@ public class TestMonitoring extends BusTestBase {
 				return new XmlBuilder("destination");
 			}
 		};
-		manager.registerDestination(ima);
+		manager.addDestination(ima);
 		manager.configure();
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestPipelineTest.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestPipelineTest.java
@@ -57,7 +57,7 @@ public class TestPipelineTest extends BusTestBase {
 		SpringUtils.autowireByName(configuration, adapter);
 		adapter.setName(TEST_PIPELINE_ADAPER_NAME);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestSecurityItems.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestSecurityItems.java
@@ -25,12 +25,12 @@ public class TestSecurityItems extends BusTestBase {
 		JmsRealm jdbcRealm = new JmsRealm();
 		jdbcRealm.setRealmName("dummyJmsRealm1");
 		jdbcRealm.setDatasourceName("dummyDatasourceName");
-		JmsRealmFactory.getInstance().registerJmsRealm(jdbcRealm);
+		JmsRealmFactory.getInstance().addJmsRealm(jdbcRealm);
 
 		JmsRealm jmsRealm = new JmsRealm();
 		jmsRealm.setRealmName("dummyJmsRealm2");
 		jmsRealm.setQueueConnectionFactoryName("dummyQCF");
-		JmsRealmFactory.getInstance().registerJmsRealm(jmsRealm);
+		JmsRealmFactory.getInstance().addJmsRealm(jmsRealm);
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
@@ -74,7 +74,7 @@ public class TestWebServices extends BusTestBase {
 		receiver.setName("ReceiverName2");
 		listener.setReceiver(receiver);
 		receiver.setAdapter(adapter);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		PipeLine pipeline = new PipeLine();
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
 		pipe.setName("EchoPipe");
@@ -95,7 +95,7 @@ public class TestWebServices extends BusTestBase {
 		Receiver receiver = new Receiver<>();
 		receiver.setName("ReceiverName1");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		receiver.setAdapter(adapter);
 		PipeLine pipeline = new PipeLine();
 		EchoPipe pipe = SpringUtils.createBean(configuration, EchoPipe.class);
@@ -103,7 +103,7 @@ public class TestWebServices extends BusTestBase {
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 
@@ -117,7 +117,7 @@ public class TestWebServices extends BusTestBase {
 		Receiver receiver = new Receiver<>();
 		receiver.setName("ReceiverName3");
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		receiver.setAdapter(adapter);
 		PipeLine pipeline = new PipeLine();
 		XmlValidator validator = new XmlValidator();
@@ -128,7 +128,7 @@ public class TestWebServices extends BusTestBase {
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 
-		getConfiguration().registerAdapter(adapter);
+		getConfiguration().addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/metrics/TestLocalStatisticsRegistry.java
+++ b/core/src/test/java/org/frankframework/metrics/TestLocalStatisticsRegistry.java
@@ -66,9 +66,9 @@ public class TestLocalStatisticsRegistry {
 		receiver.setName("myReceiver");
 		JavaListener<M> listener = configuration.createBean(JavaListener.class);
 		receiver.setListener(listener);
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 
-		configuration.registerAdapter(adapter);
+		configuration.addAdapter(adapter);
 	}
 
 	private static String jsonStructureToString(JsonStructure payload) {

--- a/core/src/test/java/org/frankframework/monitoring/MonitorTest.java
+++ b/core/src/test/java/org/frankframework/monitoring/MonitorTest.java
@@ -43,7 +43,7 @@ public class MonitorTest {
 		Alarm trigger = configuration.createBean(Alarm.class);
 		trigger.addEventCode(EVENT_CODE);
 		trigger.setSeverity(Severity.CRITICAL);
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 
 		manager.addMonitor(monitor);
 
@@ -52,7 +52,7 @@ public class MonitorTest {
 
 		MessageCapturingEchoSender sender = new  MessageCapturingEchoSender();
 		destination.setSender(sender);
-		manager.registerDestination(destination);
+		manager.addDestination(destination);
 		monitor.setDestinations(destination.getName());
 		Message message = new Message("very important message");
 		message.getContext().put("special-key", 123);

--- a/core/src/test/java/org/frankframework/monitoring/TriggerTest.java
+++ b/core/src/test/java/org/frankframework/monitoring/TriggerTest.java
@@ -50,7 +50,7 @@ public class TriggerTest implements EventThrowing {
 
 		monitor.setName("monitorName");
 		manager.addMonitor(monitor);
-		manager.registerDestination(destination);
+		manager.addDestination(destination);
 		monitor.setDestinations(destination.getName());
 	}
 
@@ -65,7 +65,7 @@ public class TriggerTest implements EventThrowing {
 
 		doNothing().when(destination).fireEvent(anyString(), eventTypeCaptor.capture(), severityCaptor.capture(), anyString(), monitorEventCaptor.capture());
 
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 
 		trigger.addEventCode(EVENT_CODE);
 		trigger.setSeverity(Severity.CRITICAL);
@@ -111,7 +111,7 @@ public class TriggerTest implements EventThrowing {
 
 		doNothing().when(destination).fireEvent(anyString(), eventTypeCaptor.capture(), severityCaptor.capture(), eventCode.capture(), monitorEventCaptor.capture());
 
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 
 		trigger.addEventCode(EVENT_CODE);
 		trigger.setSeverity(Severity.CRITICAL);
@@ -160,7 +160,7 @@ public class TriggerTest implements EventThrowing {
 
 		doNothing().when(destination).fireEvent(anyString(), eventTypeCaptor.capture(), severityCaptor.capture(), anyString(), monitorEventCaptor.capture());
 
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 		monitor.setAlarmSeverity(Severity.WARNING);
 
 		trigger.addEventCode(EVENT_CODE);
@@ -204,7 +204,7 @@ public class TriggerTest implements EventThrowing {
 
 		doNothing().when(destination).fireEvent(anyString(), eventTypeCaptor.capture(), severityCaptor.capture(), eventCode.capture(), monitorEventCaptor.capture());
 
-		monitor.registerTrigger(trigger);
+		monitor.addTrigger(trigger);
 
 		trigger.addEventCode(EVENT_CODE);
 		trigger.setSeverity(Severity.CRITICAL);
@@ -256,8 +256,8 @@ public class TriggerTest implements EventThrowing {
 		when(destination.toXml()).thenReturn(new XmlBuilder("destination"));
 
 		manager.addMonitor(monitor);
-		monitor.registerTrigger(trigger);
-		manager.registerDestination(destination);
+		monitor.addTrigger(trigger);
+		manager.addDestination(destination);
 		monitor.setDestinations(destination.getName());
 		trigger.addEventCode(EVENT_CODE);
 		trigger.setSeverity(Severity.CRITICAL);

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -1069,7 +1069,7 @@ public class ParameterTest {
 			PipeLineExit exit = new PipeLineExit();
 			exit.setName("exit");
 			exit.setState(ExitState.SUCCESS);
-			pipeline.registerPipeLineExit(exit);
+			pipeline.addPipeLineExit(exit);
 			pipeline.configure();
 
 			CorePipeLineProcessor cpp = configuration.createBean(CorePipeLineProcessor.class);

--- a/core/src/test/java/org/frankframework/pipes/CompareIntegerPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CompareIntegerPipeTest.java
@@ -19,18 +19,18 @@ class CompareIntegerPipeTest extends PipeTestBase<CompareIntegerPipe> {
 
 	@Test
 	void noSessionKey() throws ConfigurationException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 
 		assertThrows(ConfigurationException.class, pipe::configure, "has neither parameter [operand1] nor parameter [operand2] specified");
 	}
 
 	@Test
 	void happyFlowLessThanFromParameters() throws ConfigurationException, PipeRunException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND1, "4"));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND2, "5"));
 		pipe.configure();
@@ -41,9 +41,9 @@ class CompareIntegerPipeTest extends PipeTestBase<CompareIntegerPipe> {
 
 	@Test
 	void happyFlowGreaterThanFromParameters() throws ConfigurationException, PipeRunException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND1, "5"));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND2, "4"));
 		pipe.configure();
@@ -54,9 +54,9 @@ class CompareIntegerPipeTest extends PipeTestBase<CompareIntegerPipe> {
 
 	@Test
 	void happyFlowEqualsFromParameters() throws ConfigurationException, PipeRunException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND1, "5"));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND2, "5"));
 		pipe.configure();
@@ -67,9 +67,9 @@ class CompareIntegerPipeTest extends PipeTestBase<CompareIntegerPipe> {
 
 	@Test
 	void happyFlowEqualsOperand1InputMessage() throws ConfigurationException, PipeRunException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND2, "5"));
 		pipe.configure();
 
@@ -79,9 +79,9 @@ class CompareIntegerPipeTest extends PipeTestBase<CompareIntegerPipe> {
 
 	@Test
 	void numberFormatExceptionFromMessageOperand() throws ConfigurationException {
-		pipe.registerForward(new PipeForward("lessthan", null));
-		pipe.registerForward(new PipeForward("greaterthan", null));
-		pipe.registerForward(new PipeForward("equals", null));
+		pipe.addForward(new PipeForward("lessthan", null));
+		pipe.addForward(new PipeForward("greaterthan", null));
+		pipe.addForward(new PipeForward("equals", null));
 		pipe.addParameter(new Parameter(CompareIntegerPipe.OPERAND1, "5"));
 		pipe.configure();
 

--- a/core/src/test/java/org/frankframework/pipes/CompareStringPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CompareStringPipeTest.java
@@ -21,9 +21,9 @@ class CompareStringPipeTest extends PipeTestBase<CompareStringPipe> {
 	public CompareStringPipe createPipe() throws ConfigurationException {
 		CompareStringPipe pipe = new CompareStringPipe();
 
-		pipe.registerForward(new PipeForward(LESS_THAN, null));
-		pipe.registerForward(new PipeForward(GREATER_THAN, null));
-		pipe.registerForward(new PipeForward(EQUALS, null));
+		pipe.addForward(new PipeForward(LESS_THAN, null));
+		pipe.addForward(new PipeForward(GREATER_THAN, null));
+		pipe.addForward(new PipeForward(EQUALS, null));
 
 		return pipe;
 	}

--- a/core/src/test/java/org/frankframework/pipes/CompressPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CompressPipeTest.java
@@ -132,7 +132,7 @@ public class CompressPipeTest extends PipeTestBase<CompressPipe> {
 	public void testExceptionForward() throws Exception {
 		pipe.setMessageIsContent(true);
 		pipe.setResultIsContent(true);
-		pipe.registerForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME, "dummy"));
+		pipe.addForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME, "dummy"));
 
 		configureAndStartPipe();
 		PipeRunResult prr = doPipe(pipe, DUMMY_STRING_SEMI_COLON, session);

--- a/core/src/test/java/org/frankframework/pipes/ConsecutiveXsltPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ConsecutiveXsltPipeTest.java
@@ -25,7 +25,7 @@ public class ConsecutiveXsltPipeTest extends PipeTestBase<XsltPipe> {
 		XsltPipe first = new XsltPipe();
 		first.setName("XsltPipe");
 		first.setStyleSheetName("/Xslt/extract.xslt");
-		first.registerForward(new PipeForward("success", "nextPipe"));
+		first.addForward(new PipeForward("success", "nextPipe"));
 		autowireByType(first);
 		autowireByName(first);
 		pipeline.addPipe(first);

--- a/core/src/test/java/org/frankframework/pipes/CounterSwitchPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CounterSwitchPipeTest.java
@@ -13,8 +13,8 @@ public class CounterSwitchPipeTest extends PipeTestBase<CounterSwitchPipe> {
 	@Override
 	public CounterSwitchPipe createPipe() throws ConfigurationException {
 		CounterSwitchPipe pipe = new CounterSwitchPipe();
-		pipe.registerForward(new PipeForward("1", null));
-		pipe.registerForward(new PipeForward("2", null));
+		pipe.addForward(new PipeForward("1", null));
+		pipe.addForward(new PipeForward("2", null));
 		return pipe;
 	}
 

--- a/core/src/test/java/org/frankframework/pipes/FixedResultPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/FixedResultPipeTest.java
@@ -265,7 +265,7 @@ public class FixedResultPipeTest extends PipeTestBase<FixedResultPipe> {
 		session.put("filename", "nofile");
 
 		pipe.setFilenameSessionKey("filename");
-		pipe.registerForward(new PipeForward("filenotfound", "dummy"));
+		pipe.addForward(new PipeForward("filenotfound", "dummy"));
 		pipe.configure();
 
 		PipeRunResult res = doPipe(pipe, "propValueFromInput", session);

--- a/core/src/test/java/org/frankframework/pipes/ForEachChildElementPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ForEachChildElementPipeTest.java
@@ -714,7 +714,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
 		SwitchCounter sc = new SwitchCounter();
 		pipe.setSender(getElementRenderer());
 		pipe.setStopConditionXPathExpression("*[@name='p & Q']");
-		pipe.registerForward(new PipeForward(StopReason.STOP_CONDITION_MET.getForwardName(), "dummy"));
+		pipe.addForward(new PipeForward(StopReason.STOP_CONDITION_MET.getForwardName(), "dummy"));
 		configurePipe();
 		pipe.start();
 
@@ -768,7 +768,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
 		SwitchCounter sc = new SwitchCounter();
 		pipe.setSender(getElementRenderer());
 		pipe.setMaxItems(1);
-		pipe.registerForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
+		pipe.addForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
 		configurePipe();
 		pipe.start();
 
@@ -804,7 +804,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
 		SwitchCounter sc = new SwitchCounter();
 		pipe.setSender(getElementRenderer());
 		pipe.setMaxItems(2);
-		pipe.registerForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
+		pipe.addForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
 		configurePipe();
 		pipe.start();
 

--- a/core/src/test/java/org/frankframework/pipes/ForPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ForPipeTest.java
@@ -39,8 +39,8 @@ public class ForPipeTest extends PipeTestBase<ForPipe> {
 
 	@Test
 	void assertForwardsSet() throws ConfigurationException, PipeStartException {
-		pipe.registerForward(new PipeForward("continue", null));
-		pipe.registerForward(new PipeForward("stop", null));
+		pipe.addForward(new PipeForward("continue", null));
+		pipe.addForward(new PipeForward("stop", null));
 		pipe.setStopAt(10);
 		configureAndStartPipe();
 
@@ -52,8 +52,8 @@ public class ForPipeTest extends PipeTestBase<ForPipe> {
 		pipe.addParameter(NumberParameterBuilder.create().withName(ForPipe.STOP_AT_PARAMETER_VALUE).withValue(10));
 		pipe.setStopAt(10);
 
-		pipe.registerForward(new PipeForward("continue", null));
-		pipe.registerForward(new PipeForward("stop", null));
+		pipe.addForward(new PipeForward("continue", null));
+		pipe.addForward(new PipeForward("stop", null));
 		configureAndStartPipe();
 
 		List<String> warnings = getConfigurationWarnings().getWarnings();
@@ -70,8 +70,8 @@ public class ForPipeTest extends PipeTestBase<ForPipe> {
 
 		pipe.setStartAt(10);
 		pipe.setStopAt(10);
-		pipe.registerForward(new PipeForward("continue", null));
-		pipe.registerForward(new PipeForward("stop", null));
+		pipe.addForward(new PipeForward("continue", null));
+		pipe.addForward(new PipeForward("stop", null));
 		configureAndStartPipe();
 
 		// Assert that we start at 10
@@ -100,8 +100,8 @@ public class ForPipeTest extends PipeTestBase<ForPipe> {
 			pipe.setStopAt(10);
 		}
 
-		pipe.registerForward(new PipeForward("continue", null));
-		pipe.registerForward(new PipeForward("stop", null));
+		pipe.addForward(new PipeForward("continue", null));
+		pipe.addForward(new PipeForward("stop", null));
 		configureAndStartPipe();
 
 		// Assert that we start at 10
@@ -124,8 +124,8 @@ public class ForPipeTest extends PipeTestBase<ForPipe> {
 		String dummyInput = "dummyInput";
 
 		pipe.addParameter(new Parameter(ForPipe.STOP_AT_PARAMETER_VALUE, ""));
-		pipe.registerForward(new PipeForward("continue", null));
-		pipe.registerForward(new PipeForward("stop", null));
+		pipe.addForward(new PipeForward("continue", null));
+		pipe.addForward(new PipeForward("stop", null));
 
 		configureAndStartPipe();
 

--- a/core/src/test/java/org/frankframework/pipes/ForwardHandlingTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ForwardHandlingTest.java
@@ -31,7 +31,7 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 	void testFindForwardToPipeExplicit() throws ConfigurationException {
 		XmlSwitch pipe1 = new XmlSwitch();
 		pipe1.setName("pipe1");
-		pipe1.registerForward(new PipeForward("fakeForward", "pipe3"));
+		pipe1.addForward(new PipeForward("fakeForward", "pipe3"));
 		pipeline.addPipe(pipe1);
 
 		EchoPipe pipe2 = new EchoPipe();
@@ -99,7 +99,7 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 	void testFindForwardToExitExplicit() throws ConfigurationException {
 		XmlSwitch pipe1 = new XmlSwitch();
 		pipe1.setName("pipe1");
-		pipe1.registerForward(new PipeForward("ready", "READY"));
+		pipe1.addForward(new PipeForward("ready", "READY"));
 		pipeline.addPipe(pipe1);
 
 		EchoPipe pipe2 = new EchoPipe();
@@ -140,8 +140,8 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", null)));
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("thisForwardDoesntExist", null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("thisForwardDoesntExist", null)));
 
 		assertDoesNotThrow(pipe::configure);
 		List<String> warnings = getConfigurationWarnings().getWarnings();
@@ -158,8 +158,8 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", null))); // FixedForwardPipe requires a SUCCESS forward
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward(forwardName, null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", null))); // FixedForwardPipe requires a SUCCESS forward
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward(forwardName, null)));
 
 		assertDoesNotThrow(pipe::configure);
 		List<String> warnings = getConfigurationWarnings().getWarnings();
@@ -174,8 +174,8 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", "Sergi")));
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", "Sergi")));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", "Sergi")));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", "Sergi")));
 
 		assertDoesNotThrow(pipe::configure);
 		List<String> warnings = getConfigurationWarnings().getWarnings();
@@ -191,8 +191,8 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 			pipeline.addPipe(pipe);
 			autowireByType(pipe);
 
-			assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", "Sergi1")));
-			assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", "Sergi2")));
+			assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", "Sergi1")));
+			assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", "Sergi2")));
 			assertDoesNotThrow(pipe::configure);
 
 			assertTrue(appender.contains("INFO - PipeForward [success] already registered, pointing to [Sergi1]. Ignoring new one, that points to [Sergi2]"), "Log messages: "+appender.getLogLines());
@@ -206,7 +206,7 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", null)));
 	}
 
 	@Test
@@ -216,7 +216,7 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("thisForwardDoesntExist", null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("thisForwardDoesntExist", null)));
 	}
 
 	@Test
@@ -226,7 +226,7 @@ class ForwardHandlingTest extends ConfiguredTestBase {
 		pipeline.addPipe(pipe);
 		autowireByType(pipe);
 
-		assertDoesNotThrow(() -> pipe.registerForward(new PipeForward("success", null)));
+		assertDoesNotThrow(() -> pipe.addForward(new PipeForward("success", null)));
 	}
 
 }

--- a/core/src/test/java/org/frankframework/pipes/GetPrincipalPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/GetPrincipalPipeTest.java
@@ -68,7 +68,7 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 		// Given
 		PipeForward notFound = new PipeForward(NOT_FOUND_FORWARD_NAME, NOT_FOUND_FORWARD_PATH);
 		pipe.setNotFoundForwardName(NOT_FOUND_FORWARD_NAME);
-		pipe.registerForward(notFound);
+		pipe.addForward(notFound);
 
 		// Expect/When
 		assertDoesNotThrow(() -> pipe.configure());
@@ -152,7 +152,7 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 
 		PipeForward notFound = new PipeForward(NOT_FOUND_FORWARD_NAME, NOT_FOUND_FORWARD_PATH);
 		pipe.setNotFoundForwardName(NOT_FOUND_FORWARD_NAME);
-		pipe.registerForward(notFound);
+		pipe.addForward(notFound);
 		pipe.configure();
 		pipe.start();
 
@@ -174,7 +174,7 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 
 		PipeForward notFound = new PipeForward(NOT_FOUND_FORWARD_NAME, NOT_FOUND_FORWARD_PATH);
 		pipe.setNotFoundForwardName(NOT_FOUND_FORWARD_NAME);
-		pipe.registerForward(notFound);
+		pipe.addForward(notFound);
 		pipe.configure();
 		pipe.start();
 
@@ -196,7 +196,7 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 
 		PipeForward notFound = new PipeForward(NOT_FOUND_FORWARD_NAME, NOT_FOUND_FORWARD_PATH);
 		pipe.setNotFoundForwardName(NOT_FOUND_FORWARD_NAME);
-		pipe.registerForward(notFound);
+		pipe.addForward(notFound);
 		pipe.configure();
 		pipe.start();
 

--- a/core/src/test/java/org/frankframework/pipes/IsUserInRolePipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IsUserInRolePipeTest.java
@@ -140,9 +140,9 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 		when(securityHandler.isUserInRole(ROLE3)).thenReturn(true);
 
 		setNotInRoleForward();
-		pipe.registerForward(new PipeForward(ROLE, ""));
-		pipe.registerForward(new PipeForward(ROLE2, ""));
-		pipe.registerForward(new PipeForward(ROLE3, ""));
+		pipe.addForward(new PipeForward(ROLE, ""));
+		pipe.addForward(new PipeForward(ROLE2, ""));
+		pipe.addForward(new PipeForward(ROLE3, ""));
 		pipe.configure();
 
 		// When
@@ -178,9 +178,9 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 		when(securityHandler.isUserInRole(ROLE3)).thenReturn(true);
 
 		setNotInRoleForward();
-		pipe.registerForward(new PipeForward(ROLE, ""));
-		pipe.registerForward(new PipeForward(ROLE2, ""));
-		pipe.registerForward(new PipeForward(ROLE3, ""));
+		pipe.addForward(new PipeForward(ROLE, ""));
+		pipe.addForward(new PipeForward(ROLE2, ""));
+		pipe.addForward(new PipeForward(ROLE3, ""));
 		pipe.setRole(ROLES);
 		pipe.configure();
 
@@ -216,9 +216,9 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 		when(securityHandler.isUserInRole(ROLE3)).thenReturn(false);
 
 		setNotInRoleForward();
-		pipe.registerForward(new PipeForward(ROLE, ""));
-		pipe.registerForward(new PipeForward(ROLE2, ""));
-		pipe.registerForward(new PipeForward(ROLE3, ""));
+		pipe.addForward(new PipeForward(ROLE, ""));
+		pipe.addForward(new PipeForward(ROLE2, ""));
+		pipe.addForward(new PipeForward(ROLE3, ""));
 		pipe.configure();
 
 		// When
@@ -254,9 +254,9 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 		when(securityHandler.isUserInRole(ROLE3)).thenReturn(false);
 
 		setNotInRoleForward();
-		pipe.registerForward(new PipeForward(ROLE, ""));
-		pipe.registerForward(new PipeForward(ROLE2, ""));
-		pipe.registerForward(new PipeForward(ROLE3, ""));
+		pipe.addForward(new PipeForward(ROLE, ""));
+		pipe.addForward(new PipeForward(ROLE2, ""));
+		pipe.addForward(new PipeForward(ROLE3, ""));
 		pipe.setRole(ROLES);
 		pipe.configure();
 
@@ -269,7 +269,7 @@ class IsUserInRolePipeTest extends PipeTestBase<IsUserInRolePipe> {
 
 	protected void setNotInRoleForward() throws ConfigurationException {
 		PipeForward notInRole = new PipeForward(NOT_IN_ROLE_FORWARD_NAME, NOT_IN_ROLE_FORWARD_PATH);
-		pipe.registerForward(notInRole);
+		pipe.addForward(notInRole);
 	}
 
 

--- a/core/src/test/java/org/frankframework/pipes/IsXmlPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IsXmlPipeTest.java
@@ -21,8 +21,8 @@ public class IsXmlPipeTest extends PipeTestBase<IsXmlPipe> {
 		IsXmlPipe isXmlPipe = new IsXmlPipe();
 
 		//Add default pipes
-		isXmlPipe.registerForward(new PipeForward(pipeForwardThen, null));
-		isXmlPipe.registerForward(new PipeForward(pipeForwardElse, null));
+		isXmlPipe.addForward(new PipeForward(pipeForwardThen, null));
+		isXmlPipe.addForward(new PipeForward(pipeForwardElse, null));
 		return isXmlPipe;
 	}
 
@@ -39,7 +39,7 @@ public class IsXmlPipeTest extends PipeTestBase<IsXmlPipe> {
 	@Test
 	void emptySpaceInputOnValidThenPipeTest() throws Exception {
 		String pipeName = "test123";
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		pipe.setThenForwardName(pipeName);
 		configureAndStartPipe();
 
@@ -60,7 +60,7 @@ public class IsXmlPipeTest extends PipeTestBase<IsXmlPipe> {
 	@Test
 	void tabSpaceInputOnValidThenPipeTest() throws Exception {
 		String pipeName = "test123";
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		pipe.setThenForwardName(pipeName);
 		configureAndStartPipe();
 
@@ -93,7 +93,7 @@ public class IsXmlPipeTest extends PipeTestBase<IsXmlPipe> {
 		String pipeName = "test123";
 
 		pipe.setElseForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName,null));
+		pipe.addForward(new PipeForward(pipeName,null));
 		configureAndStartPipe();
 
 		PipeRunResult prr  = doPipe(pipe, "test1", session);
@@ -104,7 +104,7 @@ public class IsXmlPipeTest extends PipeTestBase<IsXmlPipe> {
 	void validInputOnInvalidThenPipeTest() throws Exception {
 		String pipeName = "test123";
 		pipe.setThenForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName,null));
+		pipe.addForward(new PipeForward(pipeName,null));
 		configureAndStartPipe();
 
 		PipeRunResult prr  = doPipe(pipe, "<test1", session);

--- a/core/src/test/java/org/frankframework/pipes/Json2WsdlXmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/Json2WsdlXmlValidatorTest.java
@@ -76,7 +76,7 @@ public class Json2WsdlXmlValidatorTest extends ValidatorTestBase {
 		val.setWsdl(wsdl);
 //        val.setSoapBody("TradePriceRequest");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.setSoapBody(soapBody);
 		val.setValidateJsonToRootElementOnly(false);
 		val.configure();
@@ -128,7 +128,7 @@ public class Json2WsdlXmlValidatorTest extends ValidatorTestBase {
 		WsdlXmlValidator val = configuration.createBean(WsdlXmlValidator.class);
 		val.setWsdl(wsdl);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.setSoapBody(soapBody);
 		val.configure();
 		val.start();

--- a/core/src/test/java/org/frankframework/pipes/Json2XmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/Json2XmlValidatorTest.java
@@ -110,7 +110,7 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.setName("Response_Validator");
 		pipe.setSchema("/Validation/NoNamespace/bp.xsd");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success",null));
+		pipe.addForward(new PipeForward("success",null));
 		pipe.configure();
 		pipe.start();
 
@@ -620,8 +620,8 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 			pipe.setRoot("a");
 		}
 
-		pipe.registerForward(new PipeForward("failure",null));
-		pipe.registerForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME,null));
+		pipe.addForward(new PipeForward("failure",null));
+		pipe.addForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME,null));
 
 		pipe.configure();
 		pipe.start();
@@ -671,9 +671,9 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 		pipe.setXmlReasonSessionKey("XmlReasons");
 		pipe.setIgnoreUndeclaredElements(ignoreUndeclaredElements);
 
-		pipe.registerForward(new PipeForward("failure",null));
-		pipe.registerForward(new PipeForward("warnings",null));
-		pipe.registerForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME,null));
+		pipe.addForward(new PipeForward("failure",null));
+		pipe.addForward(new PipeForward("warnings",null));
+		pipe.addForward(new PipeForward(PipeForward.EXCEPTION_FORWARD_NAME,null));
 
 		pipe.configure();
 		pipe.start();
@@ -738,7 +738,7 @@ public class Json2XmlValidatorTest extends PipeTestBase<Json2XmlValidator> {
 
 		pipe.setThrowException(true);
 
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		URL json = TestFileUtils.getTestFileURL("/Validation/AttributesOnDifferentLevels/input-"+input+".json");

--- a/core/src/test/java/org/frankframework/pipes/JsonValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/JsonValidatorTest.java
@@ -32,7 +32,7 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 	@Test
 	public void basicInvalid() throws Exception {
 		pipe.setSchema("/Align/FamilyTree/family-compact-family.jsd");
-		pipe.registerForward(new PipeForward("failure", null));
+		pipe.addForward(new PipeForward("failure", null));
 		configureAndStartPipe();
 
 		String input = "{}";
@@ -48,7 +48,7 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 	@Test
 	public void basicNullInput() throws Exception {
 		pipe.setSchema("/Align/FamilyTree/family-compact-family.jsd");
-		pipe.registerForward(new PipeForward("failure", null));
+		pipe.addForward(new PipeForward("failure", null));
 		configureAndStartPipe();
 
 		String input = null;
@@ -64,8 +64,8 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 	@Test
 	public void parserError() throws Exception {
 		pipe.setSchema("/Align/FamilyTree/family-compact-family.jsd");
-		pipe.registerForward(new PipeForward("failure", null));
-		pipe.registerForward(new PipeForward("parserError", null));
+		pipe.addForward(new PipeForward("failure", null));
+		pipe.addForward(new PipeForward("parserError", null));
 		configureAndStartPipe();
 
 		String input = "{asdf";
@@ -93,7 +93,7 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 	@Test
 	public void overrideRootElement() throws Exception {
 		pipe.setSchema("/Align/FamilyTree/family-compact-family.jsd");
-		pipe.registerForward(new PipeForward("failure", null));
+		pipe.addForward(new PipeForward("failure", null));
 		configureAndStartPipe();
 
 		String input = TestFileUtils.getTestFile("/Align/FamilyTree/address.json");
@@ -107,7 +107,7 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 	public void overrideRootElementInvalid() throws Exception {
 		pipe.setSchema("/Align/FamilyTree/family-compact-family.jsd");
 		pipe.setRoot("address");
-		pipe.registerForward(new PipeForward("failure", null));
+		pipe.addForward(new PipeForward("failure", null));
 		configureAndStartPipe();
 
 		String input = "{}";

--- a/core/src/test/java/org/frankframework/pipes/JsonWellFormedCheckerTest.java
+++ b/core/src/test/java/org/frankframework/pipes/JsonWellFormedCheckerTest.java
@@ -36,7 +36,7 @@ public class JsonWellFormedCheckerTest extends PipeTestBase<JsonWellFormedChecke
 	@ParameterizedTest(name = "{index}: input [ {0} ] forward [{1}]")
 	public void runTest(String input, String forward) throws Exception {
 		initJsonWellFormedCheckerTestData(input, forward);
-		pipe.registerForward( new PipeForward("failure", "path") );
+		pipe.addForward( new PipeForward("failure", "path") );
 		pipe.configure();
 		pipe.start();
 		PipeRunResult pipeRunResult = doPipe(pipe, input, session);

--- a/core/src/test/java/org/frankframework/pipes/PasswordHashPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/PasswordHashPipeTest.java
@@ -47,7 +47,7 @@ public class PasswordHashPipeTest extends PipeTestBase<PasswordHashPipe> {
 		String hashed = PasswordHash.createHash("password");
 		session.put("key", hashed + "2132"); // this will make test fail as validation of the hash and the password will not be the same
 		pipe.setHashSessionKey("key");
-		pipe.registerForward(new PipeForward("failure", "random/path"));
+		pipe.addForward(new PipeForward("failure", "random/path"));
 		pipe.configure();
 		PipeRunResult res = doPipe(pipe, "password", session);
 		assertEquals("failure", res.getPipeForward().getName());
@@ -59,7 +59,7 @@ public class PasswordHashPipeTest extends PipeTestBase<PasswordHashPipe> {
 		session.put("key", hashed); // this will make test fail as validation of the hash and the paswword will not
 									// be the same
 		pipe.setHashSessionKey("key");
-		pipe.registerForward(new PipeForward("failure", "random/path"));
+		pipe.addForward(new PipeForward("failure", "random/path"));
 		pipe.configure();
 		PipeRunResult res = doPipe(pipe, "password", session);
 		assertEquals("success", res.getPipeForward().getName());

--- a/core/src/test/java/org/frankframework/pipes/PgpPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/PgpPipeTest.java
@@ -111,10 +111,10 @@ public class PgpPipeTest {
 		encryptPipe = new PGPPipe();
 		decryptPipe = new PGPPipe();
 
-		encryptPipe.registerForward(new PipeForward("success", null));
+		encryptPipe.addForward(new PipeForward("success", null));
 		encryptPipe.setName(encryptPipe.getClass().getSimpleName() + " under test");
 
-		decryptPipe.registerForward(new PipeForward("success", null));
+		decryptPipe.addForward(new PipeForward("success", null));
 		decryptPipe.setName(decryptPipe.getClass().getSimpleName() + " under test");
 	}
 

--- a/core/src/test/java/org/frankframework/pipes/PipeTestBase.java
+++ b/core/src/test/java/org/frankframework/pipes/PipeTestBase.java
@@ -36,7 +36,7 @@ public abstract class PipeTestBase<P extends IPipe> extends ConfiguredTestBase {
 		super.setUp();
 		pipe = createPipe();
 		autowireByType(pipe);
-		pipe.registerForward(new PipeForward("success", "READY"));
+		pipe.addForward(new PipeForward("success", "READY"));
 		pipe.setName(pipe.getClass().getSimpleName()+" under test");
 		pipeline.addPipe(pipe);
 	}

--- a/core/src/test/java/org/frankframework/pipes/PipeTestBasedXmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/PipeTestBasedXmlValidatorTest.java
@@ -23,7 +23,7 @@ public class PipeTestBasedXmlValidatorTest extends PipeTestBase<XmlValidator> {
 		pipe.setRoot("Root");
 		pipe.setReasonSessionKey("reason");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		pipe.setSchemaLocation(SCHEMA_LOCATION_FACET_ERROR);
 		configureAndStartPipe();
 		assertEquals(1, getConfigurationWarnings().size());

--- a/core/src/test/java/org/frankframework/pipes/RegExPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/RegExPipeTest.java
@@ -27,8 +27,8 @@ public class RegExPipeTest extends PipeTestBase<RegExPipe> {
 		RegExPipe pipe = new RegExPipe();
 
 		//Add default pipes
-		pipe.registerForward(new PipeForward(RegExPipe.THEN_FORWARD, null));
-		pipe.registerForward(new PipeForward(RegExPipe.ELSE_FORWARD, null));
+		pipe.addForward(new PipeForward(RegExPipe.THEN_FORWARD, null));
+		pipe.addForward(new PipeForward(RegExPipe.ELSE_FORWARD, null));
 		return pipe;
 	}
 

--- a/core/src/test/java/org/frankframework/pipes/SignaturePipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/SignaturePipeTest.java
@@ -167,7 +167,7 @@ public class SignaturePipeTest extends PipeTestBase<SignaturePipe> {
 
 		PipeForward failure = new PipeForward();
 		failure.setName("failure");
-		pipe.registerForward(failure);
+		pipe.addForward(failure);
 		configureAndStartPipe();
 
 		PipeRunResult prr = doPipe(new Message(testMessage));
@@ -187,7 +187,7 @@ public class SignaturePipeTest extends PipeTestBase<SignaturePipe> {
 
 		PipeForward failure = new PipeForward();
 		failure.setName("failure");
-		pipe.registerForward(failure);
+		pipe.addForward(failure);
 		configureAndStartPipe();
 
 		PipeRunResult prr = doPipe(new Message("otherMessage"));
@@ -205,7 +205,7 @@ public class SignaturePipeTest extends PipeTestBase<SignaturePipe> {
 
 		PipeForward failure = new PipeForward();
 		failure.setName("failure");
-		pipe.registerForward(failure);
+		pipe.addForward(failure);
 		configureAndStartPipe();
 
 		PipeRunResult prr = doPipe(new Message(testMessage));

--- a/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/SoapWrapperPipeTest.java
@@ -625,7 +625,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		// Arrange: inputWrapper 2 - wrap
 		SoapWrapperPipe outputWrapper = createPipe();
 		autowireByType(outputWrapper);
-		outputWrapper.registerForward(new PipeForward("success", PipeLine.OUTPUT_WRAPPER_NAME + "2"));
+		outputWrapper.addForward(new PipeForward("success", PipeLine.OUTPUT_WRAPPER_NAME + "2"));
 		outputWrapper.setName(PipeLine.OUTPUT_WRAPPER_NAME + "1");
 		outputWrapper.setSoapVersion(SoapVersion.SOAP11);
 		pipeline.addPipe(outputWrapper);
@@ -637,7 +637,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		outputWrapper2.setName(PipeLine.OUTPUT_WRAPPER_NAME + "2");
 		outputWrapper2.setDirection(Direction.UNWRAP);
 		outputWrapper2.setRemoveOutputNamespaces(true);
-		outputWrapper2.registerForward(new PipeForward("success", "READY"));
+		outputWrapper2.addForward(new PipeForward("success", "READY"));
 		outputWrapper2.configure();
 		outputWrapper2.start();
 		pipeline.addPipe(outputWrapper2);
@@ -662,7 +662,7 @@ public class SoapWrapperPipeTest extends PipeTestBase<SoapWrapperPipe> {
 		SoapWrapperPipe wrapPipeSoap = createPipe();
 		wrapPipeSoap.setDirection(Direction.WRAP);
 		autowireByType(wrapPipeSoap);
-		wrapPipeSoap.registerForward(new PipeForward("success", "READY"));
+		wrapPipeSoap.addForward(new PipeForward("success", "READY"));
 		wrapPipeSoap.setName(PipeLine.OUTPUT_WRAPPER_NAME);
 		wrapPipeSoap.setSoapVersion(soapVersion);
 		pipeline.addPipe(wrapPipeSoap);

--- a/core/src/test/java/org/frankframework/pipes/StreamLineIteratorPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/StreamLineIteratorPipeTest.java
@@ -174,7 +174,7 @@ class StreamLineIteratorPipeTest extends IteratingPipeTestBase<StreamLineIterato
 		pipe.setLinePrefix("{");
 		pipe.setLineSuffix("}");
 		pipe.setCombineBlocks(true);
-		pipe.registerForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
+		pipe.addForward(new PipeForward(StopReason.MAX_ITEMS_REACHED.getForwardName(), "dummy"));
 		configurePipe();
 		pipe.start();
 
@@ -234,7 +234,7 @@ class StreamLineIteratorPipeTest extends IteratingPipeTestBase<StreamLineIterato
 		pipe.setSender(getElementRenderer());
 		pipe.setStartPosition(4);
 		pipe.setEndPosition(5);
-		pipe.registerForward(new PipeForward(StopReason.STOP_CONDITION_MET.getForwardName(), "dummy"));
+		pipe.addForward(new PipeForward(StopReason.STOP_CONDITION_MET.getForwardName(), "dummy"));
 		pipe.setStopConditionXPathExpression("/block='key 4 nine'");
 		pipe.setCombineBlocks(true);
 		configurePipe();

--- a/core/src/test/java/org/frankframework/pipes/StreamPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/StreamPipeTest.java
@@ -96,7 +96,7 @@ class StreamPipeTest extends PipeTestBase<StreamPipe> {
 		pipe.setCheckAntiVirus(true);
 		PipeForward pipeAntiVirusFailedForward = new PipeForward();
 		pipeAntiVirusFailedForward.setName(StreamPipe.ANTIVIRUS_FAILED_FORWARD);
-		pipe.registerForward(pipeAntiVirusFailedForward);
+		pipe.addForward(pipeAntiVirusFailedForward);
 		MockMultipartHttpServletRequest request = createMultipartHttpRequest(pipe, true, true);
 		pipe.addParameter(createHttpRequestParameter(request, session));
 		pipe.configure();

--- a/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorMixedModeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorMixedModeTest.java
@@ -40,7 +40,7 @@ public class WsdlXmlValidatorMixedModeTest {
 		val.setSoapBody(REQUEST_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		return val;
@@ -52,7 +52,7 @@ public class WsdlXmlValidatorMixedModeTest {
 		val.setSoapBody(RESPONSE_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		return val;
@@ -65,7 +65,7 @@ public class WsdlXmlValidatorMixedModeTest {
 		val.setOutputSoapBody(RESPONSE_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.getResponseValidator().configure();
 		val.start();

--- a/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
@@ -54,7 +54,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setWsdl(SIMPLE);
 		val.setSoapBody("TradePriceRequest");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		val.validate("<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\"><Body><TradePriceRequest xmlns=\"http://example.com/stockquote.xsd\"><tickerSymbol>foo</tickerSymbol></TradePriceRequest></Body></Envelope>", session);
@@ -66,7 +66,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setWsdl(SIMPLE_WITH_INCLUDE);
 		val.setSoapBody("TradePriceRequest");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		val.validate("<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\"><Body><TradePriceRequest xmlns=\"http://example.com/stockquote.xsd\"><tickerSymbol>foo</tickerSymbol></TradePriceRequest></Body></Envelope>", session);
@@ -81,7 +81,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		validator.setSoapVersion(SoapVersion.AUTO);
 		validator.setIgnoreUnknownNamespaces(true);
 		validator.setThrowException(true);
-		validator.registerForward(new PipeForward("success", null));
+		validator.addForward(new PipeForward("success", null));
 
 		// Act
 		validator.configure();
@@ -101,7 +101,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 			validator.setSoapVersion(SoapVersion.AUTO);
 			validator.setIgnoreUnknownNamespaces(true);
 			validator.setThrowException(true);
-			validator.registerForward(new PipeForward("success", null));
+			validator.addForward(new PipeForward("success", null));
 
 			int nrOfWarningsBefore = getConfigurationWarnings().size();
 
@@ -149,7 +149,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setSoapBody("TradePriceRequest,TradePrice,Fault");
 		val.setTargetNamespace("");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 
@@ -182,7 +182,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(MULTIPLE_OPERATIONS);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		session.put("SOAPAction", "add");
 		val.configure();
 		val.start();
@@ -217,7 +217,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(MULTIPLE_OPERATIONS);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		session.put("SOAPAction", "add");
 		val.configure();
 		val.start();
@@ -261,7 +261,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(MULTIPLE_OPERATIONS);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		assertThrows(XmlValidatorException.class, () ->
@@ -284,7 +284,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setWsdl(SIMPLE_WITH_REFERENCE);
 		val.setSoapBody("TradePriceRequest");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		val.validate("<Envelope xmlns=\"http://schemas.xmlsoap.org/soap/envelope/\"><Body><TradePriceRequest xmlns=\"http://example.com/stockquote.xsd\"><tickerSymbol>foo</tickerSymbol></TradePriceRequest></Body></Envelope>", session);
@@ -295,7 +295,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(SIMPLE_WITH_REFERENCE);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		assertThrows(XmlValidatorException.class, () ->
@@ -310,7 +310,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setSoapHeader("MessageHeader");
 		val.setSoapBody("Request");
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		val.validate("""
@@ -348,7 +348,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(TIBCO);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		assertThrows(XmlValidatorException.class, () ->
@@ -387,7 +387,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		WsdlXmlValidator val = pipe;
 		val.setWsdl(TIBCO);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		assertThrows(XmlValidatorException.class, () ->
@@ -428,7 +428,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setWsdl(SIMPLE);
 		val.setSoapBody("TradePriceRequest");
 		val.setForwardFailureToSuccess(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		PipeLineSession pls = new PipeLineSession();
@@ -452,7 +452,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		val.setSoapBodyNamespace("http://frankframework.org/XSD/LifeRetailCB/PolicyJuice/1/GetPolicyDetails/1");
 		val.setAddNamespaceToSchema(true);
 		val.setThrowException(true);
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		assertThrows(ConfigurationException.class, val::configure
 		);
 	}
@@ -465,7 +465,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setAddNamespaceToSchema(true);
 		pipe.setSchemaLocation("http://frankframework.org/XSD/LifeRetailCB/PolicyJuice/1/GetPolicyDetails/1 schema2 http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 ");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		assertEquals(1, getConfigurationWarnings().size());
@@ -483,7 +483,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setAddNamespaceToSchema(true);
 		pipe.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://frankframework.org/XSD/LifeRetailCB/PolicyJuice/1/GetPolicyDetails/2 schema2");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		assertEquals(1, getConfigurationWarnings().size());
@@ -499,7 +499,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setSoapBody("TradePriceRequest");
 		pipe.setSchemaLocation("dummy schema1");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		assertEquals(1, getConfigurationWarnings().size());
@@ -518,7 +518,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setSoapBody("StartIncomingValueTransferRequest");
 		pipe.setImportedNamespacesToIgnore("http://nn.nl/XSD/PensionsSMB/ValueTransfer/ValueTransferLegacy/1/StartIncomingValueTransferProcess/1");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		String input = TestFileUtils.getTestFile(ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/in-ok.xml");
@@ -534,7 +534,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setSoapBody("StartIncomingValueTransferRequest");
 		pipe.setImportedNamespacesToIgnore("http://nn.nl/XSD/PensionsSMB/ValueTransfer/ValueTransferLegacy/1/StartIncomingValueTransferProcess/1");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		String input = TestFileUtils.getTestFile(ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/in-err.xml");
@@ -551,7 +551,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setSoapBody("StartIncomingValueTransferRequest");
 		pipe.setImportedSchemaLocationsToIgnore("schema1.xsd");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		String input = TestFileUtils.getTestFile(ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/in-ok.xml");
@@ -567,7 +567,7 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 		pipe.setSoapBody("StartIncomingValueTransferRequest");
 		pipe.setImportedSchemaLocationsToIgnore("schema1.xsd");
 		pipe.setThrowException(true);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		configureAndStartPipe();
 
 		String input = TestFileUtils.getTestFile(ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/in-err.xml");

--- a/core/src/test/java/org/frankframework/pipes/XmlIfNamespaceUnawarenessTest.java
+++ b/core/src/test/java/org/frankframework/pipes/XmlIfNamespaceUnawarenessTest.java
@@ -22,8 +22,8 @@ public class XmlIfNamespaceUnawarenessTest extends PipeTestBase<XmlIf>{
 
 		//Add default pipes
 		try {
-			xmlIf.registerForward(new PipeForward(pipeForwardThen, null));
-			xmlIf.registerForward(new PipeForward(pipeForwardElse, null));
+			xmlIf.addForward(new PipeForward(pipeForwardThen, null));
+			xmlIf.addForward(new PipeForward(pipeForwardElse, null));
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/core/src/test/java/org/frankframework/pipes/XmlIfTest.java
+++ b/core/src/test/java/org/frankframework/pipes/XmlIfTest.java
@@ -37,8 +37,8 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		XmlIf xmlIf = new XmlIf();
 
 		//Add default pipes
-		xmlIf.registerForward(new PipeForward(pipeForwardThen, null));
-		xmlIf.registerForward(new PipeForward(pipeForwardElse, null));
+		xmlIf.addForward(new PipeForward(pipeForwardThen, null));
+		xmlIf.addForward(new PipeForward(pipeForwardElse, null));
 		return xmlIf;
 	}
 
@@ -210,7 +210,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 	void testWithInvalidThenPipe() throws Exception {
 		String pipeName = "someText";
 		pipe.setThenForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		configureAndStartPipe();
 
 		pipeRunResult = doPipe(pipe, "<test123", session);
@@ -221,7 +221,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 	void testWithInvalidElsePipe() throws Exception {
 		String pipeName = "someText";
 		pipe.setElseForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		configureAndStartPipe();
 
 		pipeRunResult = doPipe(pipe, "<test123", session);
@@ -395,7 +395,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String input = "<root><dummy>true</dummy><dummy>true</dummy></root>";
 		String pipeName = "test1";
 		pipe.setThenForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		pipe.setXpathExpression("xs:boolean(count(/root/dummy) > 1)");
 		pipe.setNamespaceDefs("xs=http://www.w3.org/2001/XMLSchema");
 		configureAndStartPipe();
@@ -409,7 +409,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String input = "<root><dummy>true</dummy><dummy>true</dummy></root>";
 		String pipeName = "test1";
 		pipe.setElseForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		pipe.setXpathExpression("xs:boolean(count(/root/dummy) > 2)");
 		pipe.setNamespaceDefs("xs=http://www.w3.org/2001/XMLSchema");
 		configureAndStartPipe();
@@ -422,7 +422,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 	void namespaceDefsTestEmptyBooleanCheck() throws Exception {
 		String pipeName = "test1";
 		pipe.setElseForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		pipe.setXpathExpression("xs:boolean()");
 		pipe.setNamespaceDefs("xs=http://www.w3.org/2001/XMLSchema");
 
@@ -434,7 +434,7 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 	void testNullInput() throws Exception {
 		String pipeName = "test1";
 		pipe.setElseForwardName(pipeName);
-		pipe.registerForward(new PipeForward(pipeName, null));
+		pipe.addForward(new PipeForward(pipeName, null));
 		configureAndStartPipe();
 
 		pipeRunResult = doPipe(pipe, new Message((String) null), session);
@@ -447,8 +447,8 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String thenPipeName = "test2";
 		pipe.setElseForwardName(elsePipeName);
 		pipe.setThenForwardName(thenPipeName);
-		pipe.registerForward(new PipeForward(elsePipeName, null));
-		pipe.registerForward(new PipeForward(thenPipeName, null));
+		pipe.addForward(new PipeForward(elsePipeName, null));
+		pipe.addForward(new PipeForward(thenPipeName, null));
 		pipe.addParameter(new Parameter("param", "value"));
 		pipe.setXpathExpression("contains(/root/test, $param)");
 		String input = "<root><test>value is present</test></root>";
@@ -465,8 +465,8 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String thenPipeName = "test2";
 		pipe.setElseForwardName(elsePipeName);
 		pipe.setThenForwardName(thenPipeName);
-		pipe.registerForward(new PipeForward(elsePipeName, null));
-		pipe.registerForward(new PipeForward(thenPipeName, null));
+		pipe.addForward(new PipeForward(elsePipeName, null));
+		pipe.addForward(new PipeForward(thenPipeName, null));
 		Parameter p = new Parameter("param", "<root><test>value</test></root>");
 		p.setType(ParameterType.DOMDOC);
 		pipe.addParameter(p);
@@ -484,8 +484,8 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String thenPipeName = "test2";
 		pipe.setElseForwardName(elsePipeName);
 		pipe.setThenForwardName(thenPipeName);
-		pipe.registerForward(new PipeForward(elsePipeName, null));
-		pipe.registerForward(new PipeForward(thenPipeName, null));
+		pipe.addForward(new PipeForward(elsePipeName, null));
+		pipe.addForward(new PipeForward(thenPipeName, null));
 		Parameter p = new Parameter("param", "<root><test>value</test></root>");
 		p.setType(ParameterType.DOMDOC);
 		pipe.addParameter(p);
@@ -507,8 +507,8 @@ public class XmlIfTest extends PipeTestBase<XmlIf> {
 		String thenPipeName = "test2";
 		pipe.setElseForwardName(elsePipeName);
 		pipe.setThenForwardName(thenPipeName);
-		pipe.registerForward(new PipeForward(elsePipeName, null));
-		pipe.registerForward(new PipeForward(thenPipeName, null));
+		pipe.addForward(new PipeForward(elsePipeName, null));
+		pipe.addForward(new PipeForward(thenPipeName, null));
 		Parameter p = ParameterBuilder.create("param", "<root><test>value</test></root>").withType(ParameterType.DOMDOC);
 		pipe.addParameter(p);
 

--- a/core/src/test/java/org/frankframework/pipes/XmlSwitchNamespaceUnawarenessTest.java
+++ b/core/src/test/java/org/frankframework/pipes/XmlSwitchNamespaceUnawarenessTest.java
@@ -43,8 +43,8 @@ public class XmlSwitchNamespaceUnawarenessTest extends PipeTestBase<XmlSwitch> {
 
 
 	public void testNamespaceAwarenessWithStylesheet(int xsltVersion, boolean namespaceAware, String expectedForwardName) throws Exception {
-		pipe.registerForward(new PipeForward("1","FixedResult1"));
-		pipe.registerForward(new PipeForward("NF","FixedResultNF"));
+		pipe.addForward(new PipeForward("1","FixedResult1"));
+		pipe.addForward(new PipeForward("NF","FixedResultNF"));
 		pipe.setServiceSelectionStylesheetFilename(TransformerPoolNamespaceUnawarenessTest.NAMESPACELESS_STYLESHEET);
 		pipe.setNotFoundForwardName("NF");
 		pipe.setXsltVersion(xsltVersion);
@@ -54,8 +54,8 @@ public class XmlSwitchNamespaceUnawarenessTest extends PipeTestBase<XmlSwitch> {
 	}
 
 	public void testNamespaceAwarenessWithXpath(int xsltVersion, boolean namespaceAware, String expectedForwardName) throws Exception {
-		pipe.registerForward(new PipeForward("1","FixedResult1"));
-		pipe.registerForward(new PipeForward("NF","FixedResultNF"));
+		pipe.addForward(new PipeForward("1","FixedResult1"));
+		pipe.addForward(new PipeForward("NF","FixedResultNF"));
 		pipe.setXpathExpression("/root/sub");
 		pipe.setNotFoundForwardName("NF");
 		pipe.setXsltVersion(xsltVersion);

--- a/core/src/test/java/org/frankframework/pipes/XmlSwitchTest.java
+++ b/core/src/test/java/org/frankframework/pipes/XmlSwitchTest.java
@@ -40,14 +40,14 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void basic() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		testSwitch(input,"Envelope");
 	}
 
 	@Test
 	void basicXpath1() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
 		pipe.setXpathExpression("name(/node()[position()=last()])");
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		testSwitch(input,"Envelope");
@@ -55,8 +55,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void basicXpath3() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("SetRequest","SetRequest-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("SetRequest","SetRequest-Path"));
 		pipe.setXpathExpression("name(/Envelope/Body/*[name()!='MessageHeader'])");
 		pipe.setNamespaceAware(false);
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
@@ -65,8 +65,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void xPathFromParameter() throws Exception {
-		pipe.registerForward(new PipeForward("1","Path1"));
-		pipe.registerForward(new PipeForward("2","Path2"));
+		pipe.addForward(new PipeForward("1","Path1"));
+		pipe.addForward(new PipeForward("2","Path2"));
 
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		Parameter inputParameter = new Parameter();
@@ -83,8 +83,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void xPathFromParameterWildCardNamespaced() throws Exception {
-		pipe.registerForward(new PipeForward("1","Path1"));
-		pipe.registerForward(new PipeForward("2","Path2"));
+		pipe.addForward(new PipeForward("1","Path1"));
+		pipe.addForward(new PipeForward("2","Path2"));
 
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		pipe.addParameter(ParameterBuilder.create().withName("source").withType(ParameterType.DOMDOC));
@@ -96,8 +96,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void xPathFromParameterNamespaced() throws Exception {
-		pipe.registerForward(new PipeForward("1","Path1"));
-		pipe.registerForward(new PipeForward("2","Path2"));
+		pipe.addForward(new PipeForward("1","Path1"));
+		pipe.addForward(new PipeForward("2","Path2"));
 
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		pipe.addParameter(ParameterBuilder.create().withName("source").withType(ParameterType.DOMDOC));
@@ -121,8 +121,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 		pipe.addParameter(param1);
 
 		pipe.setXsltVersion(1);
-		pipe.registerForward(new PipeForward("true","Envelope-Path"));
-		pipe.registerForward(new PipeForward("false","dummy-Path"));
+		pipe.addForward(new PipeForward("true","Envelope-Path"));
+		pipe.addForward(new PipeForward("false","dummy-Path"));
 
 		session=new PipeLineSession();
 		session.put(PipeLineSession.ORIGINAL_MESSAGE_KEY, message);
@@ -144,8 +144,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 		pipe.addParameter(param1);
 
 		pipe.setXsltVersion(0);
-		pipe.registerForward(new PipeForward("true","Envelope-Path"));
-		pipe.registerForward(new PipeForward("false","dummy-Path"));
+		pipe.addForward(new PipeForward("true","Envelope-Path"));
+		pipe.addForward(new PipeForward("false","dummy-Path"));
 
 		session=new PipeLineSession();
 		session.put(PipeLineSession.ORIGINAL_MESSAGE_KEY, message);
@@ -155,8 +155,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void xPathFromParameterWithXpath() throws Exception {
-		pipe.registerForward(new PipeForward("1","Path1"));
-		pipe.registerForward(new PipeForward("2","Path2"));
+		pipe.addForward(new PipeForward("1","Path1"));
+		pipe.addForward(new PipeForward("2","Path2"));
 
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
 		Parameter inputParameter = new Parameter();
@@ -172,8 +172,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void withSessionKey() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("selectValue","SelectValue-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("selectValue","SelectValue-Path"));
 		pipe.setSessionKey("selectKey");
 		session=new PipeLineSession();
 		session.put("selectKey", "selectValue");
@@ -183,8 +183,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void storeForwardInSessionKey() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("selectValue","SelectValue-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("selectValue","SelectValue-Path"));
 		pipe.setSessionKey("selectKey");
 		String forwardName = "forwardName";
 		pipe.setStoreForwardInSessionKey(forwardName);
@@ -197,8 +197,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void basicSelectionWithStylesheet() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("SetRequest","SetRequest-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("SetRequest","SetRequest-Path"));
 		pipe.setStyleSheetName("/XmlSwitch/selection.xsl");
 		pipe.setNamespaceAware(false);
 		Message input=MessageTestUtils.getMessage("/XmlSwitch/in.xml");
@@ -207,8 +207,8 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void basicSelectionWithStylesheetXslt3() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("SetRequest","SetRequest-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("SetRequest","SetRequest-Path"));
 		pipe.setXsltVersion(3);
 		pipe.setStyleSheetName("/XmlSwitch/selectionXslt3.0.xsl");
 		pipe.setNamespaceAware(false);
@@ -218,7 +218,7 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void testForwardNameFromSessionKey() throws Exception {
-		pipe.registerForward(new PipeForward("forwardName","Envelope-Path"));
+		pipe.addForward(new PipeForward("forwardName","Envelope-Path"));
 		pipe.setForwardNameSessionKey("forwardNameSessionKey");
 		session=new PipeLineSession();
 		session.put("forwardNameSessionKey", "forwardName");
@@ -228,7 +228,7 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 
 	@Test
 	void basicXpathSessionKeyUsedAsInput() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
 		pipe.setSessionKey("sessionKey");
 		pipe.setXpathExpression("name(/node()[position()=last()])");
 		session=new PipeLineSession();
@@ -247,7 +247,7 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 	void emptyForward() throws Exception {
 		pipe.setEmptyForwardName("emptyForward");
 		pipe.setSessionKey("sessionKey");
-		pipe.registerForward(new PipeForward("emptyForward", "test"));
+		pipe.addForward(new PipeForward("emptyForward", "test"));
 		testSwitch(new Message("dummy"),"emptyForward");
 	}
 
@@ -257,14 +257,14 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 		pipe.setSessionKey("sessionKey");
 		session=new PipeLineSession();
 		session.put("sessionKey", "someForward");
-		pipe.registerForward(new PipeForward("notFound", "test"));
+		pipe.addForward(new PipeForward("notFound", "test"));
 		testSwitch(new Message("dummy"),"notFound");
 	}
 
 	@Test
 	void withSessionKeyOverridesGetInputFromSessionKey() throws Exception {
-		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
-		pipe.registerForward(new PipeForward("dummy","dummy-Path"));
+		pipe.addForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.addForward(new PipeForward("dummy","dummy-Path"));
 		pipe.setGetInputFromSessionKey("input");
 		pipe.setSessionKey("selectKey");
 		pipe.setXpathExpression("name(/node()[position()=last()])");

--- a/core/src/test/java/org/frankframework/pipes/XmlValidatorPipelineTest.java
+++ b/core/src/test/java/org/frankframework/pipes/XmlValidatorPipelineTest.java
@@ -72,7 +72,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 
 		XmlValidator validator = configuration.createBean(XmlValidator.class);
 		validator.setName("validator");
-		validator.registerForward(createSuccessForward());
+		validator.addForward(createSuccessForward());
 		validator.setRoot(root);
 		validator.setSchemaLocation(schemaLocation);
 		validator.setThrowException(true);
@@ -113,7 +113,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		if (addNamespaceToSchema) {
 			validator.setAddNamespaceToSchema(addNamespaceToSchema);
 		}
-		validator.registerForward(createSuccessForward());
+		validator.addForward(createSuccessForward());
 		validator.setThrowException(true);
 		validator.setFullSchemaChecking(true);
 		return validator;
@@ -153,7 +153,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		// Arrange
 		XmlValidator validator = buildXmlValidator(configuration, null, NO_NAMESPACE_SOAP_MSGROOT);
 		validator.setFullSchemaChecking(true);
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 		try {
 			validator.setImplementation(implementation);
 		} catch (Exception e) {
@@ -212,7 +212,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		XmlValidator validator = buildXmlValidator(configuration, SCHEMA_LOCATION_BASIC_A_OK,  "anotherElement");
 		validator.setFullSchemaChecking(true);
 		validator.setReasonSessionKey("reason");
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 		validator.setThrowException(false);
 
 		// Act
@@ -301,7 +301,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		String root = "A";
 		XmlValidator validator = buildXmlValidator(configuration, SCHEMA_LOCATION_BASIC_A_OK, root);
 		validator.setReasonSessionKey("reason");
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 		validator.setThrowException(false);
 
 		// Act
@@ -461,7 +461,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		// Arrange
 		XmlValidator validator = buildXmlValidator(configuration, "http://nn.nl/root /Validation/ImportInclude/xsd/root.xsd", "root");
 		// Override throwing exception
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 		validator.setThrowException(false);
 
 		// Act
@@ -490,7 +490,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		// Arrange
 		XmlValidator validator = buildXmlValidator(configuration, "http://www.frankframework.org/test XSDTest/MultipleIncludesClashingPrefixes/root1.xsd", "cc");
 		// Override throwing exception
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 		validator.setThrowException(false);
 
 		// Act
@@ -533,7 +533,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		// Arrange
 		XmlValidator validator = buildXmlValidator(configuration, "http://www.frankframework.org/tom /Validation/Include/xsd/main.xsd", "GetParties");
 		validator.setThrowException(false);
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 
 		// Act
 		validator.configure();
@@ -563,7 +563,7 @@ public class XmlValidatorPipelineTest extends XmlValidatorTestBase {
 		XmlValidator validator = buildXmlValidator(configuration, "http://nn.nl/root /Validation/ImportNestedInclude/xsd/root.xsd", "root");
 
 		validator.setThrowException(true);
-		validator.registerForward(createFailureForward());
+		validator.addForward(createFailureForward());
 
 		// Act
 		validator.configure();

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -71,7 +71,7 @@ public class InputOutputPipeProcessorTest {
 
 		PipeForward forward = new PipeForward();
 		forward.setName("success");
-		pipe.registerForward(forward);
+		pipe.addForward(forward);
 
 		session = new PipeLineSession();
 	}
@@ -92,7 +92,7 @@ public class InputOutputPipeProcessorTest {
 		pipe.setElementToMove("identificatie");
 		PipeForward forward = new PipeForward();
 		forward.setName("success");
-		pipe.registerForward(forward);
+		pipe.addForward(forward);
 		pipe.configure();
 		pipe.start();
 
@@ -124,7 +124,7 @@ public class InputOutputPipeProcessorTest {
 		pipe1.setElementToMove("identificatie");
 		PipeForward forward1 = new PipeForward();
 		forward1.setName("success");
-		pipe1.registerForward(forward1);
+		pipe1.addForward(forward1);
 		pipe1.configure();
 		pipe1.start();
 
@@ -133,7 +133,7 @@ public class InputOutputPipeProcessorTest {
 		pipe2.setRemoveCompactMsgNamespaces(false);
 		PipeForward forward2 = new PipeForward();
 		forward2.setName("success");
-		pipe2.registerForward(forward2);
+		pipe2.addForward(forward2);
 		pipe2.configure();
 		pipe2.start();
 
@@ -170,7 +170,7 @@ public class InputOutputPipeProcessorTest {
 		PipeForward forward = new PipeForward();
 		forward.setName("success");
 
-		pipe.registerForward(forward);
+		pipe.addForward(forward);
 		pipe.configure();
 		pipe.start();
 

--- a/core/src/test/java/org/frankframework/processors/InputOutputSenderWrapperProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputSenderWrapperProcessorTest.java
@@ -32,7 +32,7 @@ public class InputOutputSenderWrapperProcessorTest {
 		secondSenderOutput = null;
 
 		sender = configuration.createBean(SenderSeries.class);
-		sender.registerSender(new SenderBase() {
+		sender.addSender(new SenderBase() {
 			@Override
 			public @Nonnull SenderResult sendMessage(@Nonnull Message message, @Nonnull PipeLineSession session) throws SenderException, TimeoutException {
 				try {
@@ -42,7 +42,7 @@ public class InputOutputSenderWrapperProcessorTest {
 				}
 			}
 		});
-		sender.registerSender(new SenderBase() {
+		sender.addSender(new SenderBase() {
 			@Override
 			public @Nonnull SenderResult sendMessage(@Nonnull Message message, @Nonnull PipeLineSession session) throws SenderException, TimeoutException {
 				try {

--- a/core/src/test/java/org/frankframework/receivers/JavaListenerTest.java
+++ b/core/src/test/java/org/frankframework/receivers/JavaListenerTest.java
@@ -108,11 +108,11 @@ public class JavaListenerTest {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName("success");
 		ple.setState(PipeLine.ExitState.SUCCESS);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		adapter.setPipeLine(pl);
 
-		adapter.registerReceiver(receiver);
-		configuration.registerAdapter(adapter);
+		adapter.addReceiver(receiver);
+		configuration.addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/receivers/ReceiverSubAdapterTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverSubAdapterTest.java
@@ -90,8 +90,8 @@ public class ReceiverSubAdapterTest {
 		failure.setState(PipeLine.ExitState.ERROR);
 
 		PipeLineExits exits = new PipeLineExits();
-		exits.registerPipeLineExit(success);
-		exits.registerPipeLineExit(failure);
+		exits.addPipeLineExit(success);
+		exits.addPipeLineExit(failure);
 		pl.setPipeLineExits(exits);
 
 		CorePipeLineProcessor plp = new CorePipeLineProcessor();
@@ -121,9 +121,9 @@ public class ReceiverSubAdapterTest {
 		receiver.setName(name);
 		adapter.setName(name);
 
-		configuration.registerAdapter(adapter);
+		configuration.addAdapter(adapter);
 
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 
 		receiver.setApplicationContext(configuration);
 		receiver.setAdapter(adapter);
@@ -253,8 +253,8 @@ public class ReceiverSubAdapterTest {
 		AtomicInteger succeeds = new AtomicInteger();
 
 		FailurePipe() throws ConfigurationException {
-			registerForward(failureForward);
-			registerForward(successForward);
+			addForward(failureForward);
+			addForward(successForward);
 			setName("fail");
 		}
 

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -208,11 +208,11 @@ public class ReceiverTest {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName("success");
 		ple.setState(exitState);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		adapter.setPipeLine(pl);
 
-		adapter.registerReceiver(receiver);
-		configuration.registerAdapter(adapter);
+		adapter.addReceiver(receiver);
+		configuration.addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/receivers/TestReceiverOnError.java
+++ b/core/src/test/java/org/frankframework/receivers/TestReceiverOnError.java
@@ -120,11 +120,11 @@ public class TestReceiverOnError {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName("success");
 		ple.setState(ExitState.SUCCESS);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		adapter.setPipeLine(pl);
 
-		adapter.registerReceiver(receiver);
-		configuration.registerAdapter(adapter);
+		adapter.addReceiver(receiver);
+		configuration.addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/scheduler/CleanupDatabaseJobTest.java
+++ b/core/src/test/java/org/frankframework/scheduler/CleanupDatabaseJobTest.java
@@ -80,7 +80,7 @@ public class CleanupDatabaseJobTest {
 			when(mockReceiver.getMessageLog()).thenReturn(storage);
 			when(mockReceiver.getName()).thenReturn("MockReceiver");
 			when(mockAdapter.getReceivers()).thenReturn(Collections.singletonList(mockReceiver));
-			configuration.registerAdapter(mockAdapter);
+			configuration.addAdapter(mockAdapter);
 		}
 
 		// Ensure we have an IbisManager via side effects of method

--- a/core/src/test/java/org/frankframework/scheduler/DatabaseSchedulerTest.java
+++ b/core/src/test/java/org/frankframework/scheduler/DatabaseSchedulerTest.java
@@ -51,7 +51,7 @@ public class DatabaseSchedulerTest extends Mockito {
 		builder.setValue("MESSAGE", "dummy message");
 		Adapter adapter = configuration.createBean(Adapter.class);
 		adapter.setName("testAdapter");
-		configuration.registerAdapter(adapter);
+		configuration.addAdapter(adapter);
 
 		configuration.mockQuery("SELECT COUNT(*) FROM IBISSCHEDULES", builder.build());
 

--- a/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
@@ -527,7 +527,7 @@ class FrankSenderTest {
 		receiver.setListener(listener);
 		receiver.setTxManager(configuration.createBean(NarayanaJtaTransactionManager.class));
 
-		targetAdapter.registerReceiver(receiver);
+		targetAdapter.addReceiver(receiver);
 		receiver.setAdapter(targetAdapter);
 
 		listener.configure();
@@ -549,7 +549,7 @@ class FrankSenderTest {
 		receiver.setListener(listener);
 		receiver.setTxManager(configuration.createBean(NarayanaJtaTransactionManager.class));
 
-		targetAdapter.registerReceiver(receiver);
+		targetAdapter.addReceiver(receiver);
 		receiver.setAdapter(targetAdapter);
 
 		listener.open();
@@ -573,10 +573,10 @@ class FrankSenderTest {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName(exitState.name());
 		ple.setState(exitState);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		adapter.setPipeLine(pl);
 
-		configuration.registerAdapter(adapter);
+		configuration.addAdapter(adapter);
 		return adapter;
 	}
 

--- a/core/src/test/java/org/frankframework/senders/IbisLocalSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/IbisLocalSenderTest.java
@@ -359,9 +359,9 @@ class IbisLocalSenderTest {
 			registerWithServiceDispatcher(listener);
 		}
 
-		configuration.registerAdapter(adapter);
+		configuration.addAdapter(adapter);
 
-		adapter.registerReceiver(receiver);
+		adapter.addReceiver(receiver);
 		receiver.setListener(listener);
 		receiver.setAdapter(adapter);
 		receiver.setTxManager(configuration.createBean(NarayanaJtaTransactionManager.class));
@@ -381,7 +381,7 @@ class IbisLocalSenderTest {
 		PipeLineExit ple = new PipeLineExit();
 		ple.setName("success");
 		ple.setState(PipeLine.ExitState.SUCCESS);
-		pl.registerPipeLineExit(ple);
+		pl.addPipeLineExit(ple);
 		CorePipeLineProcessor plp = new CorePipeLineProcessor();
 		plp.setAdapterManager(configuration.getAdapterManager());
 		plp.setPipeProcessor(new CorePipeProcessor());

--- a/core/src/test/java/org/frankframework/senders/JavascriptSenderCallbackTest.java
+++ b/core/src/test/java/org/frankframework/senders/JavascriptSenderCallbackTest.java
@@ -58,7 +58,7 @@ class JavascriptSenderCallbackTest extends SenderTestBase<JavascriptSender> {
 
 		EchoSender log = new EchoSender();
 		log.setName("myFunction");
-		sender.registerSender(log);
+		sender.addSender(log);
 
 		sender.configure();
 		sender.open();
@@ -77,7 +77,7 @@ class JavascriptSenderCallbackTest extends SenderTestBase<JavascriptSender> {
 
 		PromiseResultSender promise = new PromiseResultSender();
 		promise.setName("result");
-		sender.registerSender(promise);
+		sender.addSender(promise);
 
 		sender.configure();
 		sender.open();

--- a/core/src/test/java/org/frankframework/senders/ParallelSendersTest.java
+++ b/core/src/test/java/org/frankframework/senders/ParallelSendersTest.java
@@ -44,7 +44,7 @@ public class ParallelSendersTest extends SenderTestBase<ParallelSenders> {
 	public void test10SubSenders() throws Exception {
 		long startTime = System.currentTimeMillis();
 		for (int i = 0; i < 10; i++) {
-			sender.registerSender(new TestSender("Sender"+i));
+			sender.addSender(new TestSender("Sender"+i));
 		}
 
 		sender.configure();
@@ -66,7 +66,7 @@ public class ParallelSendersTest extends SenderTestBase<ParallelSenders> {
 	public void test10SubSendersNonRepeatableMessage() throws Exception {
 		long startTime = System.currentTimeMillis();
 		for (int i = 0; i < 10; i++) {
-			sender.registerSender(new TestSender("Sender"+i));
+			sender.addSender(new TestSender("Sender"+i));
 		}
 
 		sender.configure();
@@ -93,9 +93,9 @@ public class ParallelSendersTest extends SenderTestBase<ParallelSenders> {
 			SenderSeries wrapper = getConfiguration().createBean(SenderSeries.class);
 			wrapper.setName("Wrapper"+i);
 			for (int j = 0; j < amountOfDelaySendersInWrapper; j++) {
-				wrapper.registerSender(new TestSender("Wrapper"+i+"-Sender"+j));
+				wrapper.addSender(new TestSender("Wrapper"+i+"-Sender"+j));
 			}
-			sender.registerSender(wrapper);
+			sender.addSender(wrapper);
 		}
 
 		sender.configure();
@@ -115,7 +115,7 @@ public class ParallelSendersTest extends SenderTestBase<ParallelSenders> {
 
 	@Test
 	public void testSingleExceptionHandling() throws Exception {
-		sender.registerSender(new ExceptionThrowingSender());
+		sender.addSender(new ExceptionThrowingSender());
 		sender.configure();
 		sender.open();
 
@@ -127,9 +127,9 @@ public class ParallelSendersTest extends SenderTestBase<ParallelSenders> {
 
 	@Test
 	public void testExceptionHandling() throws Exception {
-		sender.registerSender(new EchoSender());
-		sender.registerSender(new ExceptionThrowingSender());
-		sender.registerSender(new EchoSender());
+		sender.addSender(new EchoSender());
+		sender.addSender(new ExceptionThrowingSender());
+		sender.addSender(new EchoSender());
 
 		sender.configure();
 		sender.open();

--- a/core/src/test/java/org/frankframework/senders/ShadowSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/ShadowSenderTest.java
@@ -44,10 +44,10 @@ public class ShadowSenderTest extends ParallelSendersTest {
 		ShadowSender ps = new ShadowSender();
 
 		ps.setOriginalSender(ORIGINAL_SENDER_NAME);
-		ps.registerSender(createOriginalSender());
+		ps.addSender(createOriginalSender());
 
 		ps.setResultSender(RESULT_SENDER_NAME);
-		ps.registerSender(createResultSender());
+		ps.addSender(createResultSender());
 
 		return ps;
 	}
@@ -105,7 +105,7 @@ public class ShadowSenderTest extends ParallelSendersTest {
 	@Test
 	public void testMultipleResultSenders() {
 		ConfigurationException exception = assertThrows(ConfigurationException.class, () -> {
-			sender.registerSender(createResultSender());
+			sender.addSender(createResultSender());
 			sender.configure();
 			sender.open();
 		});
@@ -115,7 +115,7 @@ public class ShadowSenderTest extends ParallelSendersTest {
 	@Test
 	public void testMultipleOriginalSenders() {
 		ConfigurationException exception = assertThrows(ConfigurationException.class, () -> {
-			sender.registerSender(createOriginalSender());
+			sender.addSender(createOriginalSender());
 			sender.configure();
 			sender.open();
 		});
@@ -172,9 +172,9 @@ public class ShadowSenderTest extends ParallelSendersTest {
 
 	@Test
 	public void testResultSenderResultWith3ShadowSenders() throws Exception {
-		sender.registerSender(new TestSender("shadowSenderWithDelay1"));
-		sender.registerSender(new TestSender("shadowSenderWithDelay2"));
-		sender.registerSender(new TestSender("shadowSenderWithDelay3"));
+		sender.addSender(new TestSender("shadowSenderWithDelay1"));
+		sender.addSender(new TestSender("shadowSenderWithDelay2"));
+		sender.addSender(new TestSender("shadowSenderWithDelay3"));
 
 		sender.configure();
 		sender.open();
@@ -216,9 +216,9 @@ public class ShadowSenderTest extends ParallelSendersTest {
 	@Test
 	public void testResultSenderResultWith3ShadowSendersAsync() throws Exception {
 		// Arrange
-		sender.registerSender(new TestSender("shadowSenderWithDelay1"));
-		sender.registerSender(new TestSender("shadowSenderWithDelay2"));
-		sender.registerSender(new TestSender("shadowSenderWithDelay3"));
+		sender.addSender(new TestSender("shadowSenderWithDelay1"));
+		sender.addSender(new TestSender("shadowSenderWithDelay2"));
+		sender.addSender(new TestSender("shadowSenderWithDelay3"));
 		((ShadowSender)sender).setWaitForShadowsToFinish(false);
 
 		sender.configure();

--- a/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
+++ b/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
@@ -26,7 +26,7 @@ public class WsdlGeneratorTest {
 
 	private PipeLine createPipeline() throws Exception {
 		EchoPipe pipe = new EchoPipe();
-		pipe.registerForward(new PipeForward("success",null));
+		pipe.addForward(new PipeForward("success",null));
 		pipe.setName(pipe.getClass().getSimpleName().concat("4WsdlGeneratorTest"));
 		PipeLine pipeline = configuration.createBean(PipeLine.class);
 		pipeline.addPipe(pipe);
@@ -34,7 +34,7 @@ public class WsdlGeneratorTest {
 		PipeLineExit exit = new PipeLineExit();
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 
 		Adapter adapter = configuration.createBean(Adapter.class);
 		adapter.setName(pipe.getClass().getSimpleName().concat("4WsdlGeneratorTest"));

--- a/core/src/test/java/org/frankframework/validation/Json2XmlValidatorSmileyTest.java
+++ b/core/src/test/java/org/frankframework/validation/Json2XmlValidatorSmileyTest.java
@@ -45,7 +45,7 @@ public class Json2XmlValidatorSmileyTest {
 		json2xml.setSchema(xsd);
 		json2xml.setRoot("x");
 		json2xml.setThrowException(true);
-		json2xml.registerForward(new PipeForward("success",null));
+		json2xml.addForward(new PipeForward("success",null));
 		json2xml.configure();
 		json2xml.start();
 		PipeLineSession pipeLineSession = new PipeLineSession();
@@ -65,7 +65,7 @@ public class Json2XmlValidatorSmileyTest {
 		json2xml.setRoot("x");
 		json2xml.setOutputFormat(DocumentFormat.JSON);
 		json2xml.setThrowException(true);
-		json2xml.registerForward(new PipeForward("success",null));
+		json2xml.addForward(new PipeForward("success",null));
 		json2xml.configure();
 		json2xml.start();
 		PipeLineSession pipeLineSession = new PipeLineSession();

--- a/core/src/test/java/org/frankframework/validation/Json2XmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/validation/Json2XmlValidatorTest.java
@@ -56,7 +56,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 	protected void init() throws ConfigurationException  {
 		jsonPipe=new JsonPipe();
 		jsonPipe.setName("xml2json");
-		jsonPipe.registerForward(new PipeForward("success",null));
+		jsonPipe.addForward(new PipeForward("success",null));
 		jsonPipe.setDirection(Direction.XML2JSON);
 		jsonPipe.configure();
 		try {
@@ -68,7 +68,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 		validator.setFullSchemaChecking(true);
 
 		instance=new Json2XmlValidator();
-		instance.registerForward(new PipeForward("success",null));
+		instance.addForward(new PipeForward("success",null));
 		instance.setSoapNamespace(null);
 		instance.setFailOnWildcards(false);
 	}
@@ -82,13 +82,13 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 		instance.setSchemaLocation(schemaLocation);
 		instance.setAddNamespaceToSchema(addNamespaceToSchema);
 		instance.setIgnoreUnknownNamespaces(ignoreUnknownNamespaces);
-//        instance.registerForward("success");
+//        instance.addForward("success");
 		instance.setThrowException(true);
 		instance.setFullSchemaChecking(true);
 		instance.setTargetNamespace(rootNamespace);
-		instance.registerForward(new PipeForward("warnings", null));
-		instance.registerForward(new PipeForward("failure", null));
-		instance.registerForward(new PipeForward("parserError", null));
+		instance.addForward(new PipeForward("warnings", null));
+		instance.addForward(new PipeForward("failure", null));
+		instance.addForward(new PipeForward("parserError", null));
 		if (rootelement != null) {
 			instance.setRoot(rootelement);
 		}
@@ -224,7 +224,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 
 		json2xml.setThrowException(true);
 
-		json2xml.registerForward(new PipeForward("success",null));
+		json2xml.addForward(new PipeForward("success",null));
 		json2xml.configure();
 		json2xml.start();
 		PipeLineSession pipeLineSession = new PipeLineSession();
@@ -258,7 +258,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 
 		json2xml.setThrowException(true);
 
-		json2xml.registerForward(new PipeForward("success", null));
+		json2xml.addForward(new PipeForward("success", null));
 
 		try {
 			Thread.currentThread().setContextClassLoader(new ClassLoader(null) {}); //No parent classloader, getResource and getResources will not fall back
@@ -285,7 +285,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 		json2xml.setSchema(BASE_DIR_VALIDATION + "/ContentAlreadySetAsStringHandled/PostZgwZaak.xsd");
 		json2xml.setThrowException(true);
 
-		json2xml.registerForward(new PipeForward("success",null));
+		json2xml.addForward(new PipeForward("success",null));
 		json2xml.configure();
 		json2xml.start();
 

--- a/core/src/test/java/org/frankframework/xslt/ParallelXsltTest.java
+++ b/core/src/test/java/org/frankframework/xslt/ParallelXsltTest.java
@@ -67,7 +67,7 @@ public class ParallelXsltTest extends XsltErrorTestBase<SenderPipe> {
 			sender.addParameter(ParameterBuilder.create().withName("sessionKey").withSessionKey("sessionKey"+i));
 
 			autowireByType(sender);
-			psenders.registerSender(sender);
+			psenders.addSender(sender);
 			xsltSenders.add(sender);
 		}
 		session.put("sessionKeyGlobal","sessionKeyGlobalValue");

--- a/filesystem/src/test/java/org/frankframework/filesystem/FileSystemPipeTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/FileSystemPipeTest.java
@@ -51,7 +51,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		pipeLine.addPipe(fileSystemPipe);
 
 		autowireByName(fileSystemPipe);
-		fileSystemPipe.registerForward(new PipeForward("success",null));
+		fileSystemPipe.addForward(new PipeForward("success",null));
 	}
 
 	@Override
@@ -398,7 +398,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 
 	@Test
 	public void fileSystemPipeWritingFileThatAlreadyExists() throws Exception {
-		fileSystemPipe.registerForward(new PipeForward("fileAlreadyExists", "fileAlreadyExists"));
+		fileSystemPipe.addForward(new PipeForward("fileAlreadyExists", "fileAlreadyExists"));
 		prr = fileSystemPipeWriteFile("folder3", true, false);
 
 		assertNotNull(prr);
@@ -442,7 +442,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		}
 
 		fileSystemPipe.setAction(FileSystemAction.MKDIR);
-		fileSystemPipe.registerForward(new PipeForward(FileSystemException.Forward.FOLDER_ALREADY_EXISTS.getForwardName(), "x"));
+		fileSystemPipe.addForward(new PipeForward(FileSystemException.Forward.FOLDER_ALREADY_EXISTS.getForwardName(), "x"));
 		fileSystemPipe.configure();
 		fileSystemPipe.start();
 
@@ -467,7 +467,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		}
 
 		fileSystemPipe.setAction(FileSystemAction.MKDIR);
-		fileSystemPipe.registerForward(new PipeForward(FileSystemException.Forward.EXCEPTION.getForwardName(), "x"));
+		fileSystemPipe.addForward(new PipeForward(FileSystemException.Forward.EXCEPTION.getForwardName(), "x"));
 		fileSystemPipe.configure();
 		fileSystemPipe.start();
 
@@ -541,7 +541,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		}
 
 		fileSystemPipe.setAction(FileSystemAction.RMDIR);
-		fileSystemPipe.registerForward(new PipeForward(FileSystemException.Forward.FOLDER_NOT_FOUND.getForwardName(), "x"));
+		fileSystemPipe.addForward(new PipeForward(FileSystemException.Forward.FOLDER_NOT_FOUND.getForwardName(), "x"));
 		fileSystemPipe.configure();
 		fileSystemPipe.start();
 
@@ -564,7 +564,7 @@ public abstract class FileSystemPipeTest<FSP extends FileSystemPipe<F, FS>, F, F
 		}
 
 		fileSystemPipe.setAction(FileSystemAction.RMDIR);
-		fileSystemPipe.registerForward(new PipeForward(FileSystemException.Forward.EXCEPTION.getForwardName(), "x"));
+		fileSystemPipe.addForward(new PipeForward(FileSystemException.Forward.EXCEPTION.getForwardName(), "x"));
 		fileSystemPipe.configure();
 		fileSystemPipe.start();
 

--- a/filesystem/src/test/java/org/frankframework/filesystem/ForEachAttachmentPipeTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/ForEachAttachmentPipeTest.java
@@ -32,10 +32,10 @@ public abstract class ForEachAttachmentPipeTest<P extends ForEachAttachmentPipe<
 		super.setUp();
 		pipe = createForEachAttachmentPipe();
 		autowireByName(pipe);
-		pipe.registerForward(new PipeForward("success", null));
+		pipe.addForward(new PipeForward("success", null));
 		SenderSeries series = new SenderSeries();
 		autowireByName(series);
-		series.registerSender(new EchoSender());
+		series.addSender(new EchoSender());
 		pipe.setSender(series);
 	}
 

--- a/filesystem/src/test/java/org/frankframework/pipes/FilePipeTest.java
+++ b/filesystem/src/test/java/org/frankframework/pipes/FilePipeTest.java
@@ -43,7 +43,7 @@ public class FilePipeTest extends PipeTestBase<FilePipe> {
 	void doTestSuccess() throws Exception {
 		PipeForward fw = new PipeForward();
 		fw.setName("exception");
-		pipe.registerForward(fw);
+		pipe.addForward(fw);
 		pipe.setCharset("/");
 		pipe.setDirectory(sourceFolderPath);
 		pipe.setOutputType("stream");
@@ -61,7 +61,7 @@ public class FilePipeTest extends PipeTestBase<FilePipe> {
 	void doTestFailAsEncodingNotSupportedBase64() throws Exception {
 		PipeForward fw = new PipeForward();
 		fw.setName("success");
-		pipe.registerForward(fw);
+		pipe.addForward(fw);
 		pipe.setCharset("/");
 		pipe.setDirectory(sourceFolderPath);
 		pipe.setOutputType("base64");

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/DirectWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/DirectWrapperPipe.java
@@ -73,7 +73,7 @@ public class DirectWrapperPipe extends TimeoutGuardPipe {
 			}
 		}
 		try {
-			eswPipe.registerForward(getSuccessForward());
+			eswPipe.addForward(getSuccessForward());
 			eswPipe.configure();
 			return eswPipe.doPipe(message, session);
 		} catch (Exception e) {

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/WsdlGeneratorPipe.java
@@ -127,7 +127,7 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 			esbJmsListener.setQueueConnectionFactoryName("jms/qcf_" + fileBaseName);
 			esbJmsListener.setDestinationName("jms/dest_" + fileBaseName);
 			receiver.setListener(esbJmsListener);
-			adapter.registerReceiver(receiver);
+			adapter.addReceiver(receiver);
 			adapter.setPipeLine(pipeLine);
 			String generationInfo = "at " + RestListenerUtils.retrieveRequestURL(session);
 			WsdlGenerator wsdl = new WsdlGenerator(pipeLine, generationInfo);
@@ -287,7 +287,7 @@ public class WsdlGeneratorPipe extends FixedForwardPipe {
 			esbSoapValidator.setForwardFailureToSuccess(true);
 			PipeForward pf = new PipeForward();
 			pf.setName(PipeForward.SUCCESS_FORWARD_NAME);
-			esbSoapValidator.registerForward(pf);
+			esbSoapValidator.addForward(pf);
 			esbSoapValidator.setPipeLine(pipeLine);
 			esbSoapValidator.configure();
 			return esbSoapValidator;

--- a/nn-specials/src/test/java/org/frankframework/core/TestDirectWrapperPipePipeLine.java
+++ b/nn-specials/src/test/java/org/frankframework/core/TestDirectWrapperPipePipeLine.java
@@ -43,19 +43,19 @@ public class TestDirectWrapperPipePipeLine {
 
 		DirectWrapperPipe pipe = configuration.createBean(DirectWrapperPipe.class);
 		pipe.setName("DirectWrapperPipe");
-		pipe.registerForward(pf);
+		pipe.addForward(pf);
 		pipeline.addPipe(pipe);
 
 		EchoPipe echoPipe = configuration.createBean(EchoPipe.class);
 		echoPipe.setName("nextPipe");
 		echoPipe.setPipeLine(pipeline);
-		echoPipe.registerForward(toExit);
+		echoPipe.addForward(toExit);
 		pipeline.addPipe(echoPipe);
 
 		PipeLineExit exit = configuration.createBean(PipeLineExit.class);
 		exit.setName("exit");
 		exit.setState(ExitState.SUCCESS);
-		pipeline.registerPipeLineExit(exit);
+		pipeline.addPipeLineExit(exit);
 
 		pipeline.setOwner(pipe);
 		pipeline.configure();

--- a/nn-specials/src/test/java/org/frankframework/pipes/ApiWsdlXmlValidatorMixedModeTest.java
+++ b/nn-specials/src/test/java/org/frankframework/pipes/ApiWsdlXmlValidatorMixedModeTest.java
@@ -41,7 +41,7 @@ public class ApiWsdlXmlValidatorMixedModeTest {
 		val.setSoapBody(REQUEST_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		return val;
@@ -52,7 +52,7 @@ public class ApiWsdlXmlValidatorMixedModeTest {
 		val.setSoapBody(RESPONSE_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.start();
 		return val;
@@ -64,7 +64,7 @@ public class ApiWsdlXmlValidatorMixedModeTest {
 		val.setOutputSoapBody(RESPONSE_SOAP_BODY);
 		val.setThrowException(true);
 		val.setSchemaLocation("http://frankframework.org/XSD/Generic/MessageHeader/2 schema1 http://api.frankframework.org/GetPolicyDetails schema2");
-		val.registerForward(new PipeForward("success", null));
+		val.addForward(new PipeForward("success", null));
 		val.configure();
 		val.getResponseValidator().configure();
 		val.start();

--- a/sap/src/main/java/org/frankframework/extensions/sap/SapSystemFactory.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/SapSystemFactory.java
@@ -79,7 +79,7 @@ public class SapSystemFactory {
 		return result;
 	}
 
-	public void registerSapSystem(Object sapSystem, String name) {
+	public void addSapSystem(Object sapSystem, String name) {
 		sapSystems.put(name, sapSystem);
 		log.debug("SapSystemFactory registered sapSystem [{}]", sapSystem.toString());
 	}

--- a/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapSystemImpl.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapSystemImpl.java
@@ -148,7 +148,7 @@ public abstract class SapSystemImpl extends GlobalListItem implements ISapSystem
 	@Override
 	public void registerItem(Object dummyParent) {
 		super.registerItem(dummyParent);
-		SapSystemFactory.getInstance().registerSapSystem(this, getName());
+		SapSystemFactory.getInstance().addSapSystem(this, getName());
 	}
 
 	public void clearCache() {

--- a/test-integration/src/test/java/org/frankframework/ldap/LdapFindMemberPipeTest.java
+++ b/test-integration/src/test/java/org/frankframework/ldap/LdapFindMemberPipeTest.java
@@ -29,7 +29,7 @@ public class LdapFindMemberPipeTest {
 	@BeforeAll
 	public void setUp() throws ConfigurationException {
 		pipe = new LdapFindMemberPipe();
-		pipe.registerForward(new PipeForward(PipeForward.SUCCESS_FORWARD_NAME, null));
+		pipe.addForward(new PipeForward(PipeForward.SUCCESS_FORWARD_NAME, null));
 		pipe.setHost(host);
 		pipe.setPort(port);
 		pipe.setUseSsl(useSSL);

--- a/test-integration/src/test/java/org/frankframework/ldap/LdapFindMembershipsPipeTest.java
+++ b/test-integration/src/test/java/org/frankframework/ldap/LdapFindMembershipsPipeTest.java
@@ -35,7 +35,7 @@ public class LdapFindMembershipsPipeTest {
 	@BeforeAll
 	public void setUp() throws ConfigurationException {
 		pipe = new LdapFindGroupMembershipsPipe();
-		pipe.registerForward(new PipeForward(PipeForward.SUCCESS_FORWARD_NAME,null));
+		pipe.addForward(new PipeForward(PipeForward.SUCCESS_FORWARD_NAME,null));
 		pipe.setLdapProviderURL(ldapProviderUrl);
 		pipe.setHost(host);
 		pipe.setPort(port);


### PR DESCRIPTION
Closes #1601 

The ultimate goal is to replace the digester-rules, but we decided to gradually reduce the complexity of the current situation to hopefully get into a position where a migration to another system is more feasible and less complex.

This PR replaces all `registerXyz` with `addXyz`. `setXyz` is used for singular use and `addXyz` is used for plural use. A few dumb unnecessary things have also been removed.

There are a few other things, which should be replaced, but aren't changed in this PR, because we simply don't know what to with it yet:
- Remove `selfRegisterMethod`
- See what we can do with `registerTextMethod`