### PR TITLE
Update ladybug version

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<ladybug.version>3.0-20241213.172512</ladybug.version>
+		<ladybug.version>3.0-20250213.113242</ladybug.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
I must've been wrong yesterday, but apparently the built version I used yesterday, wasn't completely up to date. Retested this explicitly and ladybug _is_ loading with this version. 