### PR TITLE
Get server timezone from FF Core & handle in console frontend

### DIFF
--- a/console/frontend/src/main/frontend/src/app/app.component.html
+++ b/console/frontend/src/main/frontend/src/app/app.component.html
@@ -9,7 +9,6 @@
     <!-- Page wrapper -->
     <app-pages-topnavbar
       class="topnavbar"
-      [serverTime]="serverTime"
       [dtapSide]="dtapSide"
       [dtapStage]="dtapStage"
       [clusterMembers]="clusterMembers"

--- a/console/frontend/src/main/frontend/src/app/app.service.ts
+++ b/console/frontend/src/main/frontend/src/app/app.service.ts
@@ -227,7 +227,6 @@ export type AppInitState = (typeof appInitState)[keyof typeof appInitState];
 
 export type ConsoleState = {
   server: string;
-  timeOffset: number;
   init: AppInitState;
 };
 
@@ -316,7 +315,6 @@ export class AppService {
 
   CONSOLE_STATE: ConsoleState = {
     server: computeServerPath(),
-    timeOffset: 0,
     init: appInitState.UN_INIT,
   };
 

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
@@ -15,7 +15,7 @@
         >
       </li>
       <li>
-        <span class="m-r-sm text-muted serverTime">{{ serverTime }}</span>
+        <span class="m-r-sm text-muted serverTime">{{ serverTimeService.getCurrentTimeFormatted() }}</span>
       </li>
       <li>
         <span class="m-r-sm stage">{{ dtapStage }}</span>

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { NotificationService } from 'src/app/services/notification.service';
 import { HamburgerComponent } from './hamburger.component';
@@ -9,6 +9,7 @@ import { RouterModule } from '@angular/router';
 import { AuthService } from 'src/app/services/auth.service';
 import { AppService, ClusterMember } from 'src/app/app.service';
 import { FormsModule } from '@angular/forms';
+import { ServerTimeService } from '../../../services/server-time.service';
 
 @Component({
   selector: 'app-pages-topnavbar',
@@ -18,25 +19,22 @@ import { FormsModule } from '@angular/forms';
   imports: [CommonModule, FormsModule, HamburgerComponent, RouterModule, TimeSinceDirective, NgbDropdownModule],
 })
 export class PagesTopnavbarComponent implements OnInit, OnChanges, OnDestroy {
-  notificationCount: number = this.Notification.getCount();
-  notificationList: NotificationService['list'] = [];
-
   @Input() dtapSide: string = '';
   @Input() dtapStage: string = '';
-  @Input() serverTime: string = '';
   @Input() clusterMembers: ClusterMember[] = [];
   @Input() selectedClusterMember: ClusterMember | null = null;
   @Input() userName?: string;
 
-  loggedIn: boolean = false;
+  private Notification: NotificationService = inject(NotificationService);
 
+  protected serverTimeService: ServerTimeService = inject(ServerTimeService);
+  protected notificationCount: number = this.Notification.getCount();
+  protected notificationList: NotificationService['list'] = [];
+  protected loggedIn: boolean = false;
+
+  private appService: AppService = inject(AppService);
+  private authService: AuthService = inject(AuthService);
   private _subscriptions = new Subscription();
-
-  constructor(
-    private appService: AppService,
-    private Notification: NotificationService,
-    private authService: AuthService,
-  ) {}
 
   ngOnInit(): void {
     const notifCountSub = this.Notification.onCountUpdate$.subscribe(() => {

--- a/console/frontend/src/main/frontend/src/app/components/time-since.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/time-since.directive.ts
@@ -1,5 +1,5 @@
-import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
-import { AppService, ConsoleState } from '../app.service';
+import { Directive, ElementRef, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
+import { ServerTimeService } from '../services/server-time.service';
 
 @Directive({
   selector: '[appTimeSince]',
@@ -8,15 +8,10 @@ import { AppService, ConsoleState } from '../app.service';
 export class TimeSinceDirective implements OnInit, OnChanges, OnDestroy {
   @Input() time!: number;
 
+  private element: ElementRef<HTMLElement> = inject(ElementRef);
+  private serverTimeService: ServerTimeService = inject(ServerTimeService);
   private interval?: number;
-  private consoleState: ConsoleState;
 
-  constructor(
-    private element: ElementRef<HTMLElement>,
-    private appService: AppService,
-  ) {
-    this.consoleState = this.appService.CONSOLE_STATE;
-  }
   ngOnInit(): void {
     this.interval = window.setInterval(() => this.updateTime(), 300_000);
   }
@@ -31,7 +26,7 @@ export class TimeSinceDirective implements OnInit, OnChanges, OnDestroy {
 
   updateTime(): string {
     if (!this.time) return '';
-    let seconds = Math.round((Date.now() - this.time + this.consoleState.timeOffset) / 1000);
+    let seconds = Math.round((this.serverTimeService.getCurrentTime() - this.time) / 1000);
 
     let minutes = seconds / 60;
     seconds = Math.floor(seconds % 60);

--- a/console/frontend/src/main/frontend/src/app/components/to-date.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/to-date.directive.ts
@@ -1,45 +1,19 @@
-import { Directive, ElementRef, Inject, Input, LOCALE_ID, OnChanges, OnDestroy } from '@angular/core';
-import { formatDate } from '@angular/common';
-import { AppConstants, AppService, ConsoleState } from '../app.service';
-import { Subscription } from 'rxjs';
+import { Directive, ElementRef, inject, Input, OnChanges } from '@angular/core';
+import { ServerTimeService } from '../services/server-time.service';
 
 @Directive({
   selector: '[appToDate]',
   standalone: true,
 })
-export class ToDateDirective implements OnChanges, OnDestroy {
+export class ToDateDirective implements OnChanges {
   @Input() time: string | number = '';
 
-  private appConstants: AppConstants;
-  private consoleState: ConsoleState;
-  private _subscriptions = new Subscription();
-
-  constructor(
-    private element: ElementRef,
-    private appService: AppService,
-    @Inject(LOCALE_ID) private locale: string,
-  ) {
-    this.appConstants = this.appService.APP_CONSTANTS;
-    const appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.appConstants = this.appService.APP_CONSTANTS;
-    });
-    this._subscriptions.add(appConstantsSubscription);
-    this.consoleState = this.appService.CONSOLE_STATE;
-  }
+  private element: ElementRef = inject(ElementRef);
+  private serverTimeService: ServerTimeService = inject(ServerTimeService);
 
   ngOnChanges(): void {
     if (this.time === undefined || Number.isNaN(this.time)) return;
     if (Number.isNaN(Number(this.time))) this.time = new Date(this.time).getTime();
-
-    const toDate = new Date((this.time as number) - this.consoleState.timeOffset);
-    this.element.nativeElement.textContent = formatDate(
-      toDate,
-      this.appConstants['console.dateFormat'] as string,
-      this.locale,
-    );
-  }
-
-  ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
+    this.element.nativeElement.textContent = this.serverTimeService.toServerTime(this.time as number);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
@@ -20,6 +20,8 @@ export type ServerInfo = {
   applicationServer: string;
   javaVersion: string;
   serverTime: number;
+  serverTimezone: string;
+  serverTimeISO: string;
   'dtap.stage': string;
   'dtap.side': string;
   processMetrics: {

--- a/console/frontend/src/main/frontend/src/app/services/server-time.service.spec.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-time.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ServerTimeService } from './server-time.service';
+
+describe('ServerTimeService', () => {
+  let service: ServerTimeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ServerTimeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/console/frontend/src/main/frontend/src/app/services/server-time.service.spec.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-time.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ServerTimeService } from './server-time.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ServerTimeService', () => {
   let service: ServerTimeService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(ServerTimeService);
   });
 

--- a/console/frontend/src/main/frontend/src/app/services/server-time.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-time.service.ts
@@ -1,0 +1,61 @@
+import { Inject, inject, Injectable, LOCALE_ID } from '@angular/core';
+import { formatDate } from '@angular/common';
+import { AppConstants, AppService } from '../app.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ServerTimeService {
+  public timezone?: string;
+
+  private appService = inject(AppService);
+  @Inject(LOCALE_ID) private locale: string = inject(LOCALE_ID);
+
+  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
+  private baseTime: Date = new Date();
+  private currentTime: Date = new Date();
+  private timeUpdateIntervalId = -1;
+  private previousLocalTime: number = Date.now();
+
+  getIntialTime(): string {
+    return formatDate(this.baseTime, this.appConstants['console.dateFormat'] as string, this.locale, this.timezone);
+  }
+
+  getCurrentTime(): number {
+    return this.currentTime.getTime();
+  }
+
+  getCurrentTimeFormatted(): string {
+    if (this.currentTime)
+      return formatDate(
+        this.currentTime,
+        this.appConstants['console.dateFormat'] as string,
+        this.locale,
+        this.timezone,
+      );
+    return '';
+  }
+
+  toServerTime(value: number | Date): string {
+    return formatDate(value, this.appConstants['console.dateFormat'] as string, this.locale, this.timezone);
+  }
+
+  setServerTime(serverTime: number, timezone: string): void {
+    this.baseTime = new Date(serverTime);
+    this.currentTime = new Date(serverTime);
+    this.timezone = timezone;
+    this.previousLocalTime = Date.now();
+
+    if (this.timeUpdateIntervalId > -1) window.clearInterval(this.timeUpdateIntervalId);
+    this.timeUpdateIntervalId = window.setInterval(() => this.updateTime(), 200);
+    this.updateTime();
+  }
+
+  private updateTime(): void {
+    const previousTime = this.previousLocalTime;
+    this.previousLocalTime = Date.now();
+
+    const timeDelta = Date.now() - previousTime;
+    this.currentTime.setTime(this.currentTime.getTime() + timeDelta);
+  }
+}

--- a/console/frontend/src/main/frontend/src/app/services/server-time.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-time.service.ts
@@ -26,18 +26,13 @@ export class ServerTimeService {
   }
 
   getCurrentTimeFormatted(): string {
-    if (this.currentTime)
-      return formatDate(
-        this.currentTime,
-        this.appConstants['console.dateFormat'] as string,
-        this.locale,
-        this.timezone,
-      );
-    return '';
+    const zonedTime = this.currentTime.toLocaleString(this.locale, { timeZone: this.timezone });
+    return formatDate(zonedTime, this.appConstants['console.dateFormat'] as string, this.locale, this.timezone);
   }
 
   toServerTime(value: number | Date): string {
-    return formatDate(value, this.appConstants['console.dateFormat'] as string, this.locale, this.timezone);
+    const zonedTime = new Date(value).toLocaleString(this.locale, { timeZone: this.timezone });
+    return formatDate(zonedTime, this.appConstants['console.dateFormat'] as string, this.locale, this.timezone);
   }
 
   setServerTime(serverTime: number, timezone: string): void {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ServerStatistics.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ServerStatistics.java
@@ -17,11 +17,16 @@ package org.frankframework.management.bus.endpoints;
 
 import java.io.File;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import jakarta.annotation.security.PermitAll;
 import jakarta.servlet.ServletContext;
@@ -92,9 +97,11 @@ public class ServerStatistics extends BusEndpointBase {
 		fileSystem.put("freeSpace", getFileSystemFreeSpace());
 		returnMap.put("fileSystem", fileSystem);
 		returnMap.put("processMetrics", ProcessMetrics.toMap());
-		Date date = new Date();
-		returnMap.put("serverTime", date.getTime());
 		returnMap.put("machineName" , Misc.getHostname());
+		ZonedDateTime zonedDateTime = ZonedDateTime.now();
+		returnMap.put("serverTime", zonedDateTime.toInstant().toEpochMilli());
+		returnMap.put("serverTimezone", zonedDateTime.getZone().getId());
+		returnMap.put("serverTimeISO", zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 		try {
 			returnMap.put("uptime", getApplicationContext().getStartupDate());
 		} catch (Exception e) {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ServerStatistics.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ServerStatistics.java
@@ -17,16 +17,12 @@ package org.frankframework.management.bus.endpoints;
 
 import java.io.File;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import jakarta.annotation.security.PermitAll;
 import jakarta.servlet.ServletContext;


### PR DESCRIPTION
Server now has timezone information in `/server/info`.
Console frontend has been updated to use the new ServerTime service which keeps track of the framework's timezone & epoch time.
TopNavBar time display & TimeSince & ToDate pipes have been updated to use the framework time.

This does not do anything for the statistics page yet as that needs to be reworked and seem broken (unrelated) now anyway