### PR TITLE
Downgrade Log4J2 to avoid exception when setting loglevel.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>
-		<log4j2.version>2.24.2</log4j2.version>
+		<log4j2.version>2.23.1</log4j2.version>
 
 		<sonar.organization>frank-framework</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
The Log4J2 2.23.1 code does not yet contain the problematic change that can cause the `ConcurrentModificationException`.