### PR TITLE
Fix broken parameter pattern substitution (#8561)

### DIFF
--- a/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
@@ -576,13 +576,21 @@ public abstract class AbstractParameter implements IConfigurable, IWithParameter
 
 			// get value
 			Object substitutionValue = getValueForFormatting(alreadyResolvedParameters, session, substitutionPattern);
-			params.add(substitutionValue);
+			if (substitutionValue instanceof Message substitutionMessage) {
+				try {
+					params.add(substitutionMessage.asString());
+				} catch (IOException e) {
+					throw new ParameterException(getName(), "Cannot convert substitution pattern ["+ substitutionPattern +"] from message to string", e);
+				}
+			} else {
+				params.add(substitutionValue);
+			}
 			formatPattern.append('{').append(paramPosition++);
 		}
 		try {
 			return MessageFormat.format(formatPattern.toString(), params.toArray());
 		} catch (Exception e) {
-			throw new ParameterException(getName(), "Cannot parse ["+formatPattern.toString()+"]", e);
+			throw new ParameterException(getName(), "Cannot parse ["+ formatPattern +"]", e);
 		}
 	}
 

--- a/core/src/test/java/org/frankframework/http/HttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/HttpSenderTest.java
@@ -306,6 +306,30 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 	}
 
 	@Test
+	public void simpleMockedHttpPostWithUrlPatternAndParametersFromSessionAndInput() throws Throwable {
+		sender = getSender(false);
+		sender.setMethodType(HttpMethod.POST);
+		Parameter urlParam = ParameterBuilder.create().withName("url").withPattern("http://127.0.0.1/my/rest-resource/{fromSession}/path/{fromInput}");
+		Parameter p1 = ParameterBuilder.create().withName("fromSession").withSessionKey("fromSession");
+		Parameter p2 = ParameterBuilder.create().withName("fromInput");
+		sender.addParameter(p1);
+		sender.addParameter(p2);
+		sender.addParameter(urlParam);
+
+		sender.setTreatInputMessageAsParameters(false);
+
+		sender.configure();
+		sender.start();
+
+		session.put("fromSession", "1");
+
+		Message input = new Message("2");
+
+		String result = sender.sendMessageOrThrow(input, session).asString();
+		assertEqualsIgnoreCRLF(getFile("simpleMockedHttpPostWithUrlPatternParam.txt"), result.trim());
+	}
+
+	@Test
 	public void simpleMockedHttpPostEncodeMessage() throws Throwable {
 		sender = getSender(false); //Cannot add headers (aka parameters) for this test!
 		Message input = new Message("hallo dit is mijn bericht");

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -125,6 +125,24 @@ public class ParameterTest {
 	}
 
 	@Test
+	public void testPatternSessionVariableValueIsMessage() throws ConfigurationException, ParameterException {
+		Parameter p = new Parameter();
+		p.setName("dummy");
+		p.setPattern("{sessionKey}");
+		p.configure();
+
+		PipeLineSession session = new PipeLineSession();
+		session.put("sessionKey", new Message("fakeSessionVariable"));
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+
+		assertEquals("fakeSessionVariable", p.getValue(alreadyResolvedParameters, null, session, false));
+
+		assertFalse(p.requiresInputValueForResolution());
+		assertTrue(p.consumesSessionVariable("sessionKey"));
+	}
+
+	@Test
 	public void testPatternParameter() throws ConfigurationException, ParameterException {
 		Parameter p = new Parameter();
 		p.setName("dummy");
@@ -141,6 +159,27 @@ public class ParameterTest {
 		alreadyResolvedParameters.add(new ParameterValue(siblingParameter, siblingParameter.getValue(alreadyResolvedParameters, null, session, false)));
 
 		assertEquals("fakeParameterValue", p.getValue(alreadyResolvedParameters, null, session, false));
+
+		assertFalse(p.requiresInputValueForResolution());
+	}
+
+	@Test
+	public void testPatternParameterWithMessageAsValue() throws ConfigurationException, ParameterException {
+		Parameter p = new Parameter();
+		p.setName("dummy");
+		p.setPattern("{siblingParameter}");
+		p.configure();
+
+		PipeLineSession session = new PipeLineSession();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Parameter siblingParameter = new Parameter();
+		siblingParameter.setName("siblingParameter");
+		siblingParameter.configure();
+		Message input = new Message("valueFromMessage");
+		alreadyResolvedParameters.add(new ParameterValue(siblingParameter, siblingParameter.getValue(alreadyResolvedParameters, input, session, false)));
+
+		assertEquals("valueFromMessage", p.getValue(alreadyResolvedParameters, null, session, false));
 
 		assertFalse(p.requiresInputValueForResolution());
 	}

--- a/core/src/test/java/org/frankframework/testutil/ParameterBuilder.java
+++ b/core/src/test/java/org/frankframework/testutil/ParameterBuilder.java
@@ -29,6 +29,11 @@ public class ParameterBuilder extends Parameter {
 		return this;
 	}
 
+	public ParameterBuilder withPattern(String pattern) {
+		setPattern(pattern);
+		return this;
+	}
+
 	public ParameterBuilder withSessionKey(String sessionKey) {
 		setSessionKey(sessionKey);
 		return this;

--- a/core/src/test/resources/Http/Responses/simpleMockedHttpPostWithUrlPatternParam.txt
+++ b/core/src/test/resources/Http/Responses/simpleMockedHttpPostWithUrlPatternParam.txt
@@ -1,0 +1,6 @@
+POST /my/rest-resource/1/path/2 HTTP/1.1
+Message-Id: testmessageac13ecb1--30fe9225_16caa708707_-7fb1
+Correlation-Id: testmessageac13ecb1--30fe9225_16caa708707_-7fb2
+Content-Type: text/html; charset=UTF-8
+
+fromSession=1&fromInput=2


### PR DESCRIPTION
Closes #8559 

(cherry picked from commit 53534586e11c0fc9f5c40de01cf56b40d23380a1)