### PR TITLE
Remove logging of leaks that is now being made obsolete in 9.0

### DIFF
--- a/core/src/main/java/org/frankframework/stream/OverflowToDiskOutputStream.java
+++ b/core/src/main/java/org/frankframework/stream/OverflowToDiskOutputStream.java
@@ -27,11 +27,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.util.CleanerProvider;
 import org.frankframework.util.CloseUtils;
 import org.frankframework.util.StreamUtil;
-
-import lombok.extern.log4j.Log4j2;
 
 /**
  * Writes to an in-memory buffer until it 'overflows', after which a file on disk will be created and the in-memory buffer will be flushed to it.
@@ -103,8 +103,6 @@ public class OverflowToDiskOutputStream extends OutputStream implements AutoClos
 		@Override
 		public void run() {
 			if (shouldClean) {
-				log.info("Leak detection: File [{}] was never converted to a Message", fileToClean);
-
 				CloseUtils.closeSilently(closable);
 				try {
 					Files.deleteIfExists(fileToClean);

--- a/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
+++ b/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
@@ -168,7 +168,6 @@ public class SerializableFileReference implements Serializable, AutoCloseable {
 
 	private static class CleanupFileAction implements Runnable {
 		private final Path fileToClean;
-		private boolean calledByClose = false;
 
 		private CleanupFileAction(Path fileToClean) {
 			this.fileToClean = fileToClean;
@@ -176,9 +175,6 @@ public class SerializableFileReference implements Serializable, AutoCloseable {
 
 		@Override
 		public void run() {
-			if (!calledByClose) {
-				log.info("Leak detection: File [{}] was not closed properly, cleaning up", fileToClean);
-			}
 			try {
 				Files.deleteIfExists(fileToClean);
 			} catch (Exception e) {
@@ -218,7 +214,6 @@ public class SerializableFileReference implements Serializable, AutoCloseable {
 	@Override
 	public void close() {
 		if (cleanupFileAction != null) {
-			cleanupFileAction.calledByClose = true;
 			cleanable.clean();
 		}
 	}

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -15,7 +15,6 @@
 */
 package org.frankframework.stream;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +41,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +49,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
 import org.frankframework.functional.ThrowingSupplier;
 import org.frankframework.receivers.MessageWrapper;
 import org.frankframework.testutil.MatchUtils;
@@ -61,10 +64,6 @@ import org.frankframework.util.LogUtil;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.XmlUtils;
 import org.frankframework.xml.XmlWriter;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 public class MessageTest {
 	private static final boolean TEST_CDATA = true;
@@ -1277,26 +1276,6 @@ public class MessageTest {
 		assertFalse(msg2.isNull());
 		assertEquals("á", msg2.asString());
 		msg2.close();
-	}
-
-	@Test
-	void testMessageNotClosedByUser() {
-		try (TestAppender appender = TestAppender.newBuilder().build()) {
-			appender.setLeakDetectionFilter(false);
-			createMessageInShortLivedScope();
-			// GC should clean up the message object
-			System.gc();
-
-			// Assert: Give the garbage collector some time to clean up
-			await().pollInterval(50, TimeUnit.MILLISECONDS)
-					.atMost(2, TimeUnit.SECONDS)
-					.until(() -> appender.contains("Message was not closed properly"));
-		}
-	}
-
-	private void createMessageInShortLivedScope() {
-		Message test = new Message("fakeMessage1", new MessageContext().with("fakeContextKey", "fakeContextValue1"));
-		assertNotNull(test);
 	}
 
 	@Test


### PR DESCRIPTION
The logging of leaked items we had did not add any value to users, so now that we have a better logging I think it's better to remove it from older releases.

Since the cleaner in Message didn't actually do any work, it can be removed from there completely.