### PR TITLE
Make sure the storage id is present to be able to resend the message

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -144,12 +144,13 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 			String mid = getStringFieldOrNull(rs, getMessageIdField());
 			Object rawMessage = ois.readObject();
 
+			RawMessageWrapper<Serializable> rawMessageWrapper;
 			if (rawMessage instanceof MessageWrapper<?>) {
 				//noinspection unchecked
-				return (MessageWrapper<Serializable>) rawMessage;
+				rawMessageWrapper = (MessageWrapper<Serializable>) rawMessage;
+			} else {
+				rawMessageWrapper = new RawMessageWrapper<>((Serializable) rawMessage, mid != null ? mid : key, cid);
 			}
-
-			RawMessageWrapper<Serializable> rawMessageWrapper = new RawMessageWrapper<>((Serializable)rawMessage, mid != null ? mid : key, cid);
 			if (key != null) {
 				rawMessageWrapper.getContext().put(PipeLineSession.STORAGE_ID_KEY, key);
 			}

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -138,8 +138,10 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 	@Override
 	protected RawMessageWrapper<Serializable> extractRawMessage(ResultSet rs) throws JdbcException {
 		try (InputStream blobStream = JdbcUtil.getBlobInputStream(getDbmsSupport(), rs, getMessageField(), isBlobsCompressed());
-		 ObjectInputStream ois = new RenamingObjectInputStream(blobStream)) {
-				Object rawMessage = ois.readObject();
+			ObjectInputStream ois = new RenamingObjectInputStream(blobStream)) {
+
+			// After creating the BlobInputStream, it should be read before accessing any other fields of the RecordSet
+			Object rawMessage = ois.readObject();
 
 			String key = getStringFieldOrNull(rs, getKeyField());
 			String cid = getStringFieldOrNull(rs, getCorrelationIdField());

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -139,10 +139,11 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 	protected RawMessageWrapper<Serializable> extractRawMessage(ResultSet rs) throws JdbcException {
 		try (InputStream blobStream = JdbcUtil.getBlobInputStream(getDbmsSupport(), rs, getMessageField(), isBlobsCompressed());
 		 ObjectInputStream ois = new RenamingObjectInputStream(blobStream)) {
+				Object rawMessage = ois.readObject();
+
 			String key = getStringFieldOrNull(rs, getKeyField());
 			String cid = getStringFieldOrNull(rs, getCorrelationIdField());
 			String mid = getStringFieldOrNull(rs, getMessageIdField());
-			Object rawMessage = ois.readObject();
 
 			RawMessageWrapper<Serializable> rawMessageWrapper;
 			if (rawMessage instanceof RawMessageWrapper<?>) {

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -145,9 +145,9 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 			Object rawMessage = ois.readObject();
 
 			RawMessageWrapper<Serializable> rawMessageWrapper;
-			if (rawMessage instanceof MessageWrapper<?>) {
+			if (rawMessage instanceof RawMessageWrapper<?>) {
 				//noinspection unchecked
-				rawMessageWrapper = (MessageWrapper<Serializable>) rawMessage;
+				rawMessageWrapper = (RawMessageWrapper<Serializable>) rawMessage;
 			} else {
 				rawMessageWrapper = new RawMessageWrapper<>((Serializable) rawMessage, mid != null ? mid : key, cid);
 			}

--- a/test/src/main/configurations/JMS/Configuration.xml
+++ b/test/src/main/configurations/JMS/Configuration.xml
@@ -9,4 +9,5 @@
 	<Include ref="TestHighDeliveryCountWithEsbJmsListener.xml"/>
 	<Include ref="ConfigurationAwsSqsJmsListenerSender.xml"/>
 	<Include ref="ConfigurationPubSub.xml"/>
+	<Include ref="ConfigurationMessageStoreListeners.xml"/>
 </Configuration>

--- a/test/src/main/configurations/JMS/ConfigurationMessageStoreListeners.xml
+++ b/test/src/main/configurations/JMS/ConfigurationMessageStoreListeners.xml
@@ -1,0 +1,60 @@
+<Configuration>
+	<Module>
+		<Adapter name="MultipleReceiversAdapter" description="Used to retry messages using two EsbJmsListener and a MessageStoreListener" active="${active.jms}">
+			<Receiver name="localReceiver"
+				elementToMove="fileContent"
+				removeCompactMsgNamespaces="false"
+				maxRetries="0"
+				onError="RECOVER"
+				stopTimeout="600">
+				<JavaListener name="localListener"/>
+			</Receiver>
+
+			<Receiver name="receiver"
+				elementToMove="fileContent"
+				removeCompactMsgNamespaces="false"
+				transactionAttribute="Required"
+				maxRetries="0"
+				onError="RECOVER"
+				stopTimeout="600">
+
+				<EsbJmsListener name="esbListener"
+					destinationName="${jms.destination.i4testiaf_in}"
+					lookupDestination="false"
+					jmsRealm="qcf"
+					messageProtocol="FF"
+					messageSelector="SOURCE='${hostname}_multipleReceiver'" />
+
+				<JdbcErrorStorage name="errorStorage"
+					slotId="testSlot" />
+
+				<JdbcMessageLog name="messagelog"
+					slotId="testSlot"
+					retention="3" />
+			</Receiver>
+
+			<Receiver name="retryReceiver"
+				elementToMove="fileContent"
+				removeCompactMsgNamespaces="false"
+				transactionAttribute="Required"
+				maxRetries="0"
+				forceRetryFlag="true"
+				pollInterval="60">
+
+				<MessageStoreListener name="messageStoreListener"
+					datasourceName="${jdbc.datasource.default}"
+					slotId="testSlot"
+					statusValueInProcess="P" />
+			</Receiver>
+
+			<Pipeline firstPipe="EchoPipe">
+				<Exits>
+					<Exit name="EXIT" state="success" />
+				</Exits>
+				<EchoPipe name="EchoPipe" restoreMovedElements="true">
+					<forward name="success" path="EXIT" />
+				</EchoPipe>
+			</Pipeline>
+		</Adapter>
+	</Module>
+</Configuration>

--- a/test/src/test/testtool/MessageStoreSenderAndListener/scenario03/out-queue.xml
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/scenario03/out-queue.xml
@@ -15,7 +15,7 @@
   <rowset>
     <row number="0">
       <field name="MESSAGEKEY">768</field>
-      <field name="TYPE">M</field>
+      <field name="TYPE">A</field>
       <field name="SLOTID">TestMessageStoreSenderAndListener-Queue</field>
       <field name="HOST">LPZWNL000040524</field>
       <field name="MESSAGEID">1</field>

--- a/test/src/test/testtool/MessageStoreSenderAndListener/scenario03/out-queue.xml
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/scenario03/out-queue.xml
@@ -29,7 +29,7 @@
 		&lt;Message contentType="application/xml" encoding="UTF-8"&gt;test, with comma&lt;/Message&gt;
 	&lt;/Header&gt;
 &lt;/Envelope&gt;</field>
-      <field name="EXPIRYDATE" null="true"/>
+      <field name="EXPIRYDATE">2022-04-28 08:53:24</field>
       <field name="LABEL" null="true"/>
     </row>
   </rowset>


### PR DESCRIPTION
The storage id key was missing in the message context. This fix correctly sets the value so the retry won't fail while trying to convert a message key to a storage id (resulting in a NumberFormatException)