### PR TITLE
Add property for ladybug report retention period

### DIFF
--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/DeploymentSpecificsBeanPostProcessor.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/DeploymentSpecificsBeanPostProcessor.java
@@ -41,6 +41,11 @@ public class DeploymentSpecificsBeanPostProcessor implements BeanPostProcessor {
 				long maxStorageSizeLong = OptionConverter.toFileSize(maxStorageSize, databaseStorage.getMaxStorageSize());
 				databaseStorage.setMaxStorageSize(maxStorageSizeLong);
 			}
+			String maxStorageDays = appConstants.getProperty("ibistesttool.maxStorageDays");
+			if (maxStorageDays != null) {
+				long maxStorageDaysLong = OptionConverter.toFileSize(maxStorageDays, -1);
+				databaseStorage.setMaxStorageDays(maxStorageDaysLong);
+			}
 		}
 
 		if (bean instanceof nl.nn.testtool.storage.file.Storage loggingStorage) {


### PR DESCRIPTION
Ladybug added a new feature to allow reports to be deleted after a certain amount of days.
This change will allow developers to configure this feature via the app constants.
The property `ibistesttool.maxStorageDays` will allow developers to set a certain amount of days a report is allowed to be stored before it will automatically be removed upon the next report insertion.
By default, this property value is set to -1, which disables the feature.