### PR TITLE
Add dynamic drop down to select an adapter in "Test a Pipeline" faster 

### DIFF
--- a/console/frontend/src/main/frontend/src/app/app.module.ts
+++ b/console/frontend/src/main/frontend/src/app/app.module.ts
@@ -92,6 +92,7 @@ import { MonitorsNewComponent } from './views/monitors/monitors-new/monitors-new
 import { ConfigurationTabListComponent } from './components/tab-list/configuration-tab-list.component';
 import { TabListComponent } from './components/tab-list/tab-list.component';
 import { HasAccessToLinkDirective } from './components/has-access-to-link.directive';
+import { ComboboxComponent } from './components/combobox/combobox.component';
 
 const windowProvider: ValueProvider = {
   provide: Window,
@@ -203,6 +204,7 @@ const windowProvider: ValueProvider = {
     ConfigurationTabListComponent,
     TabListComponent,
     HasAccessToLinkDirective,
+    ComboboxComponent,
   ],
   providers: [windowProvider, { provide: TitleStrategy, useClass: PagesTitleStrategy }, httpInterceptorProviders],
   bootstrap: [AppComponent],

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -21,7 +21,8 @@
     [ngClass]="{ 'combobox__list-item--selected': i === selectedIndex }"
     (mousedown)="clickItem(i); $event.preventDefault()"
   >
-    {{ item }}
+    <div class="combobox__list-item__label">{{ item.label }}</div>
+    <div class="combobox__list-item__description" *ngIf="item.description">{{ item.description }}</div>
   </div>
   <div class="combobox__list-item" *ngIf="input" (mousedown)="clearSelectedItem(); $event.preventDefault()">
     &times; clear

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -1,0 +1,25 @@
+<input
+  type="text"
+  placeholder="Select one..."
+  [name]="name"
+  [className]="comboBoxClass"
+  [(ngModel)]="input"
+  (ngModelChange)="onUpdateInput()"
+  (keyup)="onKeyPress($event)"
+  (blur)="hideListDisplay()"
+  (focus)="showListDisplay()"
+  (click)="showListDisplay()"
+  [ngClass]="{ error: showError }"
+/>
+<div #comboBoxOptions [className]="comboBoxOptionsClass" *ngIf="listShown">
+  <div
+    class="list-item"
+    *ngFor="let item of listItems; let i = index"
+    [ngClass]="{ selected: i === selectedIndex }"
+    (mousedown)="clickItem(i); $event.preventDefault()"
+  >
+    {{ item }}
+  </div>
+  <div class="list-item" *ngIf="input" (mousedown)="clearSelectedItem(); $event.preventDefault()">&times; clear</div>
+</div>
+<i *ngIf="showError" class="error-text">Invalid Selection</i>

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -3,6 +3,8 @@
     type="text"
     placeholder="Select one..."
     [name]="name"
+    [id]="id"
+    [disabled]="disabled"
     class="form-control"
     [(ngModel)]="input"
     (ngModelChange)="onUpdateInput()"
@@ -12,9 +14,9 @@
     (click)="showListDisplay()"
     [ngClass]="{ 'combobox__input--error': showError }"
   />
-  <div class="combobox__dropdown-icon">&#9660;</div>
+  <div #comboboxDropdownIcon class="combobox__dropdown-icon">&#9660;</div>
 </div>
-<div #comboBoxOptions class="combobox__options" *ngIf="listShown">
+<div #comboboxOptions class="combobox__options" *ngIf="listShown">
   <div
     class="combobox__list-item"
     *ngFor="let item of filteredOptions; let i = index"
@@ -24,7 +26,11 @@
     <div class="combobox__list-item__label">{{ item.label }}</div>
     <div class="combobox__list-item__description" *ngIf="item.description">{{ item.description }}</div>
   </div>
-  <div class="combobox__list-item" *ngIf="input" (mousedown)="clearSelectedItem(); $event.preventDefault()">
+  <div
+    class="combobox__list-item combobox__list-item--clear"
+    *ngIf="input"
+    (mousedown)="clearSelectedItem(); $event.preventDefault()"
+  >
     &times; clear
   </div>
 </div>

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -1,37 +1,40 @@
-<div class="combobox__input-container">
-  <input
-    type="text"
-    placeholder="Select one..."
-    [name]="name"
-    [id]="id"
-    [disabled]="disabled"
-    class="form-control"
-    [(ngModel)]="input"
-    (ngModelChange)="onUpdateInput()"
-    (keyup)="onKeyPress($event)"
-    (blur)="hideListDisplay()"
-    (focus)="showListDisplay()"
-    (click)="showListDisplay()"
-    [ngClass]="{ 'combobox__input--error': showError }"
-  />
-  <div #comboboxDropdownIcon class="combobox__dropdown-icon">&#9660;</div>
-</div>
-<div #comboboxOptions class="combobox__options" *ngIf="listShown">
-  <div
-    class="combobox__list-item"
-    *ngFor="let item of filteredOptions; let i = index"
-    [ngClass]="{ 'combobox__list-item--selected': i === selectedIndex }"
-    (mousedown)="clickItem(i); $event.preventDefault()"
-  >
-    <div class="combobox__list-item__label">{{ item.label }}</div>
-    <div class="combobox__list-item__description" *ngIf="item.description">{{ item.description }}</div>
+<div class="combobox">
+  <div class="combobox__input-container">
+    <input
+      type="text"
+      placeholder="Select one..."
+      [name]="name"
+      [id]="id"
+      [disabled]="disabled"
+      class="form-control"
+      [(ngModel)]="input"
+      (ngModelChange)="onUpdateInput()"
+      (keyup)="onKeyPress($event)"
+      (blur)="hideListDisplay()"
+      (focus)="showListDisplay()"
+      (click)="showListDisplay()"
+      [ngClass]="{ 'combobox__input--error': showError }"
+    />
+    <div #comboboxDropdownIcon class="combobox__dropdown-icon">&#9660;</div>
   </div>
-  <div
-    class="combobox__list-item combobox__list-item--clear"
-    *ngIf="input"
-    (mousedown)="clearSelectedItem(); $event.preventDefault()"
-  >
-    &times; clear
+  <div #comboboxOptions class="combobox__options" *ngIf="listShown">
+    <div
+      class="combobox__list-item"
+      *ngFor="let item of filteredOptions; let i = index"
+      [ngClass]="{ 'combobox__list-item--selected': i === selectedIndex }"
+      (mousedown)="clickItem(i); $event.preventDefault()"
+    >
+      <div class="combobox__list-item__label">{{ item.label }}</div>
+      <div class="combobox__list-item__description" *ngIf="item.description">{{ item.description }}</div>
+    </div>
+    <div class="combobox__list-item combobox__list-item--empty" *ngIf="!filteredOptions.length">No results</div>
+    <div
+      class="combobox__list-item combobox__list-item--clear"
+      *ngIf="input"
+      (mousedown)="clearSelectedItem(); $event.preventDefault()"
+    >
+      &times; clear
+    </div>
   </div>
 </div>
 <i *ngIf="showError" class="combobox__error-text">Invalid Selection</i>

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -14,7 +14,7 @@
 <div #comboBoxOptions [className]="comboBoxOptionsClass" *ngIf="listShown">
   <div
     class="list-item"
-    *ngFor="let item of listItems; let i = index"
+    *ngFor="let item of filteredOptions; let i = index"
     [ngClass]="{ selected: i === selectedIndex }"
     (mousedown)="clickItem(i); $event.preventDefault()"
   >

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.html
@@ -1,25 +1,30 @@
-<input
-  type="text"
-  placeholder="Select one..."
-  [name]="name"
-  [className]="comboBoxClass"
-  [(ngModel)]="input"
-  (ngModelChange)="onUpdateInput()"
-  (keyup)="onKeyPress($event)"
-  (blur)="hideListDisplay()"
-  (focus)="showListDisplay()"
-  (click)="showListDisplay()"
-  [ngClass]="{ error: showError }"
-/>
-<div #comboBoxOptions [className]="comboBoxOptionsClass" *ngIf="listShown">
+<div class="combobox__input-container">
+  <input
+    type="text"
+    placeholder="Select one..."
+    [name]="name"
+    class="form-control"
+    [(ngModel)]="input"
+    (ngModelChange)="onUpdateInput()"
+    (keyup)="onKeyPress($event)"
+    (blur)="hideListDisplay()"
+    (focus)="showListDisplay()"
+    (click)="showListDisplay()"
+    [ngClass]="{ 'combobox__input--error': showError }"
+  />
+  <div class="combobox__dropdown-icon">&#9660;</div>
+</div>
+<div #comboBoxOptions class="combobox__options" *ngIf="listShown">
   <div
-    class="list-item"
+    class="combobox__list-item"
     *ngFor="let item of filteredOptions; let i = index"
-    [ngClass]="{ selected: i === selectedIndex }"
+    [ngClass]="{ 'combobox__list-item--selected': i === selectedIndex }"
     (mousedown)="clickItem(i); $event.preventDefault()"
   >
     {{ item }}
   </div>
-  <div class="list-item" *ngIf="input" (mousedown)="clearSelectedItem(); $event.preventDefault()">&times; clear</div>
+  <div class="combobox__list-item" *ngIf="input" (mousedown)="clearSelectedItem(); $event.preventDefault()">
+    &times; clear
+  </div>
 </div>
-<i *ngIf="showError" class="error-text">Invalid Selection</i>
+<i *ngIf="showError" class="combobox__error-text">Invalid Selection</i>

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -1,6 +1,7 @@
 .combobox {
+  position: relative;
+
   &__input-container {
-    position: relative;
     display: flex;
     align-items: center;
   }
@@ -29,8 +30,9 @@
     background-color: white;
     border: 1px solid #bdbfc2;
     max-height: 200px;
+    width: 100%;
     overflow-y: auto;
-    box-shadow: 0 2px 2px 2px #00000022;
+    box-shadow: 0 2px 3px 3px #00000011;
     z-index: 1;
   }
 
@@ -51,18 +53,20 @@
       background-color: #1ab394;
     }
 
+    &--empty {
+      font-style: italic;
+    }
+
     &--clear {
-      text-align: center;
       font-weight: bold;
       color: #cc5965;
     }
 
     &__label {
-      font-weight: bold;
     }
 
     &__description {
-      font-size: 0.9em;
+      font-size: 0.8em;
     }
   }
 

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -46,6 +46,14 @@
       color: cornsilk;
       background-color: #1ab394;
     }
+
+    &__label {
+      font-weight: bold;
+    }
+
+    &__description {
+      font-size: 0.9em;
+    }
   }
 
   &__error-text {

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -32,7 +32,7 @@
     max-height: 200px;
     width: 100%;
     overflow-y: auto;
-    box-shadow: 0 2px 3px 3px #00000011;
+    box-shadow: 0 2px 3px 3px #0001;
     z-index: 1;
   }
 
@@ -63,6 +63,7 @@
     }
 
     &__label {
+      // placeholder
     }
 
     &__description {

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -1,0 +1,36 @@
+.combobox-options {
+  margin-top: 5px;
+  position: absolute;
+  background-color: white;
+  border: 1px solid #bdbfc2;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0 2px 2px 2px #00000022;
+  z-index: 1;
+}
+
+.selected {
+  color: cornsilk;
+  background-color: #1ab394;
+}
+
+.list-item {
+  padding: 5px 15px;
+}
+
+.list-item:not(:last-child){
+  border-bottom: 1px solid #bdbfc2;
+}
+
+.list-item:hover {
+  background-color: #999;
+  color: white;
+}
+
+.error-text {
+  color: rgb(165, 112, 112);
+}
+
+.error {
+  border: 1px solid red;
+}

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -1,36 +1,54 @@
-.combobox-options {
-  margin-top: 5px;
-  position: absolute;
-  background-color: white;
-  border: 1px solid #bdbfc2;
-  max-height: 200px;
-  overflow-y: auto;
-  box-shadow: 0 2px 2px 2px #00000022;
-  z-index: 1;
-}
+.combobox {
+  &__input-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
 
-.selected {
-  color: cornsilk;
-  background-color: #1ab394;
-}
+  &__input {
+    &--error {
+      border: 1px solid red;
+    }
+  }
 
-.list-item {
-  padding: 5px 15px;
-}
+  &__dropdown-icon {
+    position: absolute;
+    right: 10px;
+    pointer-events: none;
+    font-size: 12px;
+    color: #ccc;
+  }
 
-.list-item:not(:last-child){
-  border-bottom: 1px solid #bdbfc2;
-}
+  &__options {
+    margin-top: 5px;
+    position: absolute;
+    background-color: white;
+    border: 1px solid #bdbfc2;
+    max-height: 200px;
+    overflow-y: auto;
+    box-shadow: 0 2px 2px 2px #00000022;
+    z-index: 1;
+  }
 
-.list-item:hover {
-  background-color: #999;
-  color: white;
-}
+  &__list-item {
+    padding: 5px 15px;
 
-.error-text {
-  color: rgb(165, 112, 112);
-}
+    &:not(:last-child) {
+      border-bottom: 1px solid #bdbfc2;
+    }
 
-.error {
-  border: 1px solid red;
+    &:hover {
+      background-color: #999;
+      color: white;
+    }
+
+    &--selected {
+      color: cornsilk;
+      background-color: #1ab394;
+    }
+  }
+
+  &__error-text {
+    color: rgb(165, 112, 112);
+  }
 }

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.scss
@@ -16,7 +16,11 @@
     right: 10px;
     pointer-events: none;
     font-size: 12px;
-    color: #ccc;
+    color: #999;
+
+    &--active {
+      color: #333;
+    }
   }
 
   &__options {
@@ -47,6 +51,12 @@
       background-color: #1ab394;
     }
 
+    &--clear {
+      text-align: center;
+      font-weight: bold;
+      color: #cc5965;
+    }
+
     &__label {
       font-weight: bold;
     }
@@ -57,6 +67,6 @@
   }
 
   &__error-text {
-    color: rgb(165, 112, 112);
+    color: #cc5965;
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.spec.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ComboboxComponent } from './combobox.component';
+
+describe('ComboboxComponent', () => {
+  let component: ComboboxComponent;
+  let fixture: ComponentFixture<ComboboxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComboboxComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ComboboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -1,4 +1,14 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -14,7 +24,7 @@ export type Option = {
   templateUrl: './combobox.component.html',
   styleUrl: './combobox.component.scss',
 })
-export class ComboboxComponent implements OnInit {
+export class ComboboxComponent implements OnInit, OnChanges {
   @Input({ required: true }) options!: Option[];
   @Input() required: boolean = true;
   @Input() name: string = '';
@@ -34,6 +44,12 @@ export class ComboboxComponent implements OnInit {
 
   ngOnInit(): void {
     this.resetListItems();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['selectedOption']) {
+      this.input = changes['selectedOption'].currentValue ?? '';
+    }
   }
 
   private resetListItems(): void {
@@ -56,6 +72,7 @@ export class ComboboxComponent implements OnInit {
     if (!this.listShown) return;
     this.comboboxDropdownIcon.nativeElement.classList.remove('combobox__dropdown-icon--active');
     this.listShown = false;
+    this.setSelectedOption(this.input);
     this.validateInput();
   }
 

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -2,8 +2,6 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, OnInit, Output,
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-type Options<T> = Record<string, T>;
-
 @Component({
   selector: 'app-combobox',
   standalone: true,
@@ -12,19 +10,19 @@ type Options<T> = Record<string, T>;
   templateUrl: './combobox.component.html',
   styleUrl: './combobox.component.scss',
 })
-export class ComboboxComponent<T> implements OnInit {
-  @Input({ required: true }) options!: Options<T>;
+export class ComboboxComponent implements OnInit {
+  @Input({ required: true }) options!: string[];
   @Input() comboBoxClass: string = 'form-control';
   @Input() comboBoxOptionsClass: string = 'combobox-options';
   @Input() required: boolean = true;
   @Input() name: string = '';
-  @Input() selectedOption: string = '';
+  @Input() selectedOption?: string;
   @Output() selectedOptionChange: EventEmitter<string> = new EventEmitter<string>();
 
   @ViewChild('comboBoxOptions') comboBoxOptions!: HTMLElement;
 
   protected input: string = '';
-  protected listItems: string[] = [];
+  protected filteredOptions: string[] = [];
   protected selectedIndex: number = -1;
   protected listShown: boolean = false;
   protected showError: boolean = false;
@@ -34,7 +32,7 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   private resetListItems(): void {
-    this.listItems = Object.keys(this.options);
+    this.filteredOptions = this.options;
   }
 
   protected showListDisplay(): void {
@@ -45,13 +43,7 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   private filterListItems(): void {
-    this.listItems = Object.keys(this.options).filter((item) =>
-      item.toLowerCase().startsWith(this.input.toLowerCase()),
-    );
-  }
-
-  protected hideListDisplayWithDelay(): void {
-    setTimeout(() => this.hideListDisplay(), 100);
+    this.filteredOptions = this.options.filter((item) => item.toLowerCase().startsWith(this.input.toLowerCase()));
   }
 
   hideListDisplay(): void {
@@ -61,7 +53,7 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   private validateInput(): void {
-    this.showError = !!(this.input || this.required) && !Object.keys(this.options).includes(this.input);
+    this.showError = !!(this.input || this.required) && !this.options.includes(this.input);
     if (this.showError) this.resetListItems();
   }
 
@@ -72,7 +64,7 @@ export class ComboboxComponent<T> implements OnInit {
 
   private highlightItemMatchingInput(): void {
     if (!this.input) return;
-    const matchingItem = this.listItems.indexOf(this.input);
+    const matchingItem = this.filteredOptions.indexOf(this.input);
     if (matchingItem >= 0) {
       this.selectItemInListDisplay(matchingItem);
     } else {
@@ -91,7 +83,7 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   private selectItem(index: number): void {
-    this.input = this.listItems[index];
+    this.input = this.filteredOptions[index];
     this.setSelectedOption(this.input);
   }
 
@@ -101,27 +93,26 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   protected onKeyPress(event: KeyboardEvent): void {
-    if (this.listShown) {
-      switch (event.key) {
-        case 'Escape': {
-          this.clearSelectedItem();
-          this.hideListDisplay();
-          break;
-        }
-        case 'Enter': {
-          this.selectItem(this.selectedIndex);
-          this.hideListDisplay();
-          break;
-        }
+    this.showListDisplay();
+    switch (event.key) {
+      case 'Escape': {
+        this.clearSelectedItem();
+        this.hideListDisplay();
+        break;
+      }
+      case 'Enter': {
+        this.selectItem(this.selectedIndex);
+        this.hideListDisplay();
+        break;
+      }
 
-        case 'ArrowDown': {
-          this.selectNext();
-          break;
-        }
-        case 'ArrowUp': {
-          this.selectPrevious();
-          break;
-        }
+      case 'ArrowDown': {
+        this.selectNext();
+        break;
+      }
+      case 'ArrowUp': {
+        this.selectPrevious();
+        break;
       }
     }
   }
@@ -134,20 +125,20 @@ export class ComboboxComponent<T> implements OnInit {
   }
 
   private selectNext(): void {
-    if (this.listItems.length <= 0) {
+    if (this.filteredOptions.length <= 0) {
       return;
     }
-    this.selectItemInListDisplay((this.selectedIndex + 1) % this.listItems.length);
+    this.selectItemInListDisplay((this.selectedIndex + 1) % this.filteredOptions.length);
   }
 
   private selectPrevious(): void {
-    if (this.listItems.length <= 0) {
+    if (this.filteredOptions.length <= 0) {
       return;
     }
     if (this.selectedIndex === -1) this.selectedIndex = 0;
     if (this.selectedIndex <= 0) {
-      this.selectedIndex = this.listItems.length + this.selectedIndex;
+      this.selectedIndex = this.filteredOptions.length + this.selectedIndex;
     }
-    this.selectItemInListDisplay((this.selectedIndex - 1) % this.listItems.length);
+    this.selectItemInListDisplay((this.selectedIndex - 1) % this.filteredOptions.length);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -1,4 +1,4 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -11,7 +11,6 @@ export type Option = {
   selector: 'app-combobox',
   standalone: true,
   imports: [NgClass, FormsModule, NgIf, NgForOf],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './combobox.component.html',
   styleUrl: './combobox.component.scss',
 })
@@ -19,10 +18,13 @@ export class ComboboxComponent implements OnInit {
   @Input({ required: true }) options!: Option[];
   @Input() required: boolean = true;
   @Input() name: string = '';
+  @Input() id: string = '';
+  @Input() disabled: boolean = false;
   @Input() selectedOption?: string;
   @Output() selectedOptionChange: EventEmitter<string> = new EventEmitter<string>();
 
-  @ViewChild('comboBoxOptions') comboBoxOptions!: HTMLElement;
+  @ViewChild('comboboxOptions') comboboxOptionsRef!: ElementRef;
+  @ViewChild('comboboxDropdownIcon') comboboxDropdownIcon!: ElementRef;
 
   protected input: string = '';
   protected filteredOptions: Option[] = [];
@@ -41,6 +43,7 @@ export class ComboboxComponent implements OnInit {
   protected showListDisplay(): void {
     if (this.listShown) return;
     this.listShown = true;
+    this.comboboxDropdownIcon.nativeElement.classList.add('combobox__dropdown-icon--active');
     this.filterListItems();
     this.highlightItemMatchingInput();
   }
@@ -51,6 +54,7 @@ export class ComboboxComponent implements OnInit {
 
   hideListDisplay(): void {
     if (!this.listShown) return;
+    this.comboboxDropdownIcon.nativeElement.classList.remove('combobox__dropdown-icon--active');
     this.listShown = false;
     this.validateInput();
   }
@@ -76,7 +80,9 @@ export class ComboboxComponent implements OnInit {
 
   private selectItemInListDisplay(index: number): void {
     this.selectedIndex = index;
-    document.querySelectorAll('.list-item')[this.selectedIndex]?.scrollIntoView();
+    this.comboboxOptionsRef.nativeElement
+      .querySelectorAll('.combobox__list-item')
+      [this.selectedIndex]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
 
   protected clickItem(index: number): void {

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -87,6 +87,7 @@ export class ComboboxComponent implements OnInit, OnChanges {
   }
 
   private highlightItemMatchingInput(): void {
+    if (!this.listShown) return;
     const matchingItem = this.filteredOptions.findIndex(({ label }) => label === this.input);
     if (matchingItem >= 0) {
       this.selectItemInListDisplay(matchingItem);
@@ -97,7 +98,7 @@ export class ComboboxComponent implements OnInit, OnChanges {
 
   private selectItemInListDisplay(index: number): void {
     this.selectedIndex = index;
-    this.comboboxOptionsRef.nativeElement
+    this.comboboxOptionsRef?.nativeElement
       .querySelectorAll('.combobox__list-item')
       [this.selectedIndex]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -2,6 +2,11 @@ import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, OnInit, Output,
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
+export type Option = {
+  label: string;
+  description?: string;
+};
+
 @Component({
   selector: 'app-combobox',
   standalone: true,
@@ -11,7 +16,7 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './combobox.component.scss',
 })
 export class ComboboxComponent implements OnInit {
-  @Input({ required: true }) options!: string[];
+  @Input({ required: true }) options!: Option[];
   @Input() required: boolean = true;
   @Input() name: string = '';
   @Input() selectedOption?: string;
@@ -20,7 +25,7 @@ export class ComboboxComponent implements OnInit {
   @ViewChild('comboBoxOptions') comboBoxOptions!: HTMLElement;
 
   protected input: string = '';
-  protected filteredOptions: string[] = [];
+  protected filteredOptions: Option[] = [];
   protected selectedIndex: number = -1;
   protected listShown: boolean = false;
   protected showError: boolean = false;
@@ -41,7 +46,7 @@ export class ComboboxComponent implements OnInit {
   }
 
   private filterListItems(): void {
-    this.filteredOptions = this.options.filter((item) => item.toLowerCase().startsWith(this.input.toLowerCase()));
+    this.filteredOptions = this.options.filter(({ label }) => label.toLowerCase().startsWith(this.input.toLowerCase()));
   }
 
   hideListDisplay(): void {
@@ -51,7 +56,7 @@ export class ComboboxComponent implements OnInit {
   }
 
   private validateInput(): void {
-    this.showError = !!(this.input || this.required) && !this.options.includes(this.input);
+    this.showError = !!(this.input || this.required) && !this.options.some(({ label }) => label === this.input);
     if (this.showError) this.resetListItems();
   }
 
@@ -61,8 +66,7 @@ export class ComboboxComponent implements OnInit {
   }
 
   private highlightItemMatchingInput(): void {
-    if (!this.input) return;
-    const matchingItem = this.filteredOptions.indexOf(this.input);
+    const matchingItem = this.filteredOptions.findIndex(({ label }) => label === this.input);
     if (matchingItem >= 0) {
       this.selectItemInListDisplay(matchingItem);
     } else {
@@ -81,7 +85,7 @@ export class ComboboxComponent implements OnInit {
   }
 
   private selectItem(index: number): void {
-    this.input = this.filteredOptions[index];
+    this.input = this.filteredOptions[index].label;
     this.setSelectedOption(this.input);
   }
 

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -12,8 +12,6 @@ import { FormsModule } from '@angular/forms';
 })
 export class ComboboxComponent implements OnInit {
   @Input({ required: true }) options!: string[];
-  @Input() comboBoxClass: string = 'form-control';
-  @Input() comboBoxOptionsClass: string = 'combobox-options';
   @Input() required: boolean = true;
   @Input() name: string = '';
   @Input() selectedOption?: string;

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -1,0 +1,153 @@
+import { Component, CUSTOM_ELEMENTS_SCHEMA, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { NgClass, NgForOf, NgIf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+type Options<T> = Record<string, T>;
+
+@Component({
+  selector: 'app-combobox',
+  standalone: true,
+  imports: [NgClass, FormsModule, NgIf, NgForOf],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  templateUrl: './combobox.component.html',
+  styleUrl: './combobox.component.scss',
+})
+export class ComboboxComponent<T> implements OnInit {
+  @Input({ required: true }) options!: Options<T>;
+  @Input() comboBoxClass: string = 'form-control';
+  @Input() comboBoxOptionsClass: string = 'combobox-options';
+  @Input() required: boolean = true;
+  @Input() name: string = '';
+  @Input() selectedOption: string = '';
+  @Output() selectedOptionChange: EventEmitter<string> = new EventEmitter<string>();
+
+  @ViewChild('comboBoxOptions') comboBoxOptions!: HTMLElement;
+
+  protected input: string = '';
+  protected listItems: string[] = [];
+  protected selectedIndex: number = -1;
+  protected listShown: boolean = false;
+  protected showError: boolean = false;
+
+  ngOnInit(): void {
+    this.resetListItems();
+  }
+
+  private resetListItems(): void {
+    this.listItems = Object.keys(this.options);
+  }
+
+  protected showListDisplay(): void {
+    if (this.listShown) return;
+    this.listShown = true;
+    this.filterListItems();
+    this.highlightItemMatchingInput();
+  }
+
+  private filterListItems(): void {
+    this.listItems = Object.keys(this.options).filter((item) =>
+      item.toLowerCase().startsWith(this.input.toLowerCase()),
+    );
+  }
+
+  protected hideListDisplayWithDelay(): void {
+    setTimeout(() => this.hideListDisplay(), 100);
+  }
+
+  hideListDisplay(): void {
+    if (!this.listShown) return;
+    this.listShown = false;
+    this.validateInput();
+  }
+
+  private validateInput(): void {
+    this.showError = !!(this.input || this.required) && !Object.keys(this.options).includes(this.input);
+    if (this.showError) this.resetListItems();
+  }
+
+  protected onUpdateInput(): void {
+    this.filterListItems();
+    this.highlightItemMatchingInput();
+  }
+
+  private highlightItemMatchingInput(): void {
+    if (!this.input) return;
+    const matchingItem = this.listItems.indexOf(this.input);
+    if (matchingItem >= 0) {
+      this.selectItemInListDisplay(matchingItem);
+    } else {
+      this.selectedIndex = -1;
+    }
+  }
+
+  private selectItemInListDisplay(index: number): void {
+    this.selectedIndex = index;
+    document.querySelectorAll('.list-item')[this.selectedIndex]?.scrollIntoView();
+  }
+
+  protected clickItem(index: number): void {
+    this.selectItem(index);
+    this.hideListDisplay();
+  }
+
+  private selectItem(index: number): void {
+    this.input = this.listItems[index];
+    this.setSelectedOption(this.input);
+  }
+
+  private setSelectedOption(option: string): void {
+    this.selectedOption = option;
+    this.selectedOptionChange.emit(this.selectedOption);
+  }
+
+  protected onKeyPress(event: KeyboardEvent): void {
+    if (this.listShown) {
+      switch (event.key) {
+        case 'Escape': {
+          this.clearSelectedItem();
+          this.hideListDisplay();
+          break;
+        }
+        case 'Enter': {
+          this.selectItem(this.selectedIndex);
+          this.hideListDisplay();
+          break;
+        }
+
+        case 'ArrowDown': {
+          this.selectNext();
+          break;
+        }
+        case 'ArrowUp': {
+          this.selectPrevious();
+          break;
+        }
+      }
+    }
+  }
+
+  protected clearSelectedItem(): void {
+    this.selectedIndex = -1;
+    this.input = '';
+    this.setSelectedOption('');
+    this.hideListDisplay();
+  }
+
+  private selectNext(): void {
+    if (this.listItems.length <= 0) {
+      return;
+    }
+    this.selectItemInListDisplay((this.selectedIndex + 1) % this.listItems.length);
+  }
+
+  private selectPrevious(): void {
+    if (this.listItems.length <= 0) {
+      return;
+    }
+    if (this.selectedIndex === -1) this.selectedIndex = 0;
+    if (this.selectedIndex <= 0) {
+      this.selectedIndex = this.listItems.length + this.selectedIndex;
+    }
+    this.selectItemInListDisplay((this.selectedIndex - 1) % this.listItems.length);
+  }
+}

--- a/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/combobox/combobox.component.ts
@@ -109,6 +109,7 @@ export class ComboboxComponent implements OnInit, OnChanges {
   }
 
   private selectItem(index: number): void {
+    if (index < 0 || index >= this.filteredOptions.length) return;
     this.input = this.filteredOptions[index].label;
     this.setSelectedOption(this.input);
   }

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.html
@@ -16,18 +16,11 @@
             <div class="row form-group">
               <label class="col-sm-3 control-label">Configuration</label>
               <div class="col-sm-9">
-                <input
-                  list="configurations"
-                  autocomplete="off"
-                  [(ngModel)]="selectedConfiguration"
+                <app-combobox
                   name="configuration"
-                  class="form-control"
-                />
-                <datalist id="configurations">
-                  <option *ngFor="let config of configurations" [value]="config.name">
-                    {{ config.name }}
-                  </option>
-                </datalist>
+                  [options]="configurations"
+                  [(selectedOption)]="selectedConfiguration"
+                ></app-combobox>
               </div>
             </div>
             <div class="form-group">

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
@@ -1,16 +1,17 @@
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MonitorsService } from '../monitors.service';
-import { AppService, Configuration } from '../../../app.service';
+import { AppService } from '../../../app.service';
 import { FormsModule } from '@angular/forms';
 import { NgForOf } from '@angular/common';
 import { combineLatestWith, Subscription } from 'rxjs';
 import { LaddaModule } from 'angular2-ladda';
+import { ComboboxComponent, Option } from '../../../components/combobox/combobox.component';
 
 @Component({
   selector: 'app-monitors-new',
   standalone: true,
-  imports: [RouterLink, FormsModule, NgForOf, LaddaModule],
+  imports: [RouterLink, FormsModule, NgForOf, LaddaModule, ComboboxComponent],
   templateUrl: './monitors-new.component.html',
   styleUrl: './monitors-new.component.scss',
 })
@@ -21,7 +22,7 @@ export class MonitorsNewComponent implements OnInit, OnDestroy {
 
   private appService: AppService = inject(AppService);
 
-  protected configurations: Configuration[] = this.appService.configurations;
+  protected configurations: Option[] = [];
 
   private monitorsService: MonitorsService = inject(MonitorsService);
   private router: Router = inject(Router);
@@ -29,8 +30,9 @@ export class MonitorsNewComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
 
   ngOnInit(): void {
+    this.setConfigurations();
     const configurationsSubscription = this.appService.configurations$.subscribe((configurations) => {
-      this.configurations = configurations;
+      this.setConfigurations();
     });
     this.subscriptions.add(configurationsSubscription);
 
@@ -43,6 +45,10 @@ export class MonitorsNewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  private setConfigurations(): void {
+    this.configurations = this.appService.configurations.map((config) => ({ label: config.name }));
   }
 
   submit(): void {

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -15,7 +15,7 @@
               <div class="col-sm-9">
                 <app-combobox
                   name="configuration"
-                  [options]="configurationNames"
+                  [options]="configurationOptions"
                   [(selectedOption)]="selectedConfiguration"
                   data-cy-test-pipeline="selectConfig"
                   (selectedOptionChange)="form.adapter = ''"

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -18,32 +18,20 @@
                   [options]="configurationOptions"
                   [(selectedOption)]="selectedConfiguration"
                   data-cy-test-pipeline="selectConfig"
-                  (selectedOptionChange)="form.adapter = ''"
+                  (selectedOptionChange)="setSelectedConfiguration()"
                 ></app-combobox>
               </div>
             </div>
             <div class="row form-group">
               <label class="col-sm-3 control-label label-height-30">Select an adapter</label>
               <div class="col-sm-9">
-                <input
-                  list="adapters"
-                  autocomplete="off"
+                <app-combobox
+                  name="adapters"
+                  [options]="adapterOptions"
+                  [(selectedOption)]="form.adapter"
                   data-cy-test-pipeline="selectAdapter"
-                  [(ngModel)]="form.adapter"
                   [disabled]="selectedConfiguration === ''"
-                  class="form-control"
-                  name="adapter"
-                />
-                <datalist id="adapters">
-                  <option
-                    *ngFor="let adapter of adapters | configurationFilter: selectedConfiguration | keyvalue"
-                    [value]="adapter.value.name"
-                  >
-                    {{
-                      adapter.value.name + (adapter.value.description !== null ? ' - ' + adapter.value.description : '')
-                    }}
-                  </option>
-                </datalist>
+                ></app-combobox>
               </div>
             </div>
             <div

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -13,20 +13,13 @@
             <div class="row form-group">
               <label class="col-sm-3 control-label">Configuration</label>
               <div class="col-sm-9">
-                <input
-                  list="configurations"
-                  autocomplete="off"
-                  data-cy-test-pipeline="selectConfig"
-                  [(ngModel)]="selectedConfiguration"
-                  (ngModelChange)="form.adapter = ''"
+                <app-combobox
                   name="configuration"
-                  class="form-control"
-                />
-                <datalist id="configurations">
-                  <option *ngFor="let config of configurations" [value]="config.name">
-                    {{ config.name }}
-                  </option>
-                </datalist>
+                  [options]="configurations"
+                  [(selectedOption)]="selectedConfiguration"
+                  data-cy-test-pipeline="selectConfig"
+                  (selectedOptionChange)="form.adapter = ''"
+                ></app-combobox>
               </div>
             </div>
             <div class="row form-group">

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -15,7 +15,7 @@
               <div class="col-sm-9">
                 <app-combobox
                   name="configuration"
-                  [options]="configurations"
+                  [options]="configurationNames"
                   [(selectedOption)]="selectedConfiguration"
                   data-cy-test-pipeline="selectConfig"
                   (selectedOptionChange)="form.adapter = ''"

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -27,7 +27,8 @@ type PipelineResult = {
 })
 export class TestPipelineComponent implements OnInit, OnDestroy {
   @ViewChild(InputFileUploadComponent) formFile!: InputFileUploadComponent;
-  protected configurations: Record<string, Configuration> = {};
+  protected configurations: Configuration[] = [];
+  protected configurationNames: string[] = [];
   protected adapters: Record<string, Adapter> = {};
   protected state: AlertState[] = [];
   protected selectedConfiguration = '';
@@ -77,9 +78,8 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
   }
 
   private setConfigurations(): void {
-    for (const configuration of this.appService.configurations) {
-      this.configurations[configuration.name] = configuration;
-    }
+    this.configurations = this.appService.configurations;
+    this.configurationNames = this.configurations.map(({ name }) => name);
   }
 
   addNote(type: string, message: string): void {

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -3,6 +3,7 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { Adapter, AppService, Configuration } from 'src/app/app.service';
 import { InputFileUploadComponent } from 'src/app/components/input-file-upload/input-file-upload.component';
 import { Subscription } from 'rxjs';
+import { Option } from '../../components/combobox/combobox.component';
 
 type FormSessionKey = {
   key: string;
@@ -28,7 +29,7 @@ type PipelineResult = {
 export class TestPipelineComponent implements OnInit, OnDestroy {
   @ViewChild(InputFileUploadComponent) formFile!: InputFileUploadComponent;
   protected configurations: Configuration[] = [];
-  protected configurationNames: string[] = [];
+  protected configurationOptions: Option[] = [];
   protected adapters: Record<string, Adapter> = {};
   protected state: AlertState[] = [];
   protected selectedConfiguration = '';
@@ -79,7 +80,10 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
 
   private setConfigurations(): void {
     this.configurations = this.appService.configurations;
-    this.configurationNames = this.configurations.map(({ name }) => name);
+    this.configurationOptions = this.configurations.map((configuration) => ({
+      label: configuration.name,
+      description: configuration.type,
+    }));
   }
 
   addNote(type: string, message: string): void {

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -4,6 +4,7 @@ import { Adapter, AppService, Configuration } from 'src/app/app.service';
 import { InputFileUploadComponent } from 'src/app/components/input-file-upload/input-file-upload.component';
 import { Subscription } from 'rxjs';
 import { Option } from '../../components/combobox/combobox.component';
+import { ConfigurationFilter } from '../../pipes/configuration-filter.pipe';
 
 type FormSessionKey = {
   key: string;
@@ -31,6 +32,7 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
   protected configurations: Configuration[] = [];
   protected configurationOptions: Option[] = [];
   protected adapters: Record<string, Adapter> = {};
+  protected adapterOptions: Option[] = [];
   protected state: AlertState[] = [];
   protected selectedConfiguration = '';
   protected processingMessage = false;
@@ -67,9 +69,9 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
     });
     this.subscriptions.add(configurationsSubscription);
 
-    this.adapters = this.appService.adapters;
+    this.setAdapters();
     const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.adapters = this.appService.adapters;
+      this.setAdapters();
     });
     this.subscriptions.add(adaptersSubscription);
   }
@@ -82,7 +84,18 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
     this.configurations = this.appService.configurations;
     this.configurationOptions = this.configurations.map((configuration) => ({
       label: configuration.name,
-      description: configuration.type,
+    }));
+  }
+
+  private setAdapters(): void {
+    this.adapters = this.appService.adapters;
+  }
+
+  private setAdapterOptions(selectedConfiguration: string): void {
+    const filteredAdapters = ConfigurationFilter(this.adapters, selectedConfiguration);
+    this.adapterOptions = Object.entries(filteredAdapters).map(([, adapter]) => ({
+      label: adapter.name,
+      description: adapter.description ?? '',
     }));
   }
 
@@ -175,5 +188,10 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
         this.processingMessage = false;
       },
     });
+  }
+
+  protected setSelectedConfiguration(): void {
+    this.form.adapter = '';
+    this.setAdapterOptions(this.selectedConfiguration);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -27,7 +27,7 @@ type PipelineResult = {
 })
 export class TestPipelineComponent implements OnInit, OnDestroy {
   @ViewChild(InputFileUploadComponent) formFile!: InputFileUploadComponent;
-  protected configurations: Configuration[] = [];
+  protected configurations: Record<string, Configuration> = {};
   protected adapters: Record<string, Adapter> = {};
   protected state: AlertState[] = [];
   protected selectedConfiguration = '';
@@ -59,9 +59,9 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.configurations = this.appService.configurations;
+    this.setConfigurations();
     const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
+      this.setConfigurations();
     });
     this.subscriptions.add(configurationsSubscription);
 
@@ -74,6 +74,12 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
+  }
+
+  private setConfigurations(): void {
+    for (const configuration of this.appService.configurations) {
+      this.configurations[configuration.name] = configuration;
+    }
   }
 
   addNote(type: string, message: string): void {

--- a/console/frontend/src/main/frontend/src/app/views/test-service-listener/test-service-listener.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-service-listener/test-service-listener.component.html
@@ -11,18 +11,7 @@
             <div class="row form-group">
               <label class="col-sm-3 control-label label-height-30">Select a service</label>
               <div class="col-sm-9">
-                <input
-                  list="services"
-                  autocomplete="off"
-                  class="form-control"
-                  name="service"
-                  [(ngModel)]="form.service"
-                />
-                <datalist id="services">
-                  <option *ngFor="let service of services">
-                    {{ service }}
-                  </option>
-                </datalist>
+                <app-combobox name="service" [options]="services" [(selectedOption)]="form.service"></app-combobox>
               </div>
             </div>
             <div class="row form-group">

--- a/console/frontend/src/main/frontend/src/app/views/test-service-listener/test-service-listener.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-service-listener/test-service-listener.component.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { AppService } from 'src/app/app.service';
+import { Option } from '../../components/combobox/combobox.component';
 
 type AlertState = {
   type: string;
@@ -19,7 +20,7 @@ type ServiceListenerResult = {
 })
 export class TestServiceListenerComponent implements OnInit {
   protected state: AlertState[] = [];
-  protected services: string[] = [];
+  protected services: Option[] = [];
   protected processingMessage = false;
   protected result = '';
 
@@ -50,7 +51,7 @@ export class TestServiceListenerComponent implements OnInit {
         services: string[];
       }>(`${this.appService.absoluteApiPath}test-servicelistener`)
       .subscribe((data) => {
-        this.services = data.services;
+        this.services = data.services.map((service) => ({ label: service }));
       });
   }
 


### PR DESCRIPTION
This PR adds a "combobox" component. It acts as a dropdown with autocomplete. 
It can be used with just the keyboard by typing using the keys and pressing enter (or by filling in the whole value by hand and tabbing away) 
It can also be used with the mouse only, by clicking on the input and scrolling + clicking on the preferred option. 
A combination of this techniques is also possible.
Closes #5893