### PR TITLE
Errors in events should not propagate back to the source

### DIFF
--- a/core/src/main/java/org/frankframework/configuration/SpringEventErrorHandler.java
+++ b/core/src/main/java/org/frankframework/configuration/SpringEventErrorHandler.java
@@ -1,0 +1,34 @@
+/*
+   Copyright 2024 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.configuration;
+
+import jakarta.annotation.Nonnull;
+
+import org.springframework.util.ErrorHandler;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Implementation of Spring error handler that logs errors. To be used for Event handling errors.
+ */
+@Log4j2
+public class SpringEventErrorHandler implements ErrorHandler {
+
+	@Override
+	public void handleError(@Nonnull Throwable t) {
+		log.warn("Error handling event", t);
+	}
+}

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/Monitoring.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/Monitoring.java
@@ -22,13 +22,8 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.annotation.security.RolesAllowed;
+
 import org.apache.commons.lang3.StringUtils;
-import org.frankframework.management.bus.TopicSelector;
-import org.frankframework.management.bus.dto.MonitorDTO;
-import org.frankframework.management.bus.dto.TriggerDTO;
-import org.frankframework.management.bus.message.EmptyMessage;
-import org.frankframework.management.bus.message.JsonMessage;
-import org.frankframework.management.bus.message.StringMessage;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
@@ -40,6 +35,12 @@ import org.frankframework.management.bus.BusAware;
 import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
+import org.frankframework.management.bus.TopicSelector;
+import org.frankframework.management.bus.dto.MonitorDTO;
+import org.frankframework.management.bus.dto.TriggerDTO;
+import org.frankframework.management.bus.message.EmptyMessage;
+import org.frankframework.management.bus.message.JsonMessage;
+import org.frankframework.management.bus.message.StringMessage;
 import org.frankframework.monitoring.AdapterFilter;
 import org.frankframework.monitoring.EventThrowing;
 import org.frankframework.monitoring.EventType;
@@ -51,11 +52,8 @@ import org.frankframework.monitoring.Severity;
 import org.frankframework.monitoring.SourceFiltering;
 import org.frankframework.monitoring.Trigger;
 import org.frankframework.monitoring.events.ConsoleMonitorEvent;
-
 import org.frankframework.util.EnumUtils;
-
 import org.frankframework.util.JacksonUtils;
-
 import org.frankframework.util.SpringUtils;
 
 @BusAware("frank-management-bus")
@@ -131,7 +129,9 @@ public class Monitoring extends BusEndpointBase {
 		try {
 			monitor.configure();
 		} catch (ConfigurationException e) {
-			throw new BusException("unable to (re)configure Monitor", e);
+			log.info("Unable to (re)configure monitor [{}]", monitor.getName(), e);
+			// Throw this as Warning / Bad Request, not able to configure was likely due to bad user input and not due to internal server error
+			throw new BusException("unable to (re)configure Monitor: " + e.getMessage());
 		}
 
 		return EmptyMessage.created();

--- a/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
@@ -23,6 +23,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+
+import lombok.Getter;
+import lombok.Setter;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.Adapter;
 import org.frankframework.doc.FrankDocGroup;
@@ -31,13 +39,6 @@ import org.frankframework.lifecycle.AbstractConfigurableLifecyle;
 import org.frankframework.monitoring.events.Event;
 import org.frankframework.monitoring.events.RegisterMonitorEvent;
 import org.frankframework.util.XmlBuilder;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationListener;
-
-import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Manager for Monitoring.
@@ -52,7 +53,7 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 
 	private @Getter @Setter ApplicationContext applicationContext;
 	private final List<Monitor> monitors = new ArrayList<>();                            // All monitors managed by this MonitorManager
-	private final Map<String, Event> events = new HashMap<>();                           // All events that can be thrown
+	private final Map<String, Event> events = Collections.synchronizedMap(new HashMap<>());                           // All events that can be thrown
 	private final Map<String, IMonitorDestination> destinations = new LinkedHashMap<>(); // All destinations (that can receive status messages) managed by this MonitorManager
 
 	/**

--- a/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
@@ -126,13 +127,13 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 	public Monitor getMonitor(int index) {
 		return monitors.get(index);
 	}
-	public Monitor findMonitor(String name) {
+	public Optional<Monitor> findMonitor(String name) {
 		if (name == null) {
-			return null;
+			return Optional.empty();
 		}
 		return monitors.stream()
 				.filter(monitor -> name.equals(monitor.getName()))
-				.findFirst().orElse(null);
+				.findFirst();
 	}
 
 	public List<Monitor> getMonitors() {

--- a/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
@@ -17,10 +17,10 @@ package org.frankframework.monitoring;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -53,7 +53,7 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 
 	private @Getter @Setter ApplicationContext applicationContext;
 	private final List<Monitor> monitors = new ArrayList<>();                            // All monitors managed by this MonitorManager
-	private final Map<String, Event> events = Collections.synchronizedMap(new HashMap<>());                           // All events that can be thrown
+	private final Map<String, Event> events = new ConcurrentHashMap<>();                 // All events that can be thrown
 	private final Map<String, IMonitorDestination> destinations = new LinkedHashMap<>(); // All destinations (that can receive status messages) managed by this MonitorManager
 
 	/**
@@ -131,8 +131,7 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 			return null;
 		}
 
-		for (int i=0; i<monitors.size(); i++) {
-			Monitor monitor = monitors.get(i);
+		for (Monitor monitor : monitors) {
 			if (name.equals(monitor.getName())) {
 				return monitor;
 			}

--- a/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/org/frankframework/monitoring/MonitorManager.java
@@ -127,16 +127,12 @@ public class MonitorManager extends AbstractConfigurableLifecyle implements Appl
 		return monitors.get(index);
 	}
 	public Monitor findMonitor(String name) {
-		if(name == null) {
+		if (name == null) {
 			return null;
 		}
-
-		for (Monitor monitor : monitors) {
-			if (name.equals(monitor.getName())) {
-				return monitor;
-			}
-		}
-		return null;
+		return monitors.stream()
+				.filter(monitor -> name.equals(monitor.getName()))
+				.findFirst().orElse(null);
 	}
 
 	public List<Monitor> getMonitors() {

--- a/core/src/main/java/org/frankframework/monitoring/Trigger.java
+++ b/core/src/main/java/org/frankframework/monitoring/Trigger.java
@@ -25,9 +25,12 @@ import java.util.Map;
 import java.util.Queue;
 
 import jakarta.annotation.Nonnull;
+
+import org.apache.logging.log4j.Logger;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.logging.log4j.Logger;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.Adapter;
 import org.frankframework.monitoring.events.FireMonitorEvent;
@@ -82,6 +85,10 @@ public class Trigger implements ITrigger {
 			}
 		} else { // In case of a reconfigure
 			eventDates = null;
+		}
+
+		if (severity == null) {
+			throw new ConfigurationException("you must define a severity for the trigger");
 		}
 
 		configured = true;

--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -17,6 +17,12 @@
 
 	<import resource="springUnmanagedDeployment.xml"/>
 
+	<bean name="applicationEventMulticaster" class="org.springframework.context.event.SimpleApplicationEventMulticaster" autowire="byName">
+		<property name="errorHandler">
+			<bean class="org.frankframework.configuration.SpringEventErrorHandler"/>
+		</property>
+	</bean>
+
 	<bean
 		name="lowerCasePropertySourcePostProcessor"
 		class="org.frankframework.configuration.LowerCasePropertySourcePostProcessor"

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -311,27 +310,23 @@ public class TestMonitoring extends BusTestBase {
 		request.setHeader("configuration", TestConfiguration.TEST_CONFIGURATION_NAME);
 		request.setHeader("monitor", TEST_MONITOR_NAME);
 
+		// Before the test make sure the state is as we expect
+		assertAll(
+				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
+				() -> assertEquals(1, getMonitorManager().getMonitor(0).getTriggers().size())
+		);
+
+
 		// Act
 		MessageHandlingException mhe = assertThrows(MessageHandlingException.class, ()-> callSyncGateway(request));
 
-		// Assert Exception
+		// Assert Exception and that state has not changed
 		assertInstanceOf(BusException.class, mhe.getCause());
 		BusException be = (BusException) mhe.getCause();
 		assertAll(
 				() -> assertEquals(400, be.getStatusCode()),
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
-				() -> assertEquals(2, getMonitorManager().getMonitor(0).getTriggers().size())
-			);
-
-		// Assert Trigger
-		ITrigger trigger = getMonitorManager().getMonitor(0).getTriggers().get(1);
-		assertAll(
-				() -> assertNull(trigger.getSeverity()),
-				() -> assertEquals(2, trigger.getPeriod()),
-				() -> assertEquals(1, trigger.getThreshold()),
-				() -> assertEquals(TriggerType.ALARM, trigger.getTriggerType()),
-				() -> assertThat(trigger.getEventCodes(), containsInAnyOrder("Receiver Configured")),
-				() -> assertEquals(SourceFiltering.NONE, trigger.getSourceFiltering())
+				() -> assertEquals(1, getMonitorManager().getMonitor(0).getTriggers().size())
 			);
 	}
 

--- a/core/src/test/java/org/frankframework/monitoring/TriggerTest.java
+++ b/core/src/test/java/org/frankframework/monitoring/TriggerTest.java
@@ -1,9 +1,15 @@
 package org.frankframework.monitoring;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -12,6 +18,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,10 +30,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 
 import lombok.Getter;
 
+import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.Adapter;
 import org.frankframework.monitoring.events.ConsoleMonitorEvent;
 import org.frankframework.monitoring.events.FireMonitorEvent;
 import org.frankframework.monitoring.events.MonitorEvent;
+import org.frankframework.testutil.TestAppender;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.util.XmlBuilder;
 
@@ -270,5 +280,39 @@ public class TriggerTest implements EventThrowing {
 		// Assert
 		verify(trigger, times(1)).configure();
 		assertEquals(TestFileUtils.getTestFile("/Management/Monitoring/getManagerToXML.xml"), manager.toXml().asXmlString());
+	}
+
+	@Test
+	public void testTriggerConfigure() {
+		try (TestAppender appender = TestAppender.newBuilder().build()) {
+			Trigger trigger = new Trigger();
+
+			ConfigurationException e1 = assertThrows(ConfigurationException.class, trigger::configure);
+			assertEquals("no monitor autowired", e1.getMessage());
+
+			trigger.setMonitor(monitor);
+			trigger.setEventCode(EVENT_CODE);
+			trigger.setThreshold(1);
+			trigger.setPeriod(0);
+
+			ConfigurationException e2 = assertThrows(ConfigurationException.class, trigger::configure);
+			assertEquals("you must define a period when using threshold > 0", e2.getMessage());
+
+			trigger.setPeriod(1);
+
+			ConfigurationException e3 = assertThrows(ConfigurationException.class, trigger::configure);
+			assertEquals("you must define a severity for the trigger", e3.getMessage());
+
+			trigger.setSeverity(Severity.CRITICAL);
+
+			assertDoesNotThrow(trigger::configure);
+
+			assertThat(appender.getLogLines(), not(hasItem(containsString("should have at least one eventCode specified"))));
+
+			trigger.setEventCodes(List.of());
+			assertDoesNotThrow(trigger::configure);
+
+			assertThat(appender.getLogLines(), hasItem(containsString("should have at least one eventCode specified")));
+		}
 	}
 }

--- a/management-gateway/src/main/java/org/frankframework/management/bus/BusException.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/BusException.java
@@ -15,6 +15,8 @@
 */
 package org.frankframework.management.bus;
 
+import java.io.Serial;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,12 +30,12 @@ import org.frankframework.core.IbisException;
 public class BusException extends RuntimeException {
 	private static final Logger LOG = LogManager.getLogger(BusException.class);
 
-	private static final long serialVersionUID = 1L;
+	private static final @Serial long serialVersionUID = 1L;
 
 	private final @Getter int statusCode;
 
 	/**
-	 * Seen as WARNING
+	 * Seen as WARNING / HTTP Bad Request
 	 */
 	public BusException(String message) {
 		this(message, 400);
@@ -47,7 +49,7 @@ public class BusException extends RuntimeException {
 	}
 
 	/**
-	 * Seen as ERROR
+	 * Seen as ERROR / HTTP Internal Server Error.
 	 * Stacktrace information is logged but not passed to the parent to limit sensitive information being sent over the 'bus'.
 	 */
 	public BusException(String message, Throwable exception) {


### PR DESCRIPTION
Make event handling asynchronous and add an error-handler.
Adding the error-handler will prevent the propagation of errors from events back to their publisher. Making event asynchronous seems like a logical thing to do, so the main process can continue while events are handled in the background, but isn't really part of the original issue.