### PR TITLE
Reduce memory footprint when using iterating pipes and returned sessionkeys (#8528)

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -17,6 +17,8 @@ package org.frankframework.core;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.Temporal;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -143,9 +145,8 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 		} else if (keysToCopy == null || "*".equals(keysToCopy)) { // if keys are not set explicitly ...
 			to.putAll(this);                                      // ... all keys will be copied
 		}
-		Set<AutoCloseable> closeablesInDestination = to.entrySet().stream()
-				.filter(entry -> shouldCloseSessionResource(entry.getKey(), entry.getValue()))
-				.map(Entry::getValue)
+		Set<AutoCloseable> closeablesInDestination = to.values().stream()
+				.filter(AutoCloseable.class::isInstance)
 				.map(AutoCloseable.class::cast)
 				.collect(Collectors.toSet());
 		if (to instanceof PipeLineSession toSession) {
@@ -169,8 +170,37 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	}
 
 	private static boolean shouldCloseSessionResource(final String key, final Object value) {
-		return value instanceof AutoCloseable &&
-			!key.startsWith(SYSTEM_MANAGED_RESOURCE_PREFIX);
+		return value instanceof AutoCloseable autoCloseable &&
+				isNotSystemManagedResource(key) &&
+				isValueToBeClosed(autoCloseable);
+
+	}
+
+	/**
+	 * Check that the AutoCloseable value is of type {@link Message}, and if it is, that it does not contain a scalar or array value.
+	 * Scalar is defined as either {@link String}, {@link Number}, a {@link Date}, {@link Temporal} or {@link Boolean}.
+	 *
+	 * @param value AutoCloseable to check
+	 * @return {@code true} if {@code value} is not a {@link Message}, or if it is a Message with a request that is not a scalar or array type. Returns {@code false} otherwise.
+	 */
+	private static boolean isValueToBeClosed(AutoCloseable value) {
+		if (!(value instanceof Message message)) return true; // Should be closed, but is not a message
+		if (message.isNull()) return false; // Null message doesn't have to be closed
+		return !(message.isRequestOfType(String.class) ||
+				message.isRequestOfType(Number.class) ||
+				message.isRequestOfType(Date.class) ||
+				message.isRequestOfType(Temporal.class) ||
+				message.isRequestOfType(Boolean.class) ||
+				message.asObject().getClass().isArray()); // Arrays we have are mostly byte[] but I think all arrays should count, for simplicity.
+	}
+
+	/**
+	 * Check that key does not indicate the resource for this key should be managed by the system.
+	 * @param key Key to check
+	 * @return {@code true} if the key does not indicate this is not a system managed resource.
+	 */
+	private static boolean isNotSystemManagedResource(String key) {
+		return !key.startsWith(SYSTEM_MANAGED_RESOURCE_PREFIX);
 	}
 
 	@Override
@@ -439,7 +469,9 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	}
 
 	public void scheduleCloseOnSessionExit(AutoCloseable resource, String requester) {
-		closeables.put(resource, ClassUtils.nameOf(resource) +" of "+requester);
+		if (isValueToBeClosed(resource)) {
+			closeables.put(resource, ClassUtils.nameOf(resource) +" of "+requester);
+		}
 	}
 
 	public boolean isScheduledForCloseOnExit(AutoCloseable message) {

--- a/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/org/frankframework/core/PipeLineSessionTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -16,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -29,6 +31,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
 
 /**
  * Lots of bugs tests, focus on getMessage(String)
@@ -259,6 +263,40 @@ public class PipeLineSessionTest {
 		assertEquals(correlationId, session.getCorrelationId());
 	}
 
+	@Test
+	public void testMessageClosing() {
+		// Arrange
+		Message m1 = new Message("123");
+		session.put("key1", m1);
+		Message m2 = Message.asMessage(123);
+		session.put("key2", m2);
+		Message m3 = Message.asMessage(true);
+		session.put("key3", m3);
+		Message m4 = Message.asMessage(new Date());
+		session.put("key4", m4);
+		Message m5 = Message.asMessage(Instant.now());
+		session.put("key5", m5);
+		Message m6 = Message.asMessage(ZonedDateTime.now());
+		session.put("key6", m6);
+		Message m7 = Message.asMessage("123".getBytes());
+		session.put("key7", m7);
+		Message m8 = Message.asMessage(new StringReader("123"));
+		session.put("key8", m8);
+
+		// Act
+		session.close();
+
+		// Assert
+		assertFalse(m1.isClosed());
+		assertFalse(m2.isClosed());
+		assertFalse(m3.isClosed());
+		assertFalse(m4.isClosed());
+		assertFalse(m5.isClosed());
+		assertFalse(m6.isClosed());
+		assertFalse(m7.isClosed());
+		assertTrue(m8.isClosed());
+	}
+
 	/**
 	 * Method: mergeToParentSession(String keys, Map<String,Object> from, Map<String,Object>
 	 * to)
@@ -299,6 +337,75 @@ public class PipeLineSessionTest {
 		assertEquals(from,to);
 	}
 
+	@Test
+	public void testMergeToParentContextMap2() throws Exception {
+		// Arrange
+		PipeLineSession parent = new PipeLineSession();
+		Message originalA = new Message("0");
+		parent.put("a", originalA);
+		Message originalB = new Message("2");
+		parent.put("b", originalB);
+
+		// Act
+		for(int i = 1; i <= 10; i++) {
+			AutoCloseable closeable = mock(AutoCloseable.class);
+			try (PipeLineSession sub = new PipeLineSession()) {
+				sub.put("a", Message.asMessage(parent.getMessage("a").asString()));
+				Message bMessage = Message.asMessage(parent.getMessage("b").asString());
+				sub.put("b", bMessage);
+				sub.put(PipeLineSession.ORIGINAL_MESSAGE_KEY, bMessage);
+
+				sub.scheduleCloseOnSessionExit(closeable, "requester field is useless");
+				sub.scheduleCloseOnSessionExit(closeable, "requester field is useless"); // Just for good measure, add it twice..
+				sub.put("c", closeable); //Store under `c` which we merge later on
+
+				for(int j = 1; j <= 10; j++) {
+
+					AutoCloseable streamMessage = spy(MessageTestUtils.getMessage(MessageType.BINARY));
+					AutoCloseable closeMe = spy(Message.asMessage(""+j));
+					sub.put("d", closeMe);
+					try (PipeLineSession child = new PipeLineSession(sub)) {
+						assertEquals(j, sub.getInteger("d"));
+
+						int valueA = child.getInteger("a") + 1;
+						Message valueAsMessage = Message.asMessage(""+valueA);
+						child.put("a", valueAsMessage); // Should be a string-value Message
+						child.put("b", Message.asMessage(sub.getMessage("b").asString()));
+
+						child.scheduleCloseOnSessionExit(streamMessage, "requester field is useless");
+						child.put("d", streamMessage);
+
+						// Overwrite values
+						child.put("c", i);
+						child.put("d", j);
+
+						child.mergeToParentSession("a,b,c,d", sub);
+					}
+
+					assertEquals(1, sub.getCloseables().size()); // <<< Keeps growing without the change!
+					verify(streamMessage, times(1)).close();
+					assertEquals(j, sub.getInteger("d")); // Only 1 `d`, with the correct value.
+				}
+
+				assertEquals(10, sub.getInteger("a"));
+				assertEquals(10, sub.getInteger("d"));
+
+				sub.mergeToParentSession("b,c", parent);
+			}
+			verify(closeable, times(1)).close();
+
+			assertEquals(i, parent.get("c"));
+		}
+
+
+		// Assert
+		assertEquals(0, parent.getCloseables().size());
+		assertEquals(originalA, parent.get("a"));
+		assertEquals("2", parent.getMessage("b").asString());
+		assertEquals(10, parent.get("c"));
+		assertNull(parent.get("d"));
+	}
+
 	@ParameterizedTest
 	@CsvSource(value = {"*", ","})
 	public void testMergeToParentSessionCopyAllKeys(String keysToCopy) throws Exception {
@@ -306,13 +413,15 @@ public class PipeLineSessionTest {
 		PipeLineSession from = new PipeLineSession();
 		PipeLineSession to = new PipeLineSession();
 		Message message = new Message("a message");
+		Message messageOfCloseable = new Message(new StringReader("a message is closeable"));
 		BufferedReader closeable1 = new BufferedReader(new StringReader("a closeable"));
-		Message closeable2 = new Message("a message is closeable");
+		Message closeable2 = new Message(new StringReader("a message is closeable"));
 		from.put("a", 15);
 		from.put("b", 16);
 		from.put("c", message);
 		from.put("d", closeable1);
 		from.put("__e", closeable2);
+		from.put("f", messageOfCloseable);
 
 		from.scheduleCloseOnSessionExit(message, "test-c");
 
@@ -324,7 +433,8 @@ public class PipeLineSessionTest {
 		// Assert
 		assertEquals(from,to);
 
-		assertTrue(to.getCloseables().containsKey(message));
+		assertFalse(to.getCloseables().containsKey(message));
+		assertTrue(to.getCloseables().containsKey(messageOfCloseable));
 		assertTrue(to.getCloseables().containsKey(closeable1));
 		assertFalse(to.getCloseables().containsKey(closeable2));
 		assertFalse(((Message) to.get("c")).isNull());
@@ -335,8 +445,9 @@ public class PipeLineSessionTest {
 		to.close();
 
 		// Assert
-		assertTrue(((Message) to.get("c")).isNull());
+		assertFalse(((Message) to.get("c")).isNull()); // String message are no longer closed
 		assertFalse(((Message) to.get("__e")).isNull());
+		assertTrue(((Message) to.get("f")).isNull());
 	}
 
 	@Test
@@ -345,8 +456,8 @@ public class PipeLineSessionTest {
 		PipeLineSession from = new PipeLineSession();
 		PipeLineSession to = new PipeLineSession();
 
-		Message message1 = new Message("m1");
-		Message message2 = new Message("m2");
+		Message message1 = new Message(new StringReader("m1")); // Message should contain a closeable not a string, in order to be eligible for closing
+		Message message2 = new Message(new StringReader("m2"));
 
 		String keys = "a,c";
 		from.put("a", 15);
@@ -376,7 +487,9 @@ public class PipeLineSessionTest {
 		assertEquals(15, to.get("a"));
 		assertNull(to.get("c"));
 
+		assertTrue(message1.isClosed());
 		assertTrue(message1.isNull());
+		assertFalse(message2.isClosed());
 		assertEquals("m2", message2.asString());
 	}
 

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -159,7 +159,7 @@ public class InputOutputPipeProcessorTest {
 		// Act & Assert that closing the session closes the input message
 		session.close();
 		assertTrue(input.isNull(), "Input Message should be closed");
-		assertTrue(prr1.getResult().isNull(), "Input Message of pipe2 should be closed");
+		assertFalse(prr1.getResult().isNull(), "Input Message of pipe2 should not be closed, because it is a byte[]");
 	}
 
 	private void testRestoreMovedElement(Object sessionVarContents) throws Exception {


### PR DESCRIPTION

(cherry picked from commit 0af96569f97d2ddeb712357e40a65e1a64c46d96)