### PR TITLE
Make health endpoints available for localhost without authorization

### DIFF
--- a/console/backend/src/main/java/org/frankframework/console/configuration/RegisterServletEndpoints.java
+++ b/console/backend/src/main/java/org/frankframework/console/configuration/RegisterServletEndpoints.java
@@ -45,7 +45,7 @@ public class RegisterServletEndpoints implements ApplicationContextAware {
 	public ServletRegistration<DispatcherServlet> backendServletBean() {
 		ServletConfiguration servletConfiguration = SpringUtils.createBean(applicationContext, ServletConfiguration.class);
 		servletConfiguration.setName("IAF-API");
-		servletConfiguration.setUrlMapping("iaf/api/*,!/iaf/api/server/health");
+		servletConfiguration.setUrlMapping("iaf/api/*");
 		servletConfiguration.setSecurityRoles(DynamicRegistration.ALL_IBIS_USER_ROLES);
 		servletConfiguration.setLoadOnStartup(1);
 		servletConfiguration.loadProperties();

--- a/console/backend/src/main/java/org/frankframework/console/configuration/SecurityChainConfigurer.java
+++ b/console/backend/src/main/java/org/frankframework/console/configuration/SecurityChainConfigurer.java
@@ -128,8 +128,8 @@ public class SecurityChainConfigurer implements ApplicationContextAware, Environ
 
 	@Bean
 	public IAuthenticator consoleAuthenticator() {
-		String properyPrefix = "application.security.console.authentication.";
-		IAuthenticator authenticator = AuthenticatorUtils.createAuthenticator(applicationContext, properyPrefix);
+		String propertyPrefix = "application.security.console.authentication.";
+		IAuthenticator authenticator = AuthenticatorUtils.createAuthenticator(applicationContext, propertyPrefix);
 
 		APPLICATION_LOG.info("Securing Frank!Framework Console using {}", ClassUtils.classNameOf(authenticator));
 		return authenticator;

--- a/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainConfigurerTest.java
+++ b/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainConfigurerTest.java
@@ -51,12 +51,12 @@ public class SecurityChainConfigurerTest {
 
 	@WithMockUser(authorities = "ROLE_ADMIN")
 	@Test
-	void testWithLoggedInUser() throws Exception {
-		// localhost`
+	void testServerHealthWithLoggedInUser() throws Exception {
+		// used from localhost
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health"))
 				.andExpect(status().isOk());
 
-		// custom remote address, but with ROLE_ADMIN
+		// custom remote address
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health")
 						.remoteAddress("195.1.12.1"))
 				.andExpect(status().isOk());
@@ -76,7 +76,7 @@ public class SecurityChainConfigurerTest {
 	}
 
 	@Test
-	void testIafHealthAnonymous() throws Exception {
+	void testServerHealthEndpoint() throws Exception {
 		// use localhost as remote address, not authorized
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health"))
 				.andExpect(status().isOk());

--- a/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainConfigurerTest.java
+++ b/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainConfigurerTest.java
@@ -1,0 +1,95 @@
+package org.frankframework.console.configuration;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.frankframework.console.controllers.ServerStatistics;
+import org.frankframework.console.controllers.WebTestConfiguration;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { SecurityChainTestConfiguration.class, SecurityChainConfigurer.class, WebTestConfiguration.class, ServerStatistics.class })
+@WebAppConfiguration
+public class SecurityChainConfigurerTest {
+
+	@Autowired
+	private WebApplicationContext context;
+
+	private MockMvc mockMvc;
+
+	@DynamicPropertySource
+	static void dynamicProperties(DynamicPropertyRegistry registry) {
+		registry.add("dtap.stage", () -> "ACC");
+		registry.add("application.security.console.authentication.type", () -> "IN_MEMORY");
+		registry.add("application.security.console.authentication.username", () -> "Admin");
+		registry.add("application.security.console.authentication.password", () -> "Nimda");
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		mockMvc = MockMvcBuilders
+				.webAppContextSetup(context)
+				.apply(springSecurity())
+				.build();
+	}
+
+	@WithMockUser(authorities = "ROLE_ADMIN")
+	@Test
+	void testWithLoggedInUser() throws Exception {
+		// localhost`
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health"))
+				.andExpect(status().isOk());
+
+		// custom remote address, but with ROLE_ADMIN
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health")
+						.remoteAddress("195.1.12.1"))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	void testInfoEndpoint() throws Exception {
+		// without authentication
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/info"))
+				.andExpect(status().isUnauthorized());
+
+		// with authentication
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/info")
+						.with(httpBasic("Admin", "Nimda")))
+				.andDo(MockMvcResultHandlers.print())
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	void testIafHealthAnonymous() throws Exception {
+		// use localhost as remote address, not authorized
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health"))
+				.andExpect(status().isOk());
+
+		// custom remote address, not authorized
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health")
+						.remoteAddress("192.168.0.1"))
+				.andExpect(status().isUnauthorized());
+
+		// custom remote address, authorized
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/server/health")
+						.with(httpBasic("Admin", "Nimda"))
+						.remoteAddress("192.168.0.1"))
+				.andExpect(status().isOk());
+	}
+}

--- a/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
+++ b/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
@@ -41,6 +41,8 @@ public class SecurityChainTestConfiguration implements ApplicationContextAware {
 	/**
 	 * Needed to configure the backend endpoint for the IAF API to /* - we're missing the default /iaf/api/* mapping which is configured
 	 * in the RegisterServletEndpoints class on 'normal' startup.
+	 *
+	 * @see RegisterServletEndpoints
 	 */
 	@Bean
 	public ServletRegistration<DispatcherServlet> backendServletBean() {

--- a/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
+++ b/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
@@ -1,0 +1,70 @@
+package org.frankframework.console.configuration;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.MultipartConfigElement;
+
+import org.springframework.beans.BeansException;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import org.frankframework.console.ConsoleFrontend;
+import org.frankframework.lifecycle.DynamicRegistration;
+import org.frankframework.lifecycle.servlets.SecuritySettings;
+import org.frankframework.lifecycle.servlets.ServletConfiguration;
+import org.frankframework.security.config.ServletRegistration;
+import org.frankframework.util.SpringUtils;
+
+public class SecurityChainTestConfiguration implements ApplicationContextAware {
+	private ApplicationContext applicationContext;
+
+	/**
+	 * For MockMvc testing, we need to register the SpringSecurityFilterChain manually.
+	 */
+	@Bean
+	public FilterRegistrationBean<Filter> getFilterRegistrationBean() {
+		FilterRegistrationBean<Filter> bean = new FilterRegistrationBean<>();
+		Filter filter = applicationContext.getBean("springSecurityFilterChain", Filter.class);
+		bean.setFilter(filter);
+		return bean;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+		SecuritySettings.setupDefaultSecuritySettings(applicationContext.getEnvironment());
+	}
+
+	/**
+	 * Needed to configure the backend endpoint for the IAF API to /* - we're missing the default /iaf/api/* mapping which is configured
+	 * in the RegisterServletEndpoints class on 'normal' startup.
+	 */
+	@Bean
+	public ServletRegistration<DispatcherServlet> backendServletBean() {
+		ServletConfiguration servletConfiguration = SpringUtils.createBean(applicationContext, ServletConfiguration.class);
+		servletConfiguration.setName("IAF-API");
+		servletConfiguration.setUrlMapping("/*");
+		servletConfiguration.setSecurityRoles(DynamicRegistration.ALL_IBIS_USER_ROLES);
+		servletConfiguration.setLoadOnStartup(1);
+		servletConfiguration.loadProperties();
+
+		ServletRegistration<DispatcherServlet> servlet = new ServletRegistration<>(DispatcherServlet.class, servletConfiguration);
+		servlet.setMultipartConfig(new MultipartConfigElement(""));
+		servlet.setAsyncSupported(true);
+		return servlet;
+	}
+
+	@Bean
+	public ServletRegistration<ConsoleFrontend> frontendServletBean() {
+		ServletConfiguration servletConfiguration = SpringUtils.createBean(applicationContext, ServletConfiguration.class);
+		servletConfiguration.setName("IAF-GUI");
+		servletConfiguration.setUrlMapping("iaf/gui/*");
+		servletConfiguration.setSecurityRoles(DynamicRegistration.ALL_IBIS_USER_ROLES);
+		servletConfiguration.setLoadOnStartup(1);
+		servletConfiguration.loadProperties();
+
+		return new ServletRegistration<>(ConsoleFrontend.class, servletConfiguration);
+	}
+}

--- a/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
+++ b/console/backend/src/test/java/org/frankframework/console/configuration/SecurityChainTestConfiguration.java
@@ -21,7 +21,8 @@ public class SecurityChainTestConfiguration implements ApplicationContextAware {
 	private ApplicationContext applicationContext;
 
 	/**
-	 * For MockMvc testing, we need to register the SpringSecurityFilterChain manually.
+	 * For MockMvc testing, we need to register the SpringSecurityFilterChain as a Filter in a Bean manually.
+	 * This is used by mockMvc configuration with `SecurityMockMvcConfigurers#springSecurity()`.
 	 */
 	@Bean
 	public FilterRegistrationBean<Filter> getFilterRegistrationBean() {

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -266,3 +266,7 @@ framework.api.user.alias=
 larva.parallel.blacklistDirs=MessageStoreSenderAndListener,QuerySender,Receivers,BlockEnabledSenders,TransactionHandling,BatchFileTransformerPipe,JdbcListener
 
 receiver.defaultMaxBackoffDelay=0
+
+application.security.console.authentication.type=IN_MEMORY
+application.security.console.authentication.username=Admin
+application.security.console.authentication.password=Nimda

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -266,7 +266,3 @@ framework.api.user.alias=
 larva.parallel.blacklistDirs=MessageStoreSenderAndListener,QuerySender,Receivers,BlockEnabledSenders,TransactionHandling,BatchFileTransformerPipe,JdbcListener
 
 receiver.defaultMaxBackoffDelay=0
-
-application.security.console.authentication.type=IN_MEMORY
-application.security.console.authentication.username=Admin
-application.security.console.authentication.password=Nimda


### PR DESCRIPTION
Added spring security configuration to make sure that 'localhost' ip addresses can always access /**/health endpoints. This only applies if security is active on the console