### PR TITLE
Move placeholder text on edit-trigger page to a 'hint'

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-add-edit/monitors-add-edit.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-add-edit/monitors-add-edit.component.html
@@ -93,7 +93,9 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="col-sm-3 control-label">Threshold</label>
+              <label class="col-sm-3 control-label"
+                >Threshold <small><br />(Hint: Amount of triggers required before sounding an alarm)</small></label
+              >
               <div class="col-sm-9">
                 <input
                   class="form-control m-b"
@@ -101,12 +103,13 @@
                   type="number"
                   min="0"
                   [(ngModel)]="trigger.threshold"
-                  placeholder="Amount of triggers before sounding an alarm"
                 />
               </div>
             </div>
             <div class="form-group">
-              <label class="col-sm-3 control-label">Period</label>
+              <label class="col-sm-3 control-label"
+                >Period <small><br />(Hint: Amount of hits required within 'n' seconds to count as a trigger)</small></label
+              >
               <div class="col-sm-9">
                 <input
                   class="form-control m-b"
@@ -114,7 +117,6 @@
                   type="number"
                   min="0"
                   [(ngModel)]="trigger.period"
-                  placeholder="Amount of triggers within a period of time"
                 />
               </div>
             </div>


### PR DESCRIPTION
It's a lot of text, and it overflows if there is not enough space. It's not the best solution but for now it's the easiest...
Placeholders do not work when there is a default value. Though this not the best solution, and perhaps we should revamp all the forms, but at least it improves the current user-flow a bit...