### PR TITLE
Revert "Bump @types/dompurify from 3.0.5 to 3.2.0 in /console/frontend/src/main/frontend"

### DIFF
--- a/console/frontend/src/main/frontend/package-lock.json
+++ b/console/frontend/src/main/frontend/package-lock.json
@@ -51,7 +51,7 @@
         "@angular/cli": "^17.3.11",
         "@angular/compiler-cli": "^17.3.12",
         "@types/d3": "^7.4.3",
-        "@types/dompurify": "^3.2.0",
+        "@types/dompurify": "^3.0.5",
         "@types/jasmine": "~4.6.4",
         "@types/lodash": "^4.17.13",
         "@types/markdown-it": "^13.0.7",
@@ -4325,13 +4325,12 @@
       }
     },
     "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
       "dev": true,
       "dependencies": {
-        "dompurify": "*"
+        "@types/trusted-types": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -4547,6 +4546,12 @@
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/@types/tinycon/-/tinycon-0.6.7.tgz",
       "integrity": "sha512-rRklPHkd/mWYEqNpgVi5ItpamqPSl6VVkvvCFavvVyrNdSN+qCM8vzza6FkLYKTRSMzOQhUwhPTktRetjJ4ctw==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true
     },
     "node_modules/@types/unist": {

--- a/console/frontend/src/main/frontend/package.json
+++ b/console/frontend/src/main/frontend/package.json
@@ -55,7 +55,7 @@
     "@angular/cli": "^17.3.11",
     "@angular/compiler-cli": "^17.3.12",
     "@types/d3": "^7.4.3",
-    "@types/dompurify": "^3.2.0",
+    "@types/dompurify": "^3.0.5",
     "@types/jasmine": "~4.6.4",
     "@types/lodash": "^4.17.13",
     "@types/markdown-it": "^13.0.7",


### PR DESCRIPTION
Reverts frankframework/frankframework#7972

The DomPurify update breaks the Console build.