### PR TITLE
fix: update queryParamsHandling and replaceUrl

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
@@ -173,7 +173,8 @@ export class MonacoEditorComponent implements AfterViewInit, OnChanges, OnDestro
     this.zone.run(() => {
       this.router.navigate([], {
         fragment: fragment,
-        queryParamsHandling: 'preserve',
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
       });
     });
   }

--- a/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
@@ -17,11 +17,11 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   @Input() showAll: boolean = false;
   @Input() filterIAF_Util: boolean = false;
 
-  private route: ActivatedRoute = inject(ActivatedRoute);
-  private router: Router = inject(Router);
-  private appService: AppService = inject(AppService);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly router: Router = inject(Router);
+  private readonly appService: AppService = inject(AppService);
+  private readonly subscriptions: Subscription = new Subscription();
   private configurationsList: string[] = [];
-  private subscriptions: Subscription = new Subscription();
 
   @Input({ required: true })
   set configurations(configurations: Configuration[]) {
@@ -42,6 +42,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
         return;
       } else if (tab) {
         this.setSelectedTab(tab);
+        this.appService.updateSelectedConfigurationTab(tab);
       } else if (this.showAllTab) {
         this.setSelectedTab(this._allTabName);
       } else if (this.tabsList.length > 0) {
@@ -63,11 +64,12 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
 
   protected override changeTab(tab: string): void {
     this.appService.updateSelectedConfigurationTab(tab);
+    const queryParameters = tab === this._allTabName ? { [this.queryParamName]: null } : { [this.queryParamName]: tab };
     this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: tab === this._allTabName ? { [this.queryParamName]: null } : { [this.queryParamName]: tab },
+      queryParams: queryParameters,
       queryParamsHandling: 'merge',
-      skipLocationChange: true,
+      replaceUrl: true,
     });
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.ts
@@ -84,6 +84,7 @@ export class ConfigurationsShowComponent implements OnInit, OnDestroy {
       },
       queryParamsHandling: 'merge',
       fragment: this.fragment,
+      replaceUrl: true,
     });
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -152,8 +152,8 @@ export class StatusComponent implements OnInit, OnDestroy {
         filterCount += 1;
       }
     }
-    const transitionObject: Record<string, string> = {};
-    if (filterCount < 3) transitionObject['filter'] = filterString.join('+');
+    const transitionObject: Record<string, string | null> = {};
+    transitionObject['filter'] = filterCount < 3 ? filterString.join('+') : null;
     transitionObject['search'] = this.searchText;
 
     const fragment = this.adapterName === '' ? undefined : this.adapterName;
@@ -162,6 +162,7 @@ export class StatusComponent implements OnInit, OnDestroy {
       relativeTo: this.route,
       queryParams: transitionObject,
       queryParamsHandling: 'merge',
+      replaceUrl: true,
       fragment,
     });
   }


### PR DESCRIPTION
Change queryParamsHandling to 'merge' and add replaceUrl option  in multiple components to improve URL management. This ensures  that the application maintains a cleaner URL structure while  navigating between tabs and views. Additionally, refactor  variable declarations to use 'readonly' for better code  clarity and immutability.