### PR TITLE
Force max Java version because of Lombok support

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '17', '21' ]
+        java: [ '17', '21', '22', '23' ]
 
     steps:
     - name: Checkout repository

--- a/pom.xml
+++ b/pom.xml
@@ -1185,7 +1185,7 @@
 								</rules>
 								<rules>
 									<requireJavaVersion>
-										<version>[17,22)</version>
+										<version>[17,24)</version>
 									</requireJavaVersion>
 								</rules>
 							</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1182,6 +1182,11 @@
 										<message>Dont use com.sun but glassfish instead</message>
 									</bannedDependencies>
 								</rules>
+								<rules>
+									<requireJavaVersion>
+										<version>[17,21]</version>
+									</requireJavaVersion>
+								</rules>
 							</configuration>
 						</execution>
 						<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.proc>full</maven.compiler.proc>
 		<log4j2.version>2.24.3</log4j2.version>
 
 		<sonar.organization>frank-framework</sonar.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -1184,7 +1184,7 @@
 								</rules>
 								<rules>
 									<requireJavaVersion>
-										<version>[17,21]</version>
+										<version>[17,22)</version>
 									</requireJavaVersion>
 								</rules>
 							</configuration>


### PR DESCRIPTION
They apparently released a new version but somehow this doesn't seem to be working properly yet..
https://github.com/projectlombok/lombok/issues/3722

For now it's probably best to just limit the version to 21 until Java 24 has been released (with full Lombok support)