### PR TITLE
Remove old branches from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,63 +30,12 @@ updates:
     reviewers:
       - frankframework/maintainers
     ignore:
-      - dependency-name: "org.ibissource:ibis-ladybug"
-      - dependency-name: "com.aspose:*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
-    labels:
-      - "Dependencies"
-      - "Backport"
-      - "Java"
-      - "7.8"
-    reviewers:
-      - frankframework/maintainers
-    target-branch: "7.8-release"
-    ignore:
-      - dependency-name: "org.ibissource:ibis-ladybug"
-      - dependency-name: "com.aspose:*"
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      # The following versions are not available for JDK 8, see https://github.com/frankframework/frankframework/issues/3503
-      - dependency-name: "org.apache.activemq:activemq-*"
-        versions: ["[5.17.0,)"]
-      - dependency-name: "org.apache.activemq:artemis-*"
-        versions: ["[2.20.0,)"]
-      # End of versions not available for JDK 8
-
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0
-    labels:
-      - "Dependencies"
-      - "Backport"
-      - "Java"
-      - "7.9"
-    reviewers:
-      - frankframework/maintainers
-    target-branch: "7.9-release"
-    ignore:
-      - dependency-name: "org.ibissource:ibis-ladybug"
-      - dependency-name: "com.aspose:*"
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      # The following versions are not available for JDK 8, see https://github.com/frankframework/frankframework/issues/3503
-      - dependency-name: "org.apache.activemq:activemq-*"
-        versions: ["[5.17.0,)"]
-      - dependency-name: "org.apache.activemq:artemis-*"
-        versions: ["[2.20.0,)"]
-      # End of versions not available for JDK 8
       
   - package-ecosystem: "docker"
     directories:
+      # Globstar only works like this: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
       - "/docker/**/*"
     schedule: 
       interval: "daily"


### PR DESCRIPTION
We are using the build in security PR's from GitHub now.

We'll have to see how this works for the branches in a couple of days. 

Also remove wrong ignored dependencies from NPM and add a comment to the globstar for Docker