### PR TITLE
Use spring.boot.version variable as spring-boot-maven-plugin version

### DIFF
--- a/console/war/pom.xml
+++ b/console/war/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>3.4.2</version>
+				<version>${spring.boot.version}</version>
 				<configuration>
 					<mainClass>org.frankframework.console.runner.ConsoleStandaloneInitializer</mainClass>
 					<layout>WAR</layout>


### PR DESCRIPTION
Improved solution to #8473.
This should stop similar dependabot pr's from being created for every spring boot update