### PR TITLE
Fix js exception when no listener in receiver

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/status/adapter-status/adapter-status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/adapter-status/adapter-status.component.html
@@ -219,11 +219,15 @@
                   [ngClass]="{ 'text-danger': receiver.state === 'error' }"
                 >
                   <td>{{ receiver.name }}</td>
-                  <td #listenerDestination [title]="receiver.listener.destination">
-                    {{ receiver.listener.class }} ({{
-                      receiver.listener.destination | truncate: 150 : listenerDestination
-                    }})
-                  </td>
+                  <ng-container *ngIf="receiver.listener && receiver.listener.destination; else noListener">
+                    <td #listenerDestination [title]="receiver.listener.destination">
+                      {{ receiver.listener.class }} ({{ receiver.listener.destination | truncate: 150 : listenerDestination }})
+                    </td>
+                  </ng-container>
+                  
+                  <ng-template #noListener>
+                    <td>No listener found</td>
+                  </ng-template>
                   <td>{{ receiver.messages.retried }}</td>
                   <td>{{ receiver.messages.received }}</td>
                   <td>{{ receiver.messages.rejected }}</td>

--- a/console/frontend/src/main/frontend/src/app/views/status/adapter-status/adapter-status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/adapter-status/adapter-status.component.html
@@ -219,15 +219,13 @@
                   [ngClass]="{ 'text-danger': receiver.state === 'error' }"
                 >
                   <td>{{ receiver.name }}</td>
-                  <ng-container *ngIf="receiver.listener && receiver.listener.destination; else noListener">
-                    <td #listenerDestination [title]="receiver.listener.destination">
-                      {{ receiver.listener.class }} ({{ receiver.listener.destination | truncate: 150 : listenerDestination }})
-                    </td>
-                  </ng-container>
-                  
-                  <ng-template #noListener>
-                    <td>No listener found</td>
-                  </ng-template>
+                  <td #listenerDestination 
+                    *ngIf="receiver.listener && receiver.listener.destination; else noListener" 
+                    [title]="receiver.listener.destination"
+                  >
+                    {{ receiver.listener.class }} ({{ receiver.listener.destination | truncate: 150 : listenerDestination }})
+                  </td>
+                  <ng-template #noListener><td></td></ng-template>
                   <td>{{ receiver.messages.retried }}</td>
                   <td>{{ receiver.messages.received }}</td>
                   <td>{{ receiver.messages.rejected }}</td>


### PR DESCRIPTION
Added a check to prevent null pointer to listener when none are available in the adapter status page.