### PR TITLE
Fix compilation error for ExceptionPipeTest

### DIFF
--- a/core/src/test/java/org/frankframework/pipes/ExceptionPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ExceptionPipeTest.java
@@ -24,7 +24,7 @@ public class ExceptionPipeTest extends PipeTestBase<ExceptionPipe> {
 	public ExceptionPipe createPipe() {
 		var pipe = new ExceptionPipe();
 
-		pipe.registerForward(new PipeForward("success", "success"));
+		pipe.addForward(new PipeForward("success", "success"));
 
 		return pipe;
 	}


### PR DESCRIPTION
Method does not exist.

Rename was forgotten in https://github.com/frankframework/frankframework/commit/4b1dcc7d1f90863157fab322ec0df7e48179fb8a