### PR TITLE
Minor cleanup and enable skip-locked for H2 databases

### DIFF
--- a/core/src/test/java/org/frankframework/jdbc/dbms/DbmsSupportTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/dbms/DbmsSupportTest.java
@@ -690,12 +690,13 @@ public class DbmsSupportTest {
 		}
 	}
 
+	/**
+	 * We expect this test to run against a MariaDB version 10.6 or later and so it should support "skip locked" when running these tests.
+	 * Also, this is a very strange test. We should run some queries and verify the functionality instead of relying on this silly boolean.
+	 */
 	@DatabaseTest
 	public void testSkipLockedSupportPresent() {
-		// We expect this test to run against a MariaDB version 10.6 or later and so it should support "skip locked" when running these tests
-		boolean expectSkipLockedSupport = dbmsSupport.getDbms() != Dbms.H2;
-
-		assertEquals(expectSkipLockedSupport, dbmsSupport.hasSkipLockedFunctionality());
+		assertTrue(dbmsSupport.hasSkipLockedFunctionality());
 	}
 
 	protected PreparedStatement executeTranslatedQuery(Connection connection, String query, QueryType queryType) throws JdbcException, SQLException {

--- a/dbms/src/main/java/org/frankframework/dbms/Dbms.java
+++ b/dbms/src/main/java/org/frankframework/dbms/Dbms.java
@@ -55,11 +55,14 @@ public enum Dbms {
 				log.debug("Setting databasetype to MARIADB (using MariaDB driver)");
 			}
 			return new MariaDbDbmsSupport(productVersion);
+		} else if (product.equals("H2")) {
+			return new H2DbmsSupport(productVersion);
 		}
 		if (product.startsWith("DB2/")) {
 			log.debug("Setting databasetype to DB2 for product [{}]", product);
 			return new Db2DbmsSupport();
 		}
+
 		for (Dbms dbms : values()) {
 			if (dbms.getProductName().equals(product)) {
 				log.debug("Setting databasetype to [{}]", dbms);

--- a/dbms/src/main/java/org/frankframework/dbms/H2DbmsSupport.java
+++ b/dbms/src/main/java/org/frankframework/dbms/H2DbmsSupport.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015, 2019 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2015, 2019 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+
+import org.frankframework.util.StringUtil;
 
 
 /**
@@ -33,6 +36,37 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class H2DbmsSupport extends GenericDbmsSupport {
 
+	private final boolean dbmsHasSkipLockedFunctionality;
+
+	public H2DbmsSupport() {
+		throw new IllegalStateException("H2DbmsSupport should be instantiated with product-version to determine supported featureset. Calling this constructor is a code-bug.");
+	}
+
+	public H2DbmsSupport(String productVersion) {
+		dbmsHasSkipLockedFunctionality = determineSkipLockedCapability(productVersion);
+	}
+
+	// Example output `2.3.232 (2024-08-11)`
+	private boolean determineSkipLockedCapability(String productVersion) {
+		if (StringUtils.isEmpty(productVersion)) {
+			log.debug("unable to automatically determine H2 product version none provided");
+			return false;
+		}
+
+		List<String> parts = StringUtil.split(productVersion, "(");
+		if (parts.size() == 2 && parts.get(1).contains(")")) {
+			String version = parts.get(0).trim();
+			DefaultArtifactVersion thisVersion = new DefaultArtifactVersion(version);
+			DefaultArtifactVersion targetVersion = new DefaultArtifactVersion("2.2.220");
+			boolean result = thisVersion.compareTo(targetVersion) >= 0;
+			log.debug("based on H2 productversion [{}] dbms hasSkipLockedFunctionality [{}]", version, result);
+			return result;
+		}
+
+		log.debug("unable to automatically determine H2 product version from [{}]", productVersion);
+		return false;
+	}
+
 	@Override
 	public Dbms getDbms() {
 		return Dbms.H2;
@@ -40,7 +74,7 @@ public class H2DbmsSupport extends GenericDbmsSupport {
 
 	@Override
 	public boolean hasSkipLockedFunctionality() {
-		return true;
+		return dbmsHasSkipLockedFunctionality;
 	}
 
 	// See OracleDbmsSupport

--- a/dbms/src/test/java/org/frankframework/dbms/H2DbmsSupportTest.java
+++ b/dbms/src/test/java/org/frankframework/dbms/H2DbmsSupportTest.java
@@ -12,7 +12,7 @@ public class H2DbmsSupportTest {
 	public void testConvertQueryOracleToH2() throws JdbcException, SQLException {
 		String query = "DROP SEQUENCE SEQ_IBISSTORE";
 		String expected = "DROP SEQUENCE IF EXISTS SEQ_IBISSTORE";
-		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "Oracle");
+		String translatedQuery = (new H2DbmsSupport(null)).convertQuery(query, "Oracle");
 		assertEquals(expected, translatedQuery);
 	}
 
@@ -20,7 +20,7 @@ public class H2DbmsSupportTest {
 	public void testConvertQueryH2ToH2() throws JdbcException, SQLException {
 		String query = "SELECT COUNT(*) FROM IBISSTORE";
 		String expected = query;
-		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "H2");
+		String translatedQuery = (new H2DbmsSupport(null)).convertQuery(query, "H2");
 		assertEquals(expected, translatedQuery);
 	}
 
@@ -28,7 +28,7 @@ public class H2DbmsSupportTest {
 	public void testConvertMultipleQueriesOracleToH2() throws JdbcException, SQLException {
 		String query = "--------\n  --drop--\r\n--------\nDROP SEQUENCE SEQ_IBISSTORE;\nselect count(*) from ibisstore;";
 		String expected = "--------\n  --drop--\r\n--------\nDROP SEQUENCE IF EXISTS SEQ_IBISSTORE;\nselect count(*) from ibisstore;";
-		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "Oracle");
+		String translatedQuery = (new H2DbmsSupport(null)).convertQuery(query, "Oracle");
 		assertEquals(expected, translatedQuery);
 	}
 }

--- a/test/src/main/configurations/MainConfig/ConfigurationExpectedSessionKeys.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationExpectedSessionKeys.xml
@@ -1,4 +1,4 @@
-<module>
+<Module>
 	<Adapter name="Test Expects Session Keys">
 		<Pipeline>
 			<Exits>
@@ -10,7 +10,7 @@
 				<forward name="Sender with Missing Keys" path="Sender With Expected Keys Missing"/>
 			</XmlSwitchPipe>
 			<SenderPipe name="Sender With All Expected Keys">
-				<FrankSender scope="ADAPTER" target="Pipeline with Expected Session Keys">
+				<FrankSender target="Pipeline with Expected Session Keys">
 					<Param name="k1" value="1"/>
 					<Param name="k2" value="2"/>
 				</FrankSender>
@@ -18,7 +18,7 @@
 				<Forward name="success" path="SUCCESS"/>
 			</SenderPipe>
 			<SenderPipe name="Sender With Expected Keys Missing">
-				<FrankSender scope="ADAPTER" target="Pipeline with Expected Session Keys" />
+				<FrankSender target="Pipeline with Expected Session Keys" />
 				<Forward name="exception" path="SUCCESS"/>
 			</SenderPipe>
 		</Pipeline>
@@ -29,4 +29,4 @@
 			<EchoPipe name="echo"/>
 		</Pipeline>
 	</Adapter>
-</module>
+</Module>

--- a/test/src/main/configurations/MainConfig/ConfigurationFrankSender.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationFrankSender.xml
@@ -11,7 +11,7 @@
 			<XmlSwitchPipe name="select sender to test"/>
 
 			<SenderPipe name="CallAdapter1">
-				<FrankSender scope="ADAPTER" target="SubAdapter1" returnedSessionKeys="resultKey"/>
+				<FrankSender target="SubAdapter1" returnedSessionKeys="resultKey"/>
 				<Forward name="success" path="Get Result From Session"/>
 			</SenderPipe>
 			<SenderPipe name="CallAdapter2">
@@ -22,7 +22,7 @@
 				<Forward name="success" path="Get Result From Session"/>
 			</SenderPipe>
 			<SenderPipe name="CallAdapterWithParam">
-				<FrankSender scope="ADAPTER" target="MainConfig/SubAdapter3" returnedSessionKeys="resultKey">
+				<FrankSender target="MainConfig/SubAdapter3" returnedSessionKeys="resultKey">
 					<Param name="input1" value="fromInput"/>
 				</FrankSender>
 				<Forward name="success" path="Get Result From Session"/>

--- a/test/src/main/resources/Configuration.xml
+++ b/test/src/main/resources/Configuration.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE configuration [
 ]>
-<configuration name="Ibis4Test">
+<configuration>
 	<jmsRealms>
 		<jmsRealm realmName="jdbc" datasourceName="${jdbc.datasource.default}"/>
 		<jmsRealm realmName="qcf" queueConnectionFactoryName="${jms.connectionfactory.qcf}" active="${active.jms}"/>


### PR DESCRIPTION
`ON UPDATE SKIP LOCKED` is supported since H2 2.2.220.