### PR TITLE
Parameter is used incorrectly in XslErrorMessageFormatter

### DIFF
--- a/core/src/main/java/org/frankframework/errormessageformatters/XslErrorMessageFormatter.java
+++ b/core/src/main/java/org/frankframework/errormessageformatters/XslErrorMessageFormatter.java
@@ -25,7 +25,7 @@ import org.frankframework.core.INamedObject;
 import org.frankframework.core.ParameterException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.Resource;
-import org.frankframework.parameters.Parameter;
+import org.frankframework.parameters.IParameter;
 import org.frankframework.parameters.ParameterList;
 import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.stream.Message;
@@ -96,7 +96,7 @@ public class XslErrorMessageFormatter extends ErrorMessageFormatter {
 		return result;
 	}
 
-	public void addParameter(Parameter p) {
+	public void addParameter(IParameter p) {
 		if (paramList == null) {
 			paramList = new ParameterList();
 		}


### PR DESCRIPTION
Closes https://github.com/frankframework/frankframework/issues/7682

Normally the interface IParameter is used everywhere, which creates a group of Parameter, NumberParameter, BooleanParameter and DateParameter. Just using Parameter messes up the FrankDoc as it creates a seperate Parameter for this aswell.