### PR TITLE
chore(docker): make registry configurable in Dockerfile

### DIFF
--- a/docker/Tomcat/example/Dockerfile
+++ b/docker/Tomcat/example/Dockerfile
@@ -1,7 +1,7 @@
 ARG FF_VERSION=latest
 # Make repository variable so we can build and test the image before pushing it to the registry
 ARG REGISTRY=nexus.frankframework.org
-FROM ${REGISTRY}/frankframework/tomcat:${FF_VERSION}
+FROM ${REGISTRY}/frankframework:${FF_VERSION}
 
 # Copy resources
 COPY --chown=tomcat target/resources/ /opt/frank/resources/

--- a/docker/Tomcat/example/Dockerfile
+++ b/docker/Tomcat/example/Dockerfile
@@ -1,5 +1,7 @@
 ARG FF_VERSION=latest
-FROM nexus.frankframework.org/frankframework:${FF_VERSION}
+# Make repository variable so we can build and test the image before pushing it to the registry
+ARG REGISTRY=nexus.frankframework.org
+FROM ${REGISTRY}/frankframework/tomcat:${FF_VERSION}
 
 # Copy resources
 COPY --chown=tomcat target/resources/ /opt/frank/resources/


### PR DESCRIPTION
### Pull Request Description

This pull request introduces a significant enhancement to the Dockerfile by making the image registry configurable through a new `REGISTRY` argument. 

#### Changes Made:
- Added a `REGISTRY` argument to the Dockerfile, which allows developers to specify the image repository dynamically.
- This modification facilitates building and testing of the Docker image in the CI, streamlining the development workflow and ensuring that changes can be validated before being pushed to the remote registry.

#### Benefits:
- Improved flexibility in managing Docker images.
- Enhanced local development experience by allowing for easier testing and validation of images.

This change is expected to improve the overall efficiency of the development process and make it easier for developers to work with Docker images in various environments.