### PR TITLE
Fix showing non-read stream in ladybug

### DIFF
--- a/core/src/main/java/org/frankframework/util/StreamCaptureUtils.java
+++ b/core/src/main/java/org/frankframework/util/StreamCaptureUtils.java
@@ -56,7 +56,6 @@ public class StreamCaptureUtils {
 				}
 				return stream;
 			}
-
 		};
 	}
 
@@ -122,7 +121,6 @@ public class StreamCaptureUtils {
 				super.reset();
 			}
 		};
-
 	}
 
 	public static OutputStream captureOutputStream(OutputStream stream, OutputStream capture, int maxSize) {
@@ -190,7 +188,6 @@ public class StreamCaptureUtils {
 				markCompensatingWriter.reset();
 				super.reset();
 			}
-
 		};
 	}
 

--- a/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
@@ -3,10 +3,14 @@ package org.frankframework.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.frankframework.stream.Message;
@@ -14,16 +18,47 @@ import org.frankframework.stream.UrlMessage;
 
 class StreamCaptureUtilsTest {
 
+	static class BooleanContainer {
+		private boolean value;
+		public void setValue(boolean value) {
+			this.value = value;
+		}
+		public boolean getValue() {
+			return value;
+		}
+	}
+
+	@Test
+	void assertCaptureUtilsCallsWriteMethod() throws IOException {
+		ByteArrayInputStream bis = new ByteArrayInputStream("Test input".getBytes());
+
+		// We need something effectively final here, we can't use a boolean directly unfortunately.
+		BooleanContainer container = new BooleanContainer();
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream() {
+			@Override
+			public void write(byte[] b, int off, int len) {
+				container.setValue(true);
+				super.write(b, off, len);
+			}
+		};
+
+		InputStream inputStream = StreamCaptureUtils.captureInputStream(bis, baos, 16);
+		inputStream.close();
+
+		Assertions.assertTrue(container.getValue());
+	}
+
 	@Test
 	public void testMarkSupportedOutputStream() throws Exception {
-		byte[] bytes = "A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z".getBytes(); //76 chars
-		ByteArrayOutputStream boas = new ByteArrayOutputStream();
-		BufferedOutputStream bout = new BufferedOutputStream(boas, 16);
+		byte[] bytes = "A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z".getBytes(); // 76 chars
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		BufferedOutputStream bout = new BufferedOutputStream(baos, 16);
 		try (StreamCaptureUtils.MarkCompensatingOutputStream out = new StreamCaptureUtils.MarkCompensatingOutputStream(bout)) {
 
 			out.write(bytes, 9, 6);
 			out.flush();
-			assertEquals("D, E, ", boas.toString());
+			assertEquals("D, E, ", baos.toString());
 
 			for (int i = 0; i < bytes.length/4; i++) {
 				if(i%2==0) {
@@ -34,7 +69,7 @@ class StreamCaptureUtilsTest {
 		}
 
 		//D, E, prefix has already been written before the first skip has been called.
-		assertEquals("D, E, B, C, E, F, H, J, K, M, N, P, R, S, U, V, X, Z", new String(boas.toByteArray()));
+		assertEquals("D, E, B, C, E, F, H, J, K, M, N, P, R, S, U, V, X, Z", new String(baos.toByteArray()));
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
@@ -1,6 +1,7 @@
 package org.frankframework.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
@@ -9,8 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.frankframework.stream.Message;
@@ -18,27 +19,17 @@ import org.frankframework.stream.UrlMessage;
 
 class StreamCaptureUtilsTest {
 
-	static class BooleanContainer {
-		private boolean value;
-		public void setValue(boolean value) {
-			this.value = value;
-		}
-		public boolean getValue() {
-			return value;
-		}
-	}
-
 	@Test
 	void assertCaptureUtilsCallsWriteMethod() throws IOException {
 		ByteArrayInputStream bis = new ByteArrayInputStream("Test input".getBytes());
 
 		// We need something effectively final here, we can't use a boolean directly unfortunately.
-		BooleanContainer container = new BooleanContainer();
+		AtomicBoolean container = new AtomicBoolean();
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream() {
 			@Override
 			public void write(byte[] b, int off, int len) {
-				container.setValue(true);
+				container.set(true);
 				super.write(b, off, len);
 			}
 		};
@@ -46,7 +37,7 @@ class StreamCaptureUtilsTest {
 		InputStream inputStream = StreamCaptureUtils.captureInputStream(bis, baos, 16);
 		inputStream.close();
 
-		Assertions.assertTrue(container.getValue());
+		assertTrue(container.get(), "Asserts that the write method was called by the capture utils");
 	}
 
 	@Test

--- a/ladybug/debugger/src/test/java/org/frankframework/ladybug/capture/TestOutputStreamCaptureWrapper.java
+++ b/ladybug/debugger/src/test/java/org/frankframework/ladybug/capture/TestOutputStreamCaptureWrapper.java
@@ -10,34 +10,34 @@ import org.junit.jupiter.api.Test;
 public class TestOutputStreamCaptureWrapper {
 
 	@Test
-	void nothingWrittenToBOAS() throws IOException {
-		ByteArrayOutputStream boas = new ByteArrayOutputStream();
-		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(boas);
+	void nothingWrittenToBAOS() throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(baos);
 
 		wrapper.close();
 
-		assertEquals(">> Captured stream was closed without being read.", boas.toString());
+		assertEquals(">> Captured stream was closed without being read.", baos.toString());
 	}
 
 	@Test
-	void somethingWrittenToBOAS() throws IOException {
-		ByteArrayOutputStream boas = new ByteArrayOutputStream();
-		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(boas);
+	void somethingWrittenToBAOS() throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(baos);
 
 		wrapper.write("something".getBytes());
 		wrapper.close();
 
-		assertEquals("something", boas.toString());
+		assertEquals("something", baos.toString());
 	}
 
 	@Test
-	void emptyWrittenToBOAS() throws IOException {
-		ByteArrayOutputStream boas = new ByteArrayOutputStream();
-		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(boas);
+	void emptyWrittenToBAOS() throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		OutputStreamCaptureWrapper wrapper = new OutputStreamCaptureWrapper(baos);
 
 		wrapper.write("".getBytes());
 		wrapper.close();
 
-		assertEquals("", boas.toString());
+		assertEquals("", baos.toString());
 	}
 }


### PR DESCRIPTION
When an adapter was called via a SendMessageJob, the result was never read, resulting in "Captured stream was closed without being read". By applying this change, the output will be 'read' in that case.