### PR TITLE
Simplify peeking into message

### DIFF
--- a/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
@@ -48,7 +48,7 @@ public class CisConversionServiceImpl implements CisConversionService {
 	@Override
 	public CisConversionResult convertToPdf(Message message, String filename, ConversionOption conversionOption) {
 
-		CisConversionResult result = null;
+		CisConversionResult result;
 		MimeType mimeType = MessageUtils.computeMimeType(message, filename);
 		if(mimeType == null || "x-tika-msoffice".equals(mimeType.getSubtype())) {
 			// MessageUtils.computeMimeType may return the mimetype already set on the message, for instance from request header.

--- a/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2021-2022 WeAreFrank!
+   Copyright 2019, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ public class CisConversionServiceImpl implements CisConversionService {
 		CisConversionResult result = null;
 		MimeType mimeType = MessageUtils.computeMimeType(message, filename);
 		if(mimeType == null || "x-tika-msoffice".equals(mimeType.getSubtype())) {
-			// If we cannot determine the MimeType based on the files magic numbers, read part of the file.
+			// MessageUtils.computeMimeType may return the mimetype already set on the message, for instance from request header.
+			// For TIKA MS Office files we need to enforce that TIKA actually checks the message contents.
 			// MS Office files can be password protected, which can only be determined by reading a part of the file.
 			mimeType = getMediaType(message, filename);
 		}

--- a/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/MediaTypeValidator.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/services/conv/impl/MediaTypeValidator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2021-2022 WeAreFrank!
+   Copyright 2019, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -36,8 +36,7 @@ class MediaTypeValidator {
 	 */
 	public MediaTypeValidator() {
 		// Create only once. Tika seems to be thread safe
-		// (see
-		// http://stackoverflow.com/questions/10190980/spring-tika-integration-is-my-approach-thread-safe)
+		// (see http://stackoverflow.com/questions/10190980/spring-tika-integration-is-my-approach-thread-safe)
 		tika = new Tika();
 	}
 
@@ -45,7 +44,6 @@ class MediaTypeValidator {
 	 * Detects media type from input stream
 	 */
 	public MediaType getMediaType(Message message, String filename) throws IOException {
-		message.preserve();
 		try (TikaInputStream tis = TikaInputStream.get(message.asInputStream())) {
 			String type = tika.detect(tis, filename);
 			return MediaType.valueOf(type);

--- a/aws/src/test/java/org/frankframework/senders/AmazonS3SenderTest.java
+++ b/aws/src/test/java/org/frankframework/senders/AmazonS3SenderTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.spy;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.frankframework.filesystem.TypeFilter;
-
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -24,6 +22,7 @@ import org.frankframework.filesystem.AmazonS3FileSystemTestHelper;
 import org.frankframework.filesystem.FileSystemActor.FileSystemAction;
 import org.frankframework.filesystem.IFileSystemTestHelper;
 import org.frankframework.filesystem.S3FileRef;
+import org.frankframework.filesystem.TypeFilter;
 import org.frankframework.filesystem.WritableFileSystemSenderTest;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.ParameterBuilder;
@@ -121,7 +120,7 @@ public class AmazonS3SenderTest extends WritableFileSystemSenderTest<AmazonS3Sen
 		assertTrue(_fileExists(inputFolder, FILE1), "File ["+FILE1+"] should still be there after READ action");
 		assertEquals("some content", StreamUtil.streamToString(result.asInputStream()));
 		IOException e = assertThrows(IOException.class, result::preserve); // read binary stream twice
-		assertEquals("Attempted read on closed stream.", e.getMessage());
+		assertEquals("Stream closed", e.getMessage());
 	}
 
 	@Test

--- a/commons/src/main/java/org/frankframework/util/StreamUtil.java
+++ b/commons/src/main/java/org/frankframework/util/StreamUtil.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020-2023 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 */
 package org.frankframework.util;
 
-import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FilterInputStream;
@@ -132,14 +132,14 @@ public class StreamUtil {
 	/**
 	 * Return a Reader that reads the InputStream in the character set specified by the BOM. If no BOM is found, the default character set UTF-8 is used.
 	 */
-	public static Reader getCharsetDetectingInputStreamReader(InputStream inputStream) throws IOException {
+	public static BufferedReader getCharsetDetectingInputStreamReader(InputStream inputStream) throws IOException {
 		return getCharsetDetectingInputStreamReader(inputStream, DEFAULT_INPUT_STREAM_ENCODING);
 	}
 
 	/**
 	 * Return a Reader that reads the InputStream in the character set specified by the BOM. If no BOM is found, a default character set is used.
 	 */
-	public static Reader getCharsetDetectingInputStreamReader(InputStream inputStream, String defaultCharset) throws IOException {
+	public static BufferedReader getCharsetDetectingInputStreamReader(InputStream inputStream, String defaultCharset) throws IOException {
 		BOMInputStream bOMInputStream = new BOMInputStream(inputStream, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE);
 		ByteOrderMark bom = bOMInputStream.getBOM();
 		String charsetName = bom == null ? defaultCharset : bom.getCharsetName();
@@ -148,7 +148,7 @@ public class StreamUtil {
 			charsetName = StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 		}
 
-		return new InputStreamReader(new BufferedInputStream(bOMInputStream), charsetName);
+		return new BufferedReader(new InputStreamReader(bOMInputStream, charsetName));
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -458,7 +458,7 @@ public class Message implements Serializable, Closeable {
 			LOG.debug("returning InputStream {} as Reader", this::getObjectId);
 			InputStream inputStream = asInputStream();
 			try {
-				BufferedReader reader = new BufferedReader(StreamUtil.getCharsetDetectingInputStreamReader(inputStream, readerCharset));
+				BufferedReader reader = StreamUtil.getCharsetDetectingInputStreamReader(inputStream, readerCharset);
 				if (this.request instanceof InputStream) {
 					this.request = reader;
 				}

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -420,7 +420,8 @@ public class Message implements Serializable, Closeable {
 
 	/**
 	 * Return a {@link Reader} backed by the data in this message. {@link Reader#markSupported()} is guaranteed to be true for the returned stream.
-	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the Reader is reset to its starting position.
+	 * Should not be called more than once, unless the request is {@link #isRepeatable() repeatable} or the Reader is reset to its starting position. If
+	 * the message is not {@link #isRepeatable() repeatable} then {@link #preserve()} can be called on the message to make it repeatable.
 	 */
 	@Nullable
 	public Reader asReader() throws IOException {
@@ -429,7 +430,8 @@ public class Message implements Serializable, Closeable {
 
 	/**
 	 * Return a {@link Reader} backed by the data in this message. {@link Reader#markSupported()} is guaranteed to be true for the returned stream.
-	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the Reader is reset to its starting position.
+	 * Should not be called more than once, unless the request is {@link #isRepeatable() repeatable} or the Reader is reset to its starting position. If
+	 * the message is not {@link #isRepeatable() repeatable} then {@link #preserve()} can be called on the message to make it repeatable.
 	 *
 	 * @param defaultDecodingCharset is only used when {@link #isBinary()} is {@code true}.
 	 */
@@ -479,7 +481,8 @@ public class Message implements Serializable, Closeable {
 
 	/**
 	 * Return an {@link InputStream} backed by the data in this message. {@link InputStream#markSupported()} is guaranteed to be true for the returned stream.
-	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the stream is reset to its starting position.
+	 * Should not be called more than once, unless the request is {@link #isRepeatable() repeatable} or the InputStream is reset to its starting position. If
+	 * the message is not {@link #isRepeatable() repeatable} then {@link #preserve()} can be called on the message to make it repeatable.
 	 */
 	@Nullable
 	public InputStream asInputStream() throws IOException {
@@ -488,7 +491,8 @@ public class Message implements Serializable, Closeable {
 
 	/**
 	 * Return an {@link InputStream} backed by the data in this message. {@link InputStream#markSupported()} is guaranteed to be true for the returned stream.
-	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the stream is reset to its starting position.
+	 * Should not be called more than once, unless the request is {@link #isRepeatable() repeatable} or the InputStream is reset to its starting position. If
+	 * the message is not {@link #isRepeatable() repeatable} then {@link #preserve()} can be called on the message to make it repeatable.
 	 *
 	 * @param defaultEncodingCharset is only used when the Message object is of character type (String)
 	 */
@@ -512,6 +516,7 @@ public class Message implements Serializable, Closeable {
 			}
 			if (request instanceof ThrowingSupplier) {
 				LOG.debug("returning InputStream {} from supplier", this::getObjectId);
+				@SuppressWarnings("unchecked")
 				InputStream is = ((ThrowingSupplier<InputStream, Exception>) request).get();
 				if (is.markSupported()) {
 					return is;

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -37,7 +38,6 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -419,19 +419,30 @@ public class Message implements Serializable, Closeable {
 	}
 
 	/**
-	 * return the request object as a {@link Reader}. Should not be called more than once, if request is not {@link #preserve() preserved}.
+	 * Return a {@link Reader} backed by the data in this message. {@link Reader#markSupported()} is guaranteed to be true for the returned stream.
+	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the Reader is reset to its starting position.
 	 */
 	@Nullable
 	public Reader asReader() throws IOException {
 		return asReader(null);
 	}
 
+	/**
+	 * Return a {@link Reader} backed by the data in this message. {@link Reader#markSupported()} is guaranteed to be true for the returned stream.
+	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the Reader is reset to its starting position.
+	 *
+	 * @param defaultDecodingCharset is only used when {@link #isBinary()} is {@code true}.
+	 */
 	@Nullable
 	public Reader asReader(@Nullable String defaultDecodingCharset) throws IOException {
 		if (request == null) {
 			return null;
 		}
 		if (request instanceof Reader reader) {
+			if (!reader.markSupported()) {
+				reader = new BufferedReader(reader);
+				request = reader;
+			}
 			LOG.debug("returning Reader {} as Reader", this::getObjectId);
 			return reader;
 		}
@@ -445,7 +456,11 @@ public class Message implements Serializable, Closeable {
 			LOG.debug("returning InputStream {} as Reader", this::getObjectId);
 			InputStream inputStream = asInputStream();
 			try {
-				return StreamUtil.getCharsetDetectingInputStreamReader(inputStream, readerCharset);
+				BufferedReader reader = new BufferedReader(StreamUtil.getCharsetDetectingInputStreamReader(inputStream, readerCharset));
+				if (this.request instanceof InputStream) {
+					this.request = reader;
+				}
+				return reader;
 			} catch (IOException e) {
 				onExceptionClose(e);
 				throw e;
@@ -463,7 +478,8 @@ public class Message implements Serializable, Closeable {
 	}
 
 	/**
-	 * return the request object as a {@link InputStream}. Should not be called more than once, if request is not {@link #preserve() preserved}.
+	 * Return an {@link InputStream} backed by the data in this message. {@link InputStream#markSupported()} is guaranteed to be true for the returned stream.
+	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the stream is reset to its starting position.
 	 */
 	@Nullable
 	public InputStream asInputStream() throws IOException {
@@ -471,6 +487,9 @@ public class Message implements Serializable, Closeable {
 	}
 
 	/**
+	 * Return an {@link InputStream} backed by the data in this message. {@link InputStream#markSupported()} is guaranteed to be true for the returned stream.
+	 * Should not be called more than once, unless the request is {@link #preserve() preserved} or the stream is reset to its starting position.
+	 *
 	 * @param defaultEncodingCharset is only used when the Message object is of character type (String)
 	 */
 	@Nullable
@@ -480,6 +499,10 @@ public class Message implements Serializable, Closeable {
 				return null;
 			}
 			if (request instanceof InputStream stream) {
+				if (!stream.markSupported()) {
+					stream = new BufferedInputStream(stream);
+					request = stream;
+				}
 				LOG.debug("returning InputStream {} as InputStream", this::getObjectId);
 				return stream;
 			}
@@ -489,7 +512,12 @@ public class Message implements Serializable, Closeable {
 			}
 			if (request instanceof ThrowingSupplier) {
 				LOG.debug("returning InputStream {} from supplier", this::getObjectId);
-				return ((ThrowingSupplier<InputStream, Exception>) request).get();
+				InputStream is = ((ThrowingSupplier<InputStream, Exception>) request).get();
+				if (is.markSupported()) {
+					return is;
+				} else {
+					return new BufferedInputStream(is);
+				}
 			}
 			if (request instanceof byte[] bytes) {
 				LOG.debug("returning byte[] {} as InputStream", this::getObjectId);
@@ -502,7 +530,7 @@ public class Message implements Serializable, Closeable {
 			String charset = getEncodingCharset(defaultEncodingCharset);
 			if (request instanceof Reader reader) {
 				LOG.debug("returning Reader {} as InputStream", this::getObjectId);
-				return new ReaderInputStream(reader, charset);
+				return new BufferedInputStream(new ReaderInputStream(reader, charset));
 			}
 			LOG.debug("returning String {} as InputStream", this::getObjectId);
 			return new ByteArrayInputStream(request.toString().getBytes(charset));
@@ -515,109 +543,23 @@ public class Message implements Serializable, Closeable {
 		}
 	}
 
-	/**
-	 * Reads the first 10k of a message. If the message does not support markSupported it is wrapped in a buffer.
-	 */
 	@Nonnull
-	public byte[] getMagic() throws IOException {
-		return getMagic(10 * 1024);
-	}
-
-	/**
-	 * Reads the first N bytes message, specified by parameter {@code readLimit}. If the message does not support markSupported it is wrapped in a buffer.
-	 *
-	 * @param readLimit amount of bytes to read.
-	 */
-	@Nonnull
-	public synchronized byte[] getMagic(int readLimit) throws IOException {
-		if (!isBinary()) {
-			return readBytesFromCharacterData(readLimit);
+	public synchronized String peek(int readLimit) throws IOException {
+		Reader r = asReader();
+		if (r == null) {
+			return "";
 		}
-
-		if (request instanceof InputStream) {
-			return readBytesFromInputStream(readLimit);
-		}
-		if (request instanceof byte[] bytes) { //copy of, else we can bump into buffer overflow exceptions
-			return Arrays.copyOf(bytes, readLimit);
-		}
-		if (isRepeatable()) {
-			try (InputStream stream = asInputStream()) { //Message is repeatable, close the stream after it's been (partially) read.
-				return readBytesFromInputStream(stream, readLimit);
-			}
-		}
-
-		return new byte[0];
-	}
-
-	@Nonnull
-	private byte[] readBytesFromCharacterData(int readLimit) throws IOException {
-		if (request instanceof Reader reader) {
-			if (!reader.markSupported()) {
-				reader = new BufferedReader(reader, readLimit);
-				request = reader;
-			}
-			reader.mark(readLimit);
-			try {
-				return readBytesFromReader(reader, readLimit);
-			} finally {
-				reader.reset();
-			}
-		}
-
-		if (request instanceof String string) {
-			if (string.isEmpty()) {
-				return new byte[0];
-			}
-			byte[] data = string.getBytes(StreamUtil.DEFAULT_CHARSET);
-			return Arrays.copyOf(data, readLimit);
-		}
-
-		if (isRepeatable()) {
-			try (Reader reader = asReader()) {
-				return readBytesFromReader(reader, readLimit);
-			}
-		}
-		return new byte[0];
-	}
-
-	@Nonnull
-	private byte[] readBytesFromReader(Reader reader, int readLimit) throws IOException {
-		var chars = new char[readLimit];
-		int charsRead = reader.read(chars);
-		if (charsRead <= 0) {
-			return new byte[0];
-		}
-		return new String(chars, 0, charsRead).getBytes(StreamUtil.DEFAULT_CHARSET);
-	}
-
-	@Nonnull
-	private byte[] readBytesFromInputStream(int readLimit) throws IOException {
-		assert request instanceof InputStream;
-		if (!((InputStream) request).markSupported()) {
-			request = new BufferedInputStream((InputStream) request, readLimit);
-		}
-		var stream = (InputStream) request;
-		stream.mark(readLimit);
-
+		r.mark(readLimit);
 		try {
-			return readBytesFromInputStream(stream, readLimit);
+			char[] buffer = new char[readLimit];
+			int len = r.read(buffer);
+			if (len <= 0) {
+				return "";
+			}
+			return new String(buffer, 0, len);
 		} finally {
-			stream.reset();
+			r.reset();
 		}
-	}
-
-	@Nonnull
-	private byte[] readBytesFromInputStream(InputStream stream, int readLimit) throws IOException {
-		var bytes = new byte[readLimit];
-		int numRead = stream.read(bytes);
-		if (numRead <= 0) {
-			return new byte[0];
-		}
-		if (numRead < readLimit) {
-			// move the bytes into a smaller array
-			bytes = Arrays.copyOf(bytes, numRead);
-		}
-		return bytes;
 	}
 
 	/**
@@ -857,13 +799,13 @@ public class Message implements Serializable, Closeable {
 	 * However, to do so, some I/O may have to be performed on the message thus making this a
 	 * potentially expensive operation which may throw an {@link IOException}.
 	 * <p/>
-	 * All I/O is done in such a way that no message data is lost (see also {@link Message#getMagic(int)}).
+	 * All I/O is done in such a way that no message data is lost .
 	 *
 	 * @param message Message to check. May be {@code null}.
 	 * @return Returns {@code false} if the message is {@code null} or of {@link Message#size()} returns 0.
 	 * 		Returns {@code true} if {@link Message#size()} returns a positive value.
 	 * 		If {@link Message#size()} returns {@link Message#MESSAGE_SIZE_UNKNOWN} then checks if any data can
-	 * 		be read via {@link Message#getMagic(int)}.
+	 * 		be read. Data read is pushed back onto the stream.
 	 * @throws IOException Throws an IOException if checking for data in the message throws an IOException.
 	 */
 	public static boolean hasDataAvailable(Message message) throws IOException {
@@ -871,10 +813,41 @@ public class Message implements Serializable, Closeable {
 			return false;
 		}
 		long size = message.size();
-		if (size == MESSAGE_SIZE_UNKNOWN) {
-			return message.getMagic(10).length != 0;
-		} else {
+		if (size != MESSAGE_SIZE_UNKNOWN) {
 			return size != 0;
+		}
+		if (message.isBinary()) {
+			return checkIfStreamHasData(message.asInputStream());
+		} else {
+			return checkIfReaderHasData(message.asReader());
+		}
+	}
+
+	private static boolean checkIfReaderHasData(Reader r) throws IOException {
+		if (r == null) {
+			return false;
+		}
+		r.mark(1);
+		try {
+			return r.read() != -1;
+		} catch (EOFException e) {
+			return false;
+		}  finally {
+			r.reset();
+		}
+	}
+
+	private static boolean checkIfStreamHasData(InputStream is) throws IOException {
+		if (is == null) {
+			return false;
+		}
+		is.mark(1);
+		try {
+			return is.read() != -1;
+		} catch (EOFException e) {
+			return false;
+		} finally {
+			is.reset();
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
+++ b/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023-2024 WeAreFrank!
+   Copyright 2023-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
+++ b/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
@@ -15,6 +15,7 @@
 */
 package org.frankframework.stream;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -195,8 +196,8 @@ public class SerializableFileReference implements Serializable, AutoCloseable {
 		}
 	}
 
-	public InputStream getInputStream() throws IOException {
-		return Files.newInputStream(path);
+	public BufferedInputStream getInputStream() throws IOException {
+		return new BufferedInputStream(Files.newInputStream(path));
 	}
 
 	private long getFileSize() {

--- a/core/src/main/java/org/frankframework/util/MessageUtils.java
+++ b/core/src/main/java/org/frankframework/util/MessageUtils.java
@@ -48,13 +48,13 @@ import org.frankframework.stream.MessageContext;
 
 public class MessageUtils {
 
-	private MessageUtils() {
-		throw new IllegalStateException("Don't construct utility class");
-	}
-
 	private static final Logger LOG = LogUtil.getLogger(MessageUtils.class);
 	private static final int CHARSET_CONFIDENCE_LEVEL = AppConstants.getInstance().getInt("charset.confidenceLevel", 65);
 	private static final Tika TIKA = new Tika();
+
+	private MessageUtils() {
+		throw new IllegalStateException("Don't construct utility class");
+	}
 
 	/**
 	 * Fetch metadata from the {@link HttpServletRequest} such as Content-Length, Content-Type (mimetype + charset)

--- a/core/src/main/java/org/frankframework/util/MessageUtils.java
+++ b/core/src/main/java/org/frankframework/util/MessageUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2024 WeAreFrank!
+   Copyright 2022-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/frankframework/util/MessageUtils.java
+++ b/core/src/main/java/org/frankframework/util/MessageUtils.java
@@ -237,9 +237,9 @@ public class MessageUtils {
 	}
 
 	/**
-	 * Computes the {@link MimeType} when not available, attempts to resolve the Charset when of type TEXT.
+	 * Computes the {@link MimeType} when not already available, attempts to resolve the Charset when of type TEXT.
 	 * <p>
-	 * NOTE: This is a resource intensive operation, the first kilobytes of the message are potentially being read and stored in memory.
+	 * NOTE: This might be a resource intensive operation, the first kilobytes of the message are potentially being read and stored in memory.
 	 */
 	public static MimeType computeMimeType(Message message, String filename) {
 		if(Message.isEmpty(message)) {

--- a/core/src/main/java/org/frankframework/util/MessageUtils.java
+++ b/core/src/main/java/org/frankframework/util/MessageUtils.java
@@ -15,7 +15,6 @@
 */
 package org.frankframework.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -36,10 +35,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.logging.log4j.Logger;
-import org.apache.tika.config.TikaConfig;
-import org.apache.tika.exception.TikaException;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.Tika;
 import org.springframework.util.DigestUtils;
 import org.springframework.util.MimeType;
 
@@ -58,17 +54,7 @@ public class MessageUtils {
 
 	private static final Logger LOG = LogUtil.getLogger(MessageUtils.class);
 	private static final int CHARSET_CONFIDENCE_LEVEL = AppConstants.getInstance().getInt("charset.confidenceLevel", 65);
-	private static final TikaConfig TIKA_CONFIG = createTikaConfig();
-	private static final int TIKA_MAGIC_LENGTH = 64 * 1024; // This needs to be reasonably large to be able to correctly detect things like XML root elements after initial comment and DTDs
-
-	private static TikaConfig createTikaConfig() {
-		try {
-			return new TikaConfig();
-		} catch (TikaException | IOException e) {
-			LOG.error("unable to create Tika config, cannot determine mimetypes!", e);
-			return null;
-		}
-	}
+	private static final Tika TIKA = new Tika();
 
 	/**
 	 * Fetch metadata from the {@link HttpServletRequest} such as Content-Length, Content-Type (mimetype + charset)
@@ -177,7 +163,7 @@ public class MessageUtils {
 		}
 
 		CharsetDetector detector = new CharsetDetector();
-		detector.setText(message.getMagic());
+		detector.setText(message.asInputStream());
 		CharsetMatch match = detector.detect();
 		String charset = match.getName();
 
@@ -253,7 +239,7 @@ public class MessageUtils {
 	/**
 	 * Computes the {@link MimeType} when not available, attempts to resolve the Charset when of type TEXT.
 	 * <p>
-	 * NOTE: This is a resource intensive operation, the first {@value #TIKA_MAGIC_LENGTH} bytes are being read and stored in memory.
+	 * NOTE: This is a resource intensive operation, the first kilobytes of the message are potentially being read and stored in memory.
 	 */
 	public static MimeType computeMimeType(Message message, String filename) {
 		if(Message.isEmpty(message)) {
@@ -274,14 +260,8 @@ public class MessageUtils {
 		}
 
 		try {
-			Metadata metadata = new Metadata();
-			metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
-			byte[] magic = message.getMagic(TIKA_MAGIC_LENGTH);
-			if(magic.length == 0) {
-				return null;
-			}
-			org.apache.tika.mime.MediaType tikaMediaType = TIKA_CONFIG.getDetector().detect(new ByteArrayInputStream(magic), metadata);
-			MimeType mimeType = MimeType.valueOf(tikaMediaType.toString());
+			String mediaType = TIKA.detect(message.asInputStream(), name);
+			MimeType mimeType = MimeType.valueOf(mediaType);
 			context.withMimeType(mimeType);
 			if("text".equals(mimeType.getType()) || message.getCharset() != null) { // is of type 'text' or message has charset
 				Charset charset = computeDecodingCharset(message);
@@ -385,7 +365,7 @@ public class MessageUtils {
 			message.assertNotClosed();
 			return message.asString();
 		}
-		if (object instanceof MessageWrapper wrapper) {
+		if (object instanceof MessageWrapper<?> wrapper) {
 			return wrapper.getMessage().asString();
 		}
 		// In other cases, message can be closed directly after converting to String.

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016-2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
+   Copyright 2013, 2016-2019 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -127,6 +127,7 @@ import org.frankframework.xml.XmlWriter;
  * @author  Johan Verrips
  */
 public class XmlUtils {
+	public static final int HTML_MAX_PREAMBLE_SIZE = 512;
 	static Logger log = LogManager.getLogger(XmlUtils.class);
 
 	public static final int DEFAULT_XSLT_VERSION = AppConstants.getInstance().getInt("xslt.version.default", 2);
@@ -1700,7 +1701,7 @@ public class XmlUtils {
 	public static String toXhtml(Message message) throws IOException {
 		if (!Message.isEmpty(message)) {
 			String messageCharset = message.getCharset();
-			String xhtmlString = message.peek(512);
+			String xhtmlString = message.peek(HTML_MAX_PREAMBLE_SIZE);
 			if (xhtmlString.contains("<html>") || xhtmlString.contains("<html ")) {
 				CleanerProperties props = new CleanerProperties();
 				props.setOmitDoctypeDeclaration(true);

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -1700,7 +1700,7 @@ public class XmlUtils {
 	public static String toXhtml(Message message) throws IOException {
 		if (!Message.isEmpty(message)) {
 			String messageCharset = message.getCharset();
-			String xhtmlString = new String(message.getMagic(512), messageCharset != null ? messageCharset : StreamUtil.DEFAULT_INPUT_STREAM_ENCODING);
+			String xhtmlString = message.peek(512);
 			if (xhtmlString.contains("<html>") || xhtmlString.contains("<html ")) {
 				CleanerProperties props = new CleanerProperties();
 				props.setOmitDoctypeDeclaration(true);

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
@@ -319,7 +319,7 @@ public class SoapProviderTest {
 
 		assertEquals(1, message.countAttachments());
 
-		testAttachment(message, getFile(attachmentFile).asString(), "application/octet-stream");
+		testAttachment(message, getFile(attachmentFile).asString(), "text/plain");
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/pipes/ReplacerPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/ReplacerPipeTest.java
@@ -204,7 +204,7 @@ public class ReplacerPipeTest extends PipeTestBase<ReplacerPipe> {
 
 		Message result = res.getResult();
 		result.captureBinaryStream();
-		result.getMagic(10);
+		result.peek(10);
 
 		assertEquals("statuscodeselectable: [Exit201]", result.asString());
 	}

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -118,16 +118,19 @@ public class MessageTest {
 	}
 
 	protected void testAsInputStream(Message message) throws IOException {
-		byte[] header = message.getMagic(6);
-		assertEquals("<root>", new String(header));
+		String header = message.peek(6);
+		assertEquals("<root>", header);
 
 		InputStream result = message.asInputStream();
 		String actual = StreamUtil.streamToString(result, null, StandardCharsets.UTF_8.name());
 		MatchUtils.assertXmlEquals(testString, actual);
 	}
 
-	protected void testAsReader(Message adapter) throws IOException {
-		Reader result = adapter.asReader();
+	protected void testAsReader(Message message) throws IOException {
+		String header = message.peek(6);
+		assertEquals("<root>", header);
+
+		Reader result = message.asReader();
 		String actual = StreamUtil.readerToString(result, null);
 		MatchUtils.assertXmlEquals(testString, actual);
 	}
@@ -142,16 +145,16 @@ public class MessageTest {
 	}
 
 	protected void testAsString(Message message) throws IOException {
-		byte[] header = message.getMagic(6);
-		assertEquals("<root>", new String(header));
+		String header = message.peek(6);
+		assertEquals("<root>", header);
 
 		String actual = message.asString();
 		MatchUtils.assertXmlEquals(testString, actual);
 	}
 
 	protected void testAsByteArray(Message message) throws IOException {
-		byte[] header = message.getMagic(6);
-		assertEquals("<root>", new String(header));
+		String header = message.peek(6);
+		assertEquals("<root>", header);
 
 		byte[] actual = message.asByteArray();
 		byte[] expected = testString.getBytes(StandardCharsets.UTF_8);
@@ -504,8 +507,8 @@ public class MessageTest {
 		String source = "";
 		Message message = new Message(source);
 
-		byte[] header = message.getMagic(6);
-		assertEquals("", new String(header));
+		String header = message.peek(6);
+		assertEquals("", header);
 
 		String actual = message.asString();
 		assertEquals("", actual);
@@ -1221,7 +1224,7 @@ public class MessageTest {
 		};
 		Message message = new Message(filterReader);
 		int charsToRead = 6;
-		message.getMagic(charsToRead);
+		message.peek(charsToRead);
 		message.close();
 		assertEquals(charsToRead, charsRead.get());
 	}

--- a/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
@@ -177,7 +177,7 @@ public class MessageUtilsTest {
 		try (Message message = new UrlMessage(url)) {
 			MessageDataSource ds = new MessageDataSource(new Message(message.asString()));
 			assertEquals(null, ds.getName(), "filename is unknown");
-			assertEquals("application/octet-stream", ds.getContentType(), "content-type cannot be determined");
+			assertEquals("text/plain", ds.getContentType(), "content-type cannot be determined");
 			assertEquals(StreamUtil.streamToString(url.openStream()), StreamUtil.streamToString(ds.getInputStream()), "contents should be the same");
 			assertEquals(StreamUtil.streamToString(url.openStream()), StreamUtil.streamToString(ds.getInputStream()), "should be able to read the content twice");
 		}
@@ -201,7 +201,7 @@ public class MessageUtilsTest {
 		Message json = new Message("{\"GUID\": \"ABC\"}");
 		MimeType mimeType = MessageUtils.computeMimeType(json);
 		assertNotNull(mimeType);
-		assertEquals("application/octet-stream", mimeType.toString()); //mime-type cannot be determined
+		assertEquals("text/plain", mimeType.toString()); //mime-type cannot be determined
 	}
 	@Test
 	public void testJsonMessageWithName() {

--- a/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/StreamCaptureUtilsTest.java
@@ -3,6 +3,7 @@ package org.frankframework.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -135,21 +136,21 @@ class StreamCaptureUtilsTest {
 		Message message = spy(new Message(stream)); // non-repeatable
 		ByteArrayOutputStream boas = message.captureBinaryStream();
 
-		byte[] magic = message.getMagic(bufferSize);
+		String magic = message.peek(bufferSize);
 
 		message.asString(); // Read twice after the magic has been fetched
 		message.asString();
 
 		byte[] capture = Arrays.copyOf(boas.toByteArray(), bufferSize); // It is possible more characters have been written to the captured stream
-		assertEquals(new String(magic), new String(capture));
+		assertEquals(magic, new String(capture));
 		assertEquals(message.asString(), new String(input.openStream().readAllBytes())); // Verify that the message output, after reading the magic, has not changed
 
-		verify(stream, times(2)).close();
+		verify(stream, atLeastOnce()).close();
 		verify(message, times(0)).close();
 
 		message.close();
 
-		verify(stream, times(2)).close();
+		verify(stream, atLeastOnce()).close();
 		verify(message, times(1)).close();
 	}
 


### PR DESCRIPTION
- For TIKA and CharsetDetector, do not use byte[] from the message but an InputStream that supports mark/reset. More efficient, and more correct, and less overhead on our side.
- Other uses of `Message.getMagic()` want a string, so remove `getMagic()` and the code it relies on, and instead provide a simple method `peek()` that returns a String and internally relies on being able to mark/reset the Reader or Inputstream of the message.

Some of the changes have been lifted from PR #8409 and I want to use the changes in this PR to finalize #8409.