### PR TITLE
Copy fix from 7.9, with some minor changes

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -143,9 +143,8 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 		} else if (keysToCopy == null || "*".equals(keysToCopy)) { // if keys are not set explicitly ...
 			to.putAll(this);                                      // ... all keys will be copied
 		}
-		Set<AutoCloseable> closeablesInDestination = to.entrySet().stream()
-				.filter(entry -> shouldCloseSessionResource(entry.getKey(), entry.getValue()))
-				.map(Entry::getValue)
+		Set<AutoCloseable> closeablesInDestination = to.values().stream()
+				.filter(AutoCloseable.class::isInstance)
 				.map(AutoCloseable.class::cast)
 				.collect(Collectors.toSet());
 		if (to instanceof PipeLineSession toSession) {
@@ -169,8 +168,8 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	}
 
 	private static boolean shouldCloseSessionResource(final String key, final Object value) {
-		return value instanceof AutoCloseable &&
-			!key.startsWith(SYSTEM_MANAGED_RESOURCE_PREFIX);
+		return (value instanceof AutoCloseable && !key.startsWith(SYSTEM_MANAGED_RESOURCE_PREFIX)) &&
+				!(value instanceof Message message && message.isRequestOfType(String.class));
 	}
 
 	@Override

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -159,7 +159,7 @@ public class InputOutputPipeProcessorTest {
 		// Act & Assert that closing the session closes the input message
 		session.close();
 		assertTrue(input.isNull(), "Input Message should be closed");
-		assertTrue(prr1.getResult().isNull(), "Input Message of pipe2 should be closed");
+		assertFalse(prr1.getResult().isNull(), "Input Message of pipe2 should not be closed, because it is a byte[]");
 	}
 
 	private void testRestoreMovedElement(Object sessionVarContents) throws Exception {


### PR DESCRIPTION
Fix for ballooning PipeLineSession only.

Not yet cleaning up the `closeables`, that will be a separate PR.

After some consideration, I decided to put in just the same fix as is in 7.9 with only minor cosmetic changes, and a few small changes to the way it is tested.

Closes #8258 