### PR TITLE
7969 fix two bugs with monitoring

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.html
@@ -150,7 +150,7 @@
                 <label class="col-sm-3 control-label">Destinations</label>
                 <div class="col-sm-2" *ngFor="let destination of destinations; index as index">
                   <span class="form-control m-b" style="border: none"
-                    ><input type="checkbox" name="destination" [(ngModel)]="monitor.activeDestinations[index]" />
+                    ><input type="checkbox" name="destination" [(ngModel)]="monitor.activeDestinations[destination]" />
                     {{ destination }}</span
                   >
                 </div>

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
@@ -79,11 +79,12 @@ export class MonitorsComponent implements OnInit, OnDestroy {
       for (const monitor of this.monitors) {
         monitor.displayName = monitor.name;
         if (monitor.raised) this.totalRaised++;
-        monitor.activeDestinations = [];
+        monitor.activeDestinations = {};
         for (const index in this.destinations) {
           const destination = this.destinations[index];
-          monitor.activeDestinations[index] = monitor.destinations.includes(destination);
+          monitor.activeDestinations[destination] = monitor.destinations.includes(destination);
         }
+        console.log(monitor.activeDestinations);
       }
     });
   }

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
@@ -84,7 +84,6 @@ export class MonitorsComponent implements OnInit, OnDestroy {
           const destination = this.destinations[index];
           monitor.activeDestinations[destination] = monitor.destinations.includes(destination);
         }
-        console.log(monitor.activeDestinations);
       }
     });
   }

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.service.ts
@@ -12,7 +12,7 @@ export type Monitor = {
   lastHit: string;
   triggers: Trigger[];
   displayName: string;
-  activeDestinations: boolean[];
+  activeDestinations: { [key: string]: boolean };
   edit: boolean;
   alarm: Alarm;
 };

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.service.ts
@@ -12,7 +12,7 @@ export type Monitor = {
   lastHit: string;
   triggers: Trigger[];
   displayName: string;
-  activeDestinations: { [key: string]: boolean };
+  activeDestinations: Record<string, boolean>;
   edit: boolean;
   alarm: Alarm;
 };

--- a/core/src/main/java/org/frankframework/monitoring/AbstractMonitorDestination.java
+++ b/core/src/main/java/org/frankframework/monitoring/AbstractMonitorDestination.java
@@ -17,6 +17,9 @@ package org.frankframework.monitoring;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+
+import org.frankframework.doc.Mandatory;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -38,7 +41,7 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 	protected Logger log = LogUtil.getLogger(this);
 	private @Getter @Setter ApplicationContext applicationContext;
 
-	private @Getter @Setter String name;
+	private @Getter String name;
 	private String hostname;
 
 	protected AbstractMonitorDestination() {
@@ -48,14 +51,14 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 	@Override
 	public void configure() throws ConfigurationException {
 		if (StringUtils.isEmpty(getName())) {
-			setName(ClassUtils.nameOf(this));
+			throw new ConfigurationException("name is required");
 		}
 
 		hostname = Misc.getHostname();
 	}
 
 	protected String makeXml(String monitorName, EventType eventType, Severity severity, String eventCode, MonitorEvent event) {
-		XmlBuilder eventXml = new XmlBuilder("event");
+		XmlBuilder eventXml = new XmlBuilder("Event");
 		eventXml.addAttribute("hostname", hostname);
 		eventXml.addAttribute("monitor", monitorName);
 		eventXml.addAttribute("source", event.getEventSourceName());
@@ -67,7 +70,7 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 
 	@Override
 	public XmlBuilder toXml() {
-		XmlBuilder destinationXml=new XmlBuilder("destination");
+		XmlBuilder destinationXml=new XmlBuilder("Destination");
 		destinationXml.addAttribute("name", getName());
 		destinationXml.addAttribute("className", getUserClass(this).getCanonicalName());
 		return destinationXml;
@@ -76,4 +79,10 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 	protected Class<?> getUserClass(Object clazz) {
 		return org.springframework.util.ClassUtils.getUserClass(clazz);
 	}
+
+	@Mandatory
+	public void setName(String name) {
+		this.name = name;
+	}
+
 }

--- a/core/src/main/java/org/frankframework/monitoring/AbstractMonitorDestination.java
+++ b/core/src/main/java/org/frankframework/monitoring/AbstractMonitorDestination.java
@@ -58,7 +58,7 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 	}
 
 	protected String makeXml(String monitorName, EventType eventType, Severity severity, String eventCode, MonitorEvent event) {
-		XmlBuilder eventXml = new XmlBuilder("Event");
+		XmlBuilder eventXml = new XmlBuilder("event");
 		eventXml.addAttribute("hostname", hostname);
 		eventXml.addAttribute("monitor", monitorName);
 		eventXml.addAttribute("source", event.getEventSourceName());
@@ -70,7 +70,7 @@ public abstract class AbstractMonitorDestination implements IMonitorDestination,
 
 	@Override
 	public XmlBuilder toXml() {
-		XmlBuilder destinationXml=new XmlBuilder("Destination");
+		XmlBuilder destinationXml=new XmlBuilder("destination");
 		destinationXml.addAttribute("name", getName());
 		destinationXml.addAttribute("className", getUserClass(this).getCanonicalName());
 		return destinationXml;

--- a/core/src/test/java/org/frankframework/monitoring/SenderMonitorAdapterTest.java
+++ b/core/src/test/java/org/frankframework/monitoring/SenderMonitorAdapterTest.java
@@ -29,6 +29,7 @@ public class SenderMonitorAdapterTest implements EventThrowing {
 		EchoSender sender = spy(EchoSender.class);
 		ArgumentCaptor<Message> messageCapture = ArgumentCaptor.forClass(Message.class);
 		destination.setSender(sender);
+		destination.setName("dummy destination");
 		destination.configure();
 
 		when(sender.sendMessage(messageCapture.capture(), any(PipeLineSession.class))).thenCallRealMethod();
@@ -49,6 +50,7 @@ public class SenderMonitorAdapterTest implements EventThrowing {
 		SenderMonitorAdapter destination = new SenderMonitorAdapter();
 		MessageCapturingEchoSender sender = new MessageCapturingEchoSender();
 		destination.setSender(sender);
+		destination.setName("dummy destination");
 		destination.configure();
 		String eventText = "<ik>ben<xml/></ik>";
 


### PR DESCRIPTION
Fixes #7969 

There are two bugs at play here:

First, there is a bug in the frontend which doesn't send the name of the destination, but instead sends the index, thus adding a `0`.

The name of a destination is not required and will automatically be instantiated with the name of the class (`SenderMonitorAdapter` in this case). The destination is stored in a map with the name being a key. Two destinations without a name are overwritten in the map and only one shows up. This will be fixed by following Niels' suggestion and by making the name attribute mandatory. 