### PR TITLE
Add root tag around configuration elements

### DIFF
--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -60,6 +60,7 @@ import org.frankframework.management.bus.message.StringMessage;
 public class ConfigManagement extends BusEndpointBase {
 
 	private static final String HEADER_CONFIGURATION_VERSION_KEY = "version";
+	private static final String ROOT_ELEMENT_NAME = "configurations";
 
 	/**
 	 * The header 'loaded' is used to differentiate between the loaded and original (raw) XML.
@@ -80,6 +81,9 @@ public class ConfigManagement extends BusEndpointBase {
 				result.append(loadedConfiguration ? configuration.getLoadedConfiguration() : configuration.getOriginalConfiguration());
 			}
 		}
+
+		result.insert(0, "<" + ROOT_ELEMENT_NAME + ">");
+		result.append("</" + ROOT_ELEMENT_NAME + ">");
 
 		return new StringMessage(result.toString(), MediaType.APPLICATION_XML);
 	}

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -73,7 +73,6 @@ public class ConfigManagement extends BusEndpointBase {
 		boolean loadedConfiguration = BusMessageUtils.getBooleanHeader(message, "loaded", false);
 		StringBuilder result = new StringBuilder();
 
-
 		if(configurationName != null) {
 			Configuration configuration = getConfigurationByName(configurationName);
 			result.append(loadedConfiguration ? configuration.getLoadedConfiguration() : configuration.getOriginalConfiguration());
@@ -84,7 +83,6 @@ public class ConfigManagement extends BusEndpointBase {
 			}
 			result.append("</" + ROOT_ELEMENT_NAME + ">");
 		}
-
 
 		return new StringMessage(result.toString(), MediaType.APPLICATION_XML);
 	}

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -73,6 +73,8 @@ public class ConfigManagement extends BusEndpointBase {
 		boolean loadedConfiguration = BusMessageUtils.getBooleanHeader(message, "loaded", false);
 		StringBuilder result = new StringBuilder();
 
+		result.append("<" + ROOT_ELEMENT_NAME + ">");
+
 		if(configurationName != null) {
 			Configuration configuration = getConfigurationByName(configurationName);
 			result.append(loadedConfiguration ? configuration.getLoadedConfiguration() : configuration.getOriginalConfiguration());
@@ -82,7 +84,6 @@ public class ConfigManagement extends BusEndpointBase {
 			}
 		}
 
-		result.insert(0, "<" + ROOT_ELEMENT_NAME + ">");
 		result.append("</" + ROOT_ELEMENT_NAME + ">");
 
 		return new StringMessage(result.toString(), MediaType.APPLICATION_XML);

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConfigManagement.java
@@ -73,18 +73,18 @@ public class ConfigManagement extends BusEndpointBase {
 		boolean loadedConfiguration = BusMessageUtils.getBooleanHeader(message, "loaded", false);
 		StringBuilder result = new StringBuilder();
 
-		result.append("<" + ROOT_ELEMENT_NAME + ">");
 
 		if(configurationName != null) {
 			Configuration configuration = getConfigurationByName(configurationName);
 			result.append(loadedConfiguration ? configuration.getLoadedConfiguration() : configuration.getOriginalConfiguration());
 		} else {
+			result.append("<" + ROOT_ELEMENT_NAME + ">");
 			for (Configuration configuration : getIbisManager().getConfigurations()) {
 				result.append(loadedConfiguration ? configuration.getLoadedConfiguration() : configuration.getOriginalConfiguration());
 			}
+			result.append("</" + ROOT_ELEMENT_NAME + ">");
 		}
 
-		result.append("</" + ROOT_ELEMENT_NAME + ">");
 
 		return new StringMessage(result.toString(), MediaType.APPLICATION_XML);
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestConfigManagement.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestConfigManagement.java
@@ -16,8 +16,10 @@ import org.frankframework.testutil.TestConfiguration;
 @SpringJUnitConfig(initializers = {SpringRootInitializer.class})
 @WithMockUser(roles = { "IbisTester" })
 public class TestConfigManagement extends BusTestBase {
-	private static final String LOADED_RESULT = "<configurations><loaded authAlias=\"test\" /></configurations>";
-	private static final String ORIGINAL_RESULT = "<configurations><original authAlias=\"test\" /></configurations>";
+	private static final String LOADED_RESULT = "<loaded authAlias=\"test\" />";
+	private static final String LOADED_RESULTS = "<configurations>" + LOADED_RESULT + "</configurations>";
+	private static final String ORIGINAL_RESULT = "<original authAlias=\"test\" />";
+	private static final String ORIGINAL_RESULTS = "<configurations>" + ORIGINAL_RESULT + "</configurations>";
 
 	@Test
 	public void getOriginalConfigurationByName() {
@@ -31,7 +33,7 @@ public class TestConfigManagement extends BusTestBase {
 	public void getOriginalConfigurations() {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.CONFIGURATION, BusAction.GET);
 		Message<?> response = callSyncGateway(request);
-		assertEquals(ORIGINAL_RESULT, response.getPayload());
+		assertEquals(ORIGINAL_RESULTS, response.getPayload());
 	}
 
 	@Test
@@ -48,7 +50,7 @@ public class TestConfigManagement extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.CONFIGURATION, BusAction.GET);
 		request.setHeader("loaded", true);
 		Message<?> response = callSyncGateway(request);
-		assertEquals(LOADED_RESULT, response.getPayload());
+		assertEquals(LOADED_RESULTS, response.getPayload());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestConfigManagement.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestConfigManagement.java
@@ -16,8 +16,8 @@ import org.frankframework.testutil.TestConfiguration;
 @SpringJUnitConfig(initializers = {SpringRootInitializer.class})
 @WithMockUser(roles = { "IbisTester" })
 public class TestConfigManagement extends BusTestBase {
-	private static final String LOADED_RESULT = "<loaded authAlias=\"test\" />";
-	private static final String ORIGINAL_RESULT = "<original authAlias=\"test\" />";
+	private static final String LOADED_RESULT = "<configurations><loaded authAlias=\"test\" /></configurations>";
+	private static final String ORIGINAL_RESULT = "<configurations><original authAlias=\"test\" /></configurations>";
 
 	@Test
 	public void getOriginalConfigurationByName() {


### PR DESCRIPTION
Adds a configurations root tag around the configuration elements to make the returned xml valid.

fixes #8401 