### PR TITLE
Remove some overloads of the `configure()` method

### DIFF
--- a/core/src/main/java/org/frankframework/core/IConfigurable.java
+++ b/core/src/main/java/org/frankframework/core/IConfigurable.java
@@ -26,7 +26,7 @@ public interface IConfigurable {
 	/**
 	 * Configure this component.
 	 * <p>
-	 * <code>configure()</code> is called once at startup of the framework in the configure method of the owner of this sender.
+	 * <code>configure()</code> is called once at startup of the framework in the configure method of the owner of this {@link IConfigurable}.
 	 * Purpose of this method is to check whether the static configuration of the object is correct.
 	 * As much as possible class-instantiating should take place in the <code>configure()</code>, to improve performance.
 	 * </p>

--- a/core/src/main/java/org/frankframework/core/IConfigurable.java
+++ b/core/src/main/java/org/frankframework/core/IConfigurable.java
@@ -25,6 +25,11 @@ public interface IConfigurable {
 
 	/**
 	 * Configure this component.
+	 * <p>
+	 * <code>configure()</code> is called once at startup of the framework in the configure method of the owner of this sender.
+	 * Purpose of this method is to check whether the static configuration of the object is correct.
+	 * As much as possible class-instantiating should take place in the <code>configure()</code>, to improve performance.
+	 * </p>
 	 * <p>In the case of a container, this will propagate the configure signal to all
 	 * components that apply.</p>
 	 * @throws ConfigurationException in case it was not able to configure the component.

--- a/core/src/main/java/org/frankframework/core/IListener.java
+++ b/core/src/main/java/org/frankframework/core/IListener.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import jakarta.annotation.Nonnull;
 
-import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.doc.EnterpriseIntegrationPattern;
 import org.frankframework.doc.EnterpriseIntegrationPattern.Type;
 import org.frankframework.doc.FrankDocGroup;
@@ -39,17 +38,8 @@ import org.frankframework.stream.Message;
 public interface IListener<M> extends IConfigurable, FrankElement, NameAware {
 
 	/**
-	 * <code>configure()</code> is called once at startup of the framework in the <code>configure()</code> method
-	 * of the owner of this listener.
-	 * Purpose of this method is to reduce creating connections to databases etc. in the {@link IPullingListener#getRawMessage(Map)} method.
-	 * As much as possible class-instantiating should take place in the <code>configure()</code> or {@link #start()} method, to improve performance.
-	 */
-	@Override
-	void configure() throws ConfigurationException;
-
-	/**
 	 * Prepares the listener for receiving messages.
-	 * <code>open()</code> is called once each time the listener is started.
+	 * <code>start()</code> is called once each time the listener is started.
 	 */
 	void start();
 

--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -42,18 +42,6 @@ public interface IPipe extends IConfigurable, IForwardTarget, FrankElement, Name
 	String MESSAGE_SIZE_MONITORING_EVENT = "Pipe Message Size Exceeding";
 
 	/**
-	 * <code>configure()</code> is called once after the {@link PipeLine} is registered
-	 * at the {@link Adapter}. Purpose of this method is to reduce
-	 * creating connections to databases etc. in the {@link #doPipe(Message, PipeLineSession) doPipe()} method.
-	 * As much as possible class-instantiating should take place in the
-	 * <code>configure()</code> method, to improve performance.
-	 * 
-	 * {@inheritDoc}
-	 */
-	@Override
-	void configure() throws ConfigurationException;
-
-	/**
 	 * This is where the action takes place. Pipes may only throw a PipeRunException,
 	 * to be handled by the caller of this object.
 	 * Implementations must either consume the message, or pass it on to the next Pipe in the PipeRunResult.

--- a/core/src/main/java/org/frankframework/core/ISender.java
+++ b/core/src/main/java/org/frankframework/core/ISender.java
@@ -19,7 +19,6 @@ import jakarta.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.doc.EnterpriseIntegrationPattern;
 import org.frankframework.doc.FrankDocGroup;
 import org.frankframework.doc.FrankDocGroupValue;
@@ -33,14 +32,6 @@ import org.frankframework.stream.Message;
 @FrankDocGroup(FrankDocGroupValue.SENDER)
 @EnterpriseIntegrationPattern(EnterpriseIntegrationPattern.Type.ENDPOINT)
 public interface ISender extends IConfigurable, FrankElement, NameAware {
-
-	/**
-	 * <code>configure()</code> is called once at startup of the framework in the configure method of the owner of this sender.
-	 * Purpose of this method is to check whether the static configuration of the sender is correct.
-	 * As much as possible class-instantiating should take place in the <code>configure()</code> or <code>open()</code> method, to improve performance.
-	 */
-	@Override
-	void configure() throws ConfigurationException;
 
 	/**
 	 * This method will be called to start the sender. After this method is called the sendMessage method may be called.


### PR DESCRIPTION
I'm not sure their added JavaDoc really added that much and this cleans up the interfaces a bit.