### PR TITLE
Fix file viewing rule and string resolving with multiple defaults

### DIFF
--- a/commons/src/main/java/org/frankframework/util/StringResolver.java
+++ b/commons/src/main/java/org/frankframework/util/StringResolver.java
@@ -170,8 +170,8 @@ public class StringResolver {
 	}
 
 	private static String extractNextExpression(String val, SubstitutionContext ctx) {
-		if (val.contains(VALUE_SEPARATOR)) {
-			ctx.tail = val.indexOf(VALUE_SEPARATOR);
+		if (val.substring(ctx.pointer).contains(VALUE_SEPARATOR)) {
+			ctx.tail = val.substring(ctx.pointer).indexOf(VALUE_SEPARATOR) + ctx.pointer;
 			ctx.providedDefaultValue = val.substring(ctx.tail + VALUE_SEPARATOR.length(), indexOfDelimStop(val, ctx.pointer, ctx.delimStart, ctx.delimStop));
 			ctx.containsDefault = true;
 		} else {

--- a/commons/src/main/java/org/frankframework/util/StringResolver.java
+++ b/commons/src/main/java/org/frankframework/util/StringResolver.java
@@ -170,8 +170,9 @@ public class StringResolver {
 	}
 
 	private static String extractNextExpression(String val, SubstitutionContext ctx) {
-		if (val.substring(ctx.pointer).contains(VALUE_SEPARATOR)) {
-			ctx.tail = val.substring(ctx.pointer).indexOf(VALUE_SEPARATOR) + ctx.pointer;
+		int nextSeparatorPos = val.indexOf(VALUE_SEPARATOR, ctx.pointer);
+		if (nextSeparatorPos >= 0) {
+			ctx.tail = nextSeparatorPos;
 			ctx.providedDefaultValue = val.substring(ctx.tail + VALUE_SEPARATOR.length(), indexOfDelimStop(val, ctx.pointer, ctx.delimStart, ctx.delimStop));
 			ctx.containsDefault = true;
 		} else {

--- a/commons/src/test/java/org/frankframework/util/StringResolverTest.java
+++ b/commons/src/test/java/org/frankframework/util/StringResolverTest.java
@@ -73,6 +73,15 @@ public class StringResolverTest {
 	}
 
 	@Test
+	void resolveWithTwoDefaultValues() {
+		// Act
+		String result = StringResolver.substVars("${testMultipleDefaults}", properties);
+
+		// Assert
+		assertEquals("/dev/null | /dev/null", result);
+	}
+
+	@Test
 	public void resolveFromEnvironmentBeforeProps() {
 		// Arrange
 		String envVarName = System.getenv().containsKey("Path") ? "Path" : "PATH";

--- a/commons/src/test/resources/StringResolver.properties
+++ b/commons/src/test/resources/StringResolver.properties
@@ -17,3 +17,4 @@ boolean=true
 int=1
 long=2
 double=3.0
+testMultipleDefaults=${path1:-/dev/null} | ${path2:-/dev/null}

--- a/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
+++ b/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
@@ -15,7 +15,7 @@ scenariosroot2.directory=/opt/frank/testtool-ext
 scenariosroot2.description=external testtool directory /opt/frank/testtool-ext
 
 # Permissions for the `log viewer`, which directories it may and may not read from.
-FileViewer.permission.rules=${credentialFactory.filesystem.root} * deny | /usr/local/tomcat/logs * allow | /opt/frank * allow
+FileViewer.permission.rules=${credentialFactory.filesystem.root:-/dev/null} * deny | ${credentialFactory.map.properties:-/dev/null} * deny | /usr/local/tomcat/logs * allow | /opt/frank * allow
 
 # Enables the `Frank!Framework CredentialManager Capability`, this allows property substitution in Tomcat settings, such as the Tomcat `context.xml`.
 org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource,org.frankframework.credentialprovider.CredentialProvidingPropertySource


### PR DESCRIPTION
The `FileViewer.permission.rules` had a property that wasn't set anymore. Because of this: `*` (everything) got denied, and none of the logs were viewable. I've added a default to that property and added a second property (`credentialFactory.map.properties`) to deny access to.
This created a bug because it wasn't possible to have multiple defaults in a property. That has been fixed now.