### PR TITLE
Update credential factory configuration for JBoss and WildFly

### DIFF
--- a/docker/JBoss/src/configuration/standalone.xml
+++ b/docker/JBoss/src/configuration/standalone.xml
@@ -47,8 +47,8 @@
 		<property name="web.protocol" value="http"/>
 		<property name="web.port" value="8080"/>
 		<property name="web.contextpath" value="/iaf-test"/>
-		<property name="credentialFactory.filesystem.root" value="/opt/frank/secrets"/>
-		<property name="credentialFactory.class" value="org.frankframework.credentialprovider.WildFlyCredentialFactory"/>
+		<property name="credentialFactory.class" value="nl.nn.credentialprovider.PropertyFileCredentialFactory"/>
+		<property name="credentialFactory.map.properties" value="/opt/frank/secrets/credentials.properties"/>
 		<property name="authAliases.expansion.allowed" value="testalias"/>
 		<property name="scenariosroot1.directory" value="/opt/frank/testtool"/>
 		<property name="scenariosroot1.description" value="embedded testtool directory /opt/frank/testtool"/>

--- a/docker/WildFly/src/configuration/standalone.xml
+++ b/docker/WildFly/src/configuration/standalone.xml
@@ -48,8 +48,8 @@
 		<property name="web.protocol" value="http"/>
 		<property name="web.port" value="8080"/>
 		<property name="web.contextpath" value="/iaf-test"/>
-		<property name="credentialFactory.filesystem.root" value="/opt/frank/secrets"/>
-		<property name="credentialFactory.class" value="org.frankframework.credentialprovider.WildFlyCredentialFactory"/>
+		<property name="credentialFactory.class" value="nl.nn.credentialprovider.PropertyFileCredentialFactory"/>
+		<property name="credentialFactory.map.properties" value="/opt/frank/secrets/credentials.properties"/>
 		<property name="authAliases.expansion.allowed" value="testalias"/>
 		<property name="scenariosroot1.directory" value="/opt/frank/testtool"/>
 		<property name="scenariosroot1.description" value="embedded testtool directory /opt/frank/testtool"/>

--- a/test/src/main/secrets/credentials.propertis
+++ b/test/src/main/secrets/credentials.propertis
@@ -1,5 +1,5 @@
-testif_user/username=testiaf_user
-testif_user/password=testiaf_user00
+testiaf_user/username=testiaf_user
+testiaf_user/password=testiaf_user00
 
 testalias/username=testUser
 testalias/password=testPassword


### PR DESCRIPTION
Replace the credential factory class and properties in both JBoss and 
WildFly configurations to use the PropertyFileCredentialFactory. 
Update the credentials properties file to correct the user prefix.