### PR TITLE
Console frontend Types cleanup

### DIFF
--- a/console/frontend/src/main/frontend/.eslintrc.js
+++ b/console/frontend/src/main/frontend/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
       rules: {
         'prefer-template': 'error',
         '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/triple-slash-reference': 'warn',
         'unicorn/prevent-abbreviations': 'warn',
         'unicorn/no-array-reduce': 'off',
         'unicorn/prefer-ternary': 'warn',

--- a/console/frontend/src/main/frontend/package.json
+++ b/console/frontend/src/main/frontend/package.json
@@ -54,13 +54,11 @@
     "@angular-eslint/template-parser": "^17.3.12",
     "@angular/cli": "^17.3.11",
     "@angular/compiler-cli": "^17.3.12",
-    "@types/d3": "^7.4.3",
-    "@types/dompurify": "^3.0.5",
     "@types/jasmine": "~4.6.4",
     "@types/lodash": "^4.17.13",
     "@types/markdown-it": "^13.0.7",
     "@types/sockjs-client": "^1.5.4",
-    "@types/tinycon": "^0.6.7",
+    "@types/tinycon": "^0.6.6",
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
@@ -75,6 +73,6 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "prettier": "^3.2.5",
-    "typescript": "^5.3.3"
+    "typescript": "5.4.x"
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../../../node_modules/monaco-editor/monaco.d.ts" />
 import {
   AfterViewInit,

--- a/console/frontend/src/main/frontend/src/app/components/ng-mermaid/ng-mermaid.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/ng-mermaid/ng-mermaid.component.ts
@@ -1,3 +1,4 @@
+// /// <reference path="../../../../node_modules/mermaid/dist/mermaid.d.ts" /> doesnt work
 import { CommonModule } from '@angular/common';
 import {
   Component,
@@ -10,8 +11,14 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import mermaid from 'mermaid';
 import { v4 as uuidv4 } from 'uuid';
+// @ts-expect-error mermaid does not have types
+import mermaidImport, { RenderResult } from 'mermaid/dist/mermaid.esm.mjs';
+const mermaid = mermaidImport;
+
+// Uncomment developing for type support, comment again when compiling as it causes errors
+// import type { Mermaid } from 'mermaid';
+// const mermaid: Mermaid = mermaidImport;
 
 @Component({
   selector: 'ng-mermaid',
@@ -81,7 +88,7 @@ export class NgMermaidComponent implements OnInit, OnChanges, OnDestroy {
 
             mermaid
               .render(uid, this.nmModel!, mermaidContainer)
-              .then(({ svg, bindFunctions }) => {
+              .then(({ svg, bindFunctions }: RenderResult) => {
                 mermaidContainer.innerHTML = svg;
                 const svgElement = mermaidContainer.firstChild as SVGSVGElement;
                 this.mermaidSvgElement = svgElement;
@@ -89,7 +96,7 @@ export class NgMermaidComponent implements OnInit, OnChanges, OnDestroy {
                 svgElement.setAttribute('style', 'max-width: 100%;');
                 if (bindFunctions) bindFunctions(svgElement);
               })
-              .catch((error) => {
+              .catch((error: Error) => {
                 this.handleError(error);
               })
               .finally(() => {


### PR DESCRIPTION
Removes types that were required by mermaid's type definitions
Improves type import for monaco-editor
Locks typescript to version 5.4.x (required by angular v17, it would keep pulling latest on some occasions)