### PR TITLE
Ladybug doesn't load in the console 

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<ladybug.version>3.0-20250213.113242</ladybug.version>
+		<ladybug.version>3.0-20241213.172512</ladybug.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Ladybug doesn't load in the frank console after the changes of 7-2/11-2. Tried both versions but had to revert to the version of 25-12-2024 (commit 082a644).

9.0.0 should not be affected