### PR TITLE
Reorder authorization roles for consistency

### DIFF
--- a/commons/src/main/java/org/frankframework/lifecycle/DynamicRegistration.java
+++ b/commons/src/main/java/org/frankframework/lifecycle/DynamicRegistration.java
@@ -39,9 +39,9 @@ import org.springframework.stereotype.Component;
  */
 public interface DynamicRegistration {
 
-	String[] ALL_IBIS_ROLES = {"IbisObserver", "IbisAdmin", "IbisDataAdmin", "IbisTester", "IbisWebService"};
-	String[] ALL_IBIS_USER_ROLES = {"IbisObserver", "IbisAdmin", "IbisDataAdmin", "IbisTester"};
-	String[] IBIS_FULL_SERVICE_ACCESS_ROLES = {"IbisTester", "IbisWebService"};
+	String[] ALL_IBIS_ROLES = {"IbisWebService", "IbisObserver", "IbisDataAdmin", "IbisAdmin","IbisTester"};
+	String[] ALL_IBIS_USER_ROLES = {"IbisObserver", "IbisDataAdmin","IbisAdmin", "IbisTester"};
+	String[] IBIS_FULL_SERVICE_ACCESS_ROLES = {"IbisWebService", "IbisTester"};
 
 	/**
 	 * Name of the to-be implemented class

--- a/core/src/main/java/org/frankframework/http/RestListener.java
+++ b/core/src/main/java/org/frankframework/http/RestListener.java
@@ -59,7 +59,7 @@ public class RestListener extends PushingListenerAdapter implements HasPhysicalD
 	private @Getter String contentTypeSessionKey;
 	private @Getter String restPath = "/rest";
 	private final @Getter Boolean view = null;
-	private @Getter String authRoles="IbisAdmin,IbisDataAdmin,IbisTester,IbisObserver,IbisWebService";
+	private @Getter String authRoles="IbisWebService,IbisObserver,IbisDataAdmin,IbisAdmin,IbisTester";
 	private @Getter boolean writeToSecLog = false;
 	private @Getter boolean writeSecLogMessage = false;
 	private @Getter boolean retrieveMultipart = true;
@@ -216,7 +216,7 @@ public class RestListener extends PushingListenerAdapter implements HasPhysicalD
 
 	/**
 	 * Comma separated list of authorization roles which are granted for this rest service
-	 * @ff.default IbisAdmin,IbisDataAdmin,IbisTester,IbisObserver,IbisWebService
+	 * @ff.default IbisWebService,IbisObserver,IbisDataAdmin,IbisAdmin,IbisTester
 	 */
 	public void setAuthRoles(String string) {
 		authRoles = string;

--- a/core/src/test/resources/Management/securityItemsResponse.json
+++ b/core/src/test/resources/Management/securityItemsResponse.json
@@ -1,11 +1,11 @@
 {
     "securityRoles": [
         {
-            "name": "IbisObserver",
+            "name": "IbisWebService",
             "allowed": false
         },
         {
-            "name": "IbisAdmin",
+            "name": "IbisObserver",
             "allowed": false
         },
         {
@@ -13,12 +13,12 @@
             "allowed": false
         },
         {
-            "name": "IbisTester",
-            "allowed": true
+            "name": "IbisAdmin",
+            "allowed": false
         },
         {
-            "name": "IbisWebService",
-            "allowed": false
+            "name": "IbisTester",
+            "allowed": true
         }
     ],
 	"supportedConnectionOptions": {

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractServletAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractServletAuthenticator.java
@@ -56,7 +56,7 @@ import lombok.Getter;
 
 public abstract class AbstractServletAuthenticator implements IAuthenticator, ApplicationContextAware {
 	private static final String HTTP_SECURITY_BEAN_NAME = "org.springframework.security.config.annotation.web.configuration.HttpSecurityConfiguration.httpSecurity";
-	public static final List<String> DEFAULT_IBIS_ROLES = List.of("IbisObserver", "IbisAdmin", "IbisDataAdmin", "IbisTester", "IbisWebService");
+	public static final List<String> DEFAULT_IBIS_ROLES = List.of("IbisWebService", "IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester");
 
 	public static final String ALLOW_OPTIONS_REQUESTS_KEY = "application.security.http.allowUnsecureOptionsRequests";
 


### PR DESCRIPTION
Reorder the default authorization roles in the RestListener, 
AbstractServletAuthenticator, andRegistration classes 
to maintain a consistent hierarchy.
The hierarchy goes from: few permissions -> more permissions