### PR TITLE
XHTML conversion memory-optimization

### DIFF
--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -458,24 +458,23 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 		}
 
 		if (isXhtml() && !Message.isEmpty(result)) {
-			// TODO: Streaming XHTML conversion for better performance with large result message?
-			String xhtml;
-			try(Message m = result) {
+			Message xhtml;
+			try (Message m = result) {
 				xhtml = XmlUtils.toXhtml(m);
 			} catch (IOException e) {
 				throw new SenderException("error reading http response as String", e);
 			}
 
-			if (transformerPool != null && xhtml != null) {
+			if (transformerPool != null && !xhtml.isEmpty()) {
 				log.debug("transforming result [{}]", xhtml);
 				try {
-					xhtml = transformerPool.transform(xhtml);
+					xhtml = transformerPool.transform(xhtml, null);
 				} catch (Exception e) {
 					throw new SenderException("Exception on transforming input", e);
 				}
 			}
 
-			result = new Message(xhtml);
+			result = xhtml;
 		}
 
 		if (result == null) {

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -19,6 +19,7 @@ package org.frankframework.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -1718,7 +1719,7 @@ public class XmlUtils {
 		return null;
 	}
 
-	public static String toXhtml(Message message) throws IOException {
+	public static @Nonnull Message toXhtml(Message message) throws IOException {
 		if (!Message.isEmpty(message)) {
 			String messageCharset = message.getCharset();
 			String xhtmlString = message.peek(HTML_MAX_PREAMBLE_SIZE);
@@ -1730,10 +1731,14 @@ public class XmlUtils {
 				}
 				HtmlCleaner cleaner = new HtmlCleaner(props);
 				TagNode tagNode = cleaner.clean(message.asReader());
-				return new SimpleXmlSerializer(props).getAsString(tagNode);
+				MessageBuilder messageBuilder = new MessageBuilder();
+				OutputStream outputStream = messageBuilder.asOutputStream();
+				new SimpleXmlSerializer(props).writeToStream(tagNode, outputStream);
+				outputStream.close();
+				return messageBuilder.build();
 			}
 		}
-		return null;
+		return Message.nullMessage();
 	}
 
 	public static XPathFactory getXPathFactory() {

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -226,7 +226,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 		URL url = TestFileUtils.getTestFileURL("/HtmlCleaner/html.input.html");
 		Message message = new UrlMessage(url);
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		String expected = TestFileUtils.getTestFile("/HtmlCleaner/html.output.html");
 		MatchUtils.assertXmlEquals(expected, actual);
 	}
@@ -236,7 +236,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 		URL url = TestFileUtils.getTestFileURL("/HtmlCleaner/xhtml.input.xhtml");
 		Message message = new UrlMessage(url);
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		String expected = TestFileUtils.getTestFile("/HtmlCleaner/xhtml.output.xhtml");
 		MatchUtils.assertXmlEquals(expected, actual);
 	}
@@ -246,7 +246,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 		URL url = TestFileUtils.getTestFileURL("/HtmlCleaner/html.without-doctype.input.html");
 		Message message = new UrlMessage(url);
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		String expected = TestFileUtils.getTestFile("/HtmlCleaner/html.without-doctype.output.html");
 		MatchUtils.assertXmlEquals(expected, actual);
 	}
@@ -255,7 +255,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	void noHtmlToXhtml() throws Exception {
 		Message message = new Message("<xml>tralalal</xml>");
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		assertNull(actual);
 	}
 
@@ -263,7 +263,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	void nullToXhtml() throws Exception {
 		Message message = Message.nullMessage();
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		assertNull(actual);
 	}
 
@@ -271,7 +271,7 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	void emptyToXhtml() throws Exception {
 		Message message = new Message("");
 
-		String actual = XmlUtils.toXhtml(message);
+		String actual = XmlUtils.toXhtml(message).asString();
 		assertNull(actual);
 	}
 

--- a/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
+++ b/larva/src/main/java/org/frankframework/extensions/test/IbisTester.java
@@ -94,7 +94,7 @@ public class IbisTester {
 			if (scenario == null) {
 				String htmlString = "<html><head/><body>" + writer + "</body></html>";
 				try (Message message = new Message(htmlString)) {
-					return XmlUtils.toXhtml(message);
+					return XmlUtils.toXhtml(message).asString();
 				}
 			} else {
 				return writer.toString();


### PR DESCRIPTION
DO a TODO: Make XHTML Conversion more streaming to reduce memory usage.