### PR TITLE
Fix filter condition for hiding configurations in tabs

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
@@ -79,7 +79,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
     if (!this.showAll) {
       this.tabs = this.configurationsList.filter((configuration) => {
         if (configuration === 'IAF_Util' && this.filterIAF_Util) return false;
-        return this.appService.configurationLengths[configuration] > 1;
+        return this.appService.configurationLengths[configuration] > 0;
       });
     }
   }


### PR DESCRIPTION
Adjusts the filter condition in the tab list component to allow 
configurations with lengths greater than zero. This change ensures 
that configurations with a length of one are included in the tab list, 
improving the visibility of available options for users.