### PR TITLE
Make the Resource Locator work with any type of prefix

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/datasource/FrankResource.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/FrankResource.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2024-2025 WeAreFrank!
+   Copyright 2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,25 +15,23 @@
 */
 package org.frankframework.jdbc.datasource;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Properties;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-
+import lombok.Getter;
 import lombok.Setter;
 
-public class FrankResources {
+@Getter @Setter
+public class FrankResource {
+	String name;
+	String type;
+	String url;
+	String authalias;
+	String username;
+	String password;
+	Properties properties;
 
-	private @Setter List<FrankResource> resources;
-
-	public @Nullable FrankResource findResource(@Nonnull String name) {
-		if (resources == null) {
-			return null; // No matching resources found.
-		}
-
-		Optional<FrankResource> optional = resources.stream().filter(e -> name.equals(e.getName())).findFirst();
-		return optional.orElse(null);
+	@Override
+	public String toString() {
+		return "FrankResource ["+ name+"]";
 	}
-
 }

--- a/core/src/main/java/org/frankframework/jdbc/datasource/FrankResources.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/FrankResources.java
@@ -16,7 +16,6 @@
 package org.frankframework.jdbc.datasource;
 
 import java.util.List;
-import java.util.Optional;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -32,8 +31,10 @@ public class FrankResources {
 			return null; // No matching resources found.
 		}
 
-		Optional<FrankResource> optional = resources.stream().filter(e -> name.equals(e.getName())).findFirst();
-		return optional.orElse(null);
+		return resources.stream()
+				.filter(e -> name.equals(e.getName()))
+				.findFirst()
+				.orElse(null);
 	}
 
 }

--- a/core/src/main/java/org/frankframework/jdbc/datasource/ObjectCreator.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/ObjectCreator.java
@@ -1,0 +1,149 @@
+/*
+   Copyright 2024-2025 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.jdbc.datasource;
+
+import java.lang.reflect.Method;
+import java.sql.Driver;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import org.frankframework.util.AppConstants;
+import org.frankframework.util.ClassUtils;
+import org.frankframework.util.CredentialFactory;
+import org.frankframework.util.StringResolver;
+import org.frankframework.util.StringUtil;
+
+public class ObjectCreator {
+
+	private static final AppConstants APP_CONSTANTS = AppConstants.getInstance();
+
+	@Nonnull
+	@SuppressWarnings("unchecked")
+	public <O> O instantiateResource(@Nonnull FrankResource resource, @Nullable Properties environment, @Nonnull Class<O> lookupClass) throws ClassNotFoundException {
+		if(StringUtils.isEmpty(resource.getUrl())) {
+			throw new IllegalStateException("field url is required");
+		}
+
+		Properties properties = getConnectionProperties(resource, environment);
+		String url = StringResolver.substVars(resource.getUrl(), APP_CONSTANTS);
+		String type = StringResolver.substVars(resource.getType(), APP_CONSTANTS);
+
+		Class<?> clazz = ClassUtils.loadClass(type);
+
+		if(lookupClass.isAssignableFrom(DataSource.class) && Driver.class.isAssignableFrom(clazz)) { // It's also possible to use the native drivers instead of the DataSources directly.
+			return (O) loadDataSourceThroughDriver(clazz, url, properties);
+		}
+
+		if(lookupClass.isAssignableFrom(clazz)) {
+			return (O) createInstance(clazz, url, properties);
+		}
+
+		throw new IllegalStateException("class is not of required type ["+type+"]");
+	}
+
+	/**
+	 * Ensure that the driver is loaded, else the DriverManagerDataSource can not load it.
+	 */
+	private DataSource loadDataSourceThroughDriver(Class<?> clazz, String url, Properties properties) {
+		DriverManagerDataSource dmds = new DriverManagerDataSource(url, properties);
+		dmds.setDriverClassName(clazz.getCanonicalName()); // Initialize the JDBC Driver
+		return dmds;
+	}
+
+	/**
+	 * Creates the class and populates available fields
+	 */
+	private <O> O createInstance(Class<O> clazz, String url, Properties properties) {
+		try {
+			O instance = clazz.getDeclaredConstructor().newInstance();
+
+			for(Method method: clazz.getMethods()) {
+				if(!method.getName().startsWith("set") || method.getParameterTypes().length != 1)
+					continue;
+
+				String fieldName = StringUtil.lcFirst(method.getName().substring(3));
+				String value = properties.getProperty(fieldName);
+
+				if("url".equalsIgnoreCase(fieldName) || "brokerURL".equals(fieldName)) { // Ensures the URL is always set, some drivers use upper case, others lower...
+					ClassUtils.invokeSetter(instance, method, url);
+				} else if(StringUtils.isNotEmpty(value)) {
+					ClassUtils.invokeSetter(instance, method, value);
+				}
+			}
+
+			return instance;
+		} catch (Exception e) {
+			throw new IllegalStateException("unable to create resource ["+clazz+"]", e);
+		}
+	}
+
+	/**
+	 * Combines the optional (supplied) environment, provided driver properties and resolved credentials.
+	 */
+	private Properties getConnectionProperties(FrankResource resource, Properties environment) {
+		Properties mergedProps = new Properties();
+		if(environment != null) {
+			mergedProps.putAll(environment);
+		}
+
+		Properties connProps = resource.getProperties();
+		if (connProps != null) {
+			for(Entry<Object, Object> entry : connProps.entrySet()) {
+				String key = String.valueOf(entry.getKey());
+				String value = String.valueOf(entry.getValue());
+				if(StringUtils.isNotEmpty(value)) {
+					mergedProps.setProperty(key, StringResolver.substVars(value, APP_CONSTANTS));
+				}
+			}
+		}
+		CredentialFactory cf = getCredentials(resource);
+		if(StringUtils.isNotEmpty(cf.getUsername())) {
+			mergedProps.setProperty("user", cf.getUsername());
+		}
+		if(StringUtils.isNotEmpty(cf.getPassword())) {
+			mergedProps.setProperty("password", cf.getPassword());
+		}
+		return mergedProps;
+	}
+
+	/**
+	 * Performs a 'safe' lookup of credentials.
+	 */
+	private CredentialFactory getCredentials(FrankResource resource) {
+		String alias = resource.getAuthalias();
+		if(StringUtils.isNotEmpty(alias)) {
+			alias = StringResolver.substVars(alias, APP_CONSTANTS);
+		}
+		String username = resource.getUsername();
+		if(StringUtils.isNotEmpty(username)) {
+			username = StringResolver.substVars(username, APP_CONSTANTS);
+		}
+		String password = resource.getPassword();
+		if(StringUtils.isNotEmpty(password)) {
+			password = StringResolver.substVars(password, APP_CONSTANTS);
+		}
+
+		return new CredentialFactory(alias, username, password);
+	}
+}

--- a/core/src/main/java/org/frankframework/jdbc/datasource/ObjectFactory.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/ObjectFactory.java
@@ -149,23 +149,25 @@ public abstract class ObjectFactory<O, P> implements InitializingBean, Disposabl
 	@Override
 	public void destroy() throws Exception {
 		Exception masterException=null;
-		for (Entry<String,O> entry:objects.entrySet()) {
+
+		for (Entry<String, O> entry : objects.entrySet()) {
 			final String name = entry.getKey();
 			if (entry.getValue() instanceof AutoCloseable closable) {
 				try {
 					log.debug("closing [{}] object [{}]", () -> ClassUtils.nameOf(closable), () -> name);
 					closable.close();
 				} catch (Exception e) {
-					if (masterException==null) {
-						masterException = new Exception("Exception caught closing ["+ClassUtils.nameOf(closable)+"] object ["+name+"] held by ("+getClass().getSimpleName()+")", e);
+					if (masterException == null) {
+						masterException = new Exception("Exception caught closing [" + ClassUtils.nameOf(closable) + "] object [" + name + "] held by (" + getClass().getSimpleName() + ")", e);
 					} else {
 						masterException.addSuppressed(e);
 					}
 				}
 			}
 		}
+
 		objects.clear();
-		if (masterException!=null) {
+		if (masterException != null) {
 			throw masterException;
 		}
 	}

--- a/core/src/main/java/org/frankframework/jdbc/datasource/ResourceObjectLocator.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/ResourceObjectLocator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2024 WeAreFrank!
+   Copyright 2024-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,10 +18,18 @@ package org.frankframework.jdbc.datasource;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.representer.Representer;
 
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
@@ -29,34 +37,74 @@ import lombok.extern.log4j.Log4j2;
 import org.frankframework.util.ClassUtils;
 import org.frankframework.util.StreamUtil;
 
+/**
+ * Class that look up a given resource in the resource file. By default `resources.yml`.
+ */
 @Log4j2
 public class ResourceObjectLocator implements IObjectLocator, InitializingBean {
 
-	private FrankResources resources = null;
+	private ObjectCreator objectCreator = new ObjectCreator();
+	private final ConcurrentSkipListMap<String, FrankResources> parsedFrankResources = new ConcurrentSkipListMap<>();
 	private @Setter String resourceFile = "resources.yml";
+	private URL resourceUrl;
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		URL url = ClassUtils.getResourceURL(resourceFile);
-		if(url == null) {
+		resourceUrl = ClassUtils.getResourceURL(resourceFile);
+		if(resourceUrl == null) {
 			log.info("did not find [{}] skipping resource based object lookups", resourceFile);
 			return;
 		}
 
-		try(InputStream is = url.openStream(); Reader reader = StreamUtil.getCharsetDetectingInputStreamReader(is)) {
-			Yaml yaml = new Yaml();
-			resources = yaml.loadAs(reader, FrankResources.class);
+		// pre-fill cache with known entries such as JDBC and JMS connections
+		getResources("jdbc");
+		getResources("jms");
+	}
+
+	@Nonnull
+	private FrankResources getResources(String prefix) {
+		return parsedFrankResources.computeIfAbsent(prefix, this::parseResourcesForPrefix);
+	}
+
+	/**
+	 * Reads the resource file, skips all root elements except for the given prefix.
+	 */
+	@Nonnull
+	private FrankResources parseResourcesForPrefix(String prefix) {
+		try(InputStream is = resourceUrl.openStream(); Reader reader = StreamUtil.getCharsetDetectingInputStreamReader(is)) {
+			Representer represent = new Representer(new DumperOptions());
+			represent.getPropertyUtils().setSkipMissingProperties(true);
+			Yaml yaml = new Yaml(represent, new DumperOptions());
+			TypeDescription typeDescription = new TypeDescription(FrankResources.class);
+
+			// Bind the prefix to the resource list.
+			typeDescription.substituteProperty(prefix, List.class, null, "setResources", FrankResource.class);
+			yaml.addTypeDescription(typeDescription);
+			return yaml.loadAs(reader, FrankResources.class);
 		} catch (Exception e) {
 			throw new IllegalStateException("unable to parse [" + resourceFile + "]", e);
 		}
 	}
 
-	@Override
-	public <O> O lookup(String name, Properties environment, Class<O> lookupClass) throws Exception {
-		if(resources == null) {
-			return null;
+	@Nullable
+	private FrankResource findFrankResource(String name) {
+		int slashPos = name.indexOf('/');
+		String prefix = name.substring(0, slashPos);
+		String resourceName = name.substring(slashPos + 1);
+		if (slashPos == -1) {
+			throw new IllegalStateException("no resource prefix found");
 		}
 
-		return resources.lookup(name, environment, lookupClass);
+		return getResources(prefix).findResource(resourceName);
+	}
+
+	@Override
+	public <O> O lookup(String name, Properties environment, Class<O> lookupClass) throws Exception {
+		FrankResource resource = findFrankResource(name);
+		if(resource == null) {
+			return null; // If the lookup returns null, fail-fast to allow other ResourceFactories to locate the object.
+		}
+
+		return objectCreator.instantiateResource(resource, environment, lookupClass);
 	}
 }

--- a/core/src/main/java/org/frankframework/jdbc/datasource/ResourceObjectLocator.java
+++ b/core/src/main/java/org/frankframework/jdbc/datasource/ResourceObjectLocator.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.TypeDescription;
@@ -88,6 +89,9 @@ public class ResourceObjectLocator implements IObjectLocator, InitializingBean {
 
 	@Nullable
 	private FrankResource findFrankResource(String name) {
+		if (StringUtils.isBlank(name)) {
+			throw new IllegalStateException("invalid resource defined");
+		}
 		int slashPos = name.indexOf('/');
 		String prefix = name.substring(0, slashPos);
 		String resourceName = name.substring(slashPos + 1);
@@ -100,8 +104,14 @@ public class ResourceObjectLocator implements IObjectLocator, InitializingBean {
 
 	@Override
 	public <O> O lookup(String name, Properties environment, Class<O> lookupClass) throws Exception {
+		if (resourceUrl == null) {
+			log.debug("resource locator is not configured, skip lookup");
+			return null;
+		}
+
 		FrankResource resource = findFrankResource(name);
 		if(resource == null) {
+			log.debug("no resource found for name [{}]", name);
 			return null; // If the lookup returns null, fail-fast to allow other ResourceFactories to locate the object.
 		}
 

--- a/core/src/main/java/org/frankframework/jndi/JndiObjectLocator.java
+++ b/core/src/main/java/org/frankframework/jndi/JndiObjectLocator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021-2024 WeAreFrank!
+   Copyright 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ import org.frankframework.jdbc.datasource.IObjectLocator;
 import org.frankframework.util.ClassUtils;
 
 /**
- * Baseclass for JDNI lookups.
- * Would be nice if we could have used JndiObjectFactoryBean but it has too much overhead
+ * Class that does the actual JDNI lookup.
  *
  * @author Niels Meijer
  *
@@ -55,8 +54,8 @@ public class JndiObjectLocator implements IObjectLocator, ApplicationContextAwar
 		JndiTemplate locator = new JndiTemplate(jndiEnvironment);
 		try {
 			return locator.lookup(prefixedJndiName, lookupClass);
-		} catch (NameNotFoundException e) { //Fallback and search again but this time without prefix
-			if (!jndiName.equals(prefixedJndiName)) { //But only if a prefix was used during the first lookup.
+		} catch (NameNotFoundException e) { // Fallback and search again but this time without prefix
+			if (!jndiName.equals(prefixedJndiName)) { // But only if a prefix was used during the first lookup.
 				log.debug("prefixed JNDI name [{}] not found - trying original name [{}], exception: ({}): {}", ()->prefixedJndiName, ()->jndiName, ()->ClassUtils.nameOf(e), e::getMessage);
 				try {
 					return locator.lookup(jndiName, lookupClass);
@@ -64,7 +63,7 @@ public class JndiObjectLocator implements IObjectLocator, ApplicationContextAwar
 					log.debug("non-prefixed JNDI name [{}] not found, exception: ({}): {}", ()->jndiName, ()->ClassUtils.nameOf(e2), e2::getMessage);
 				}
 			}
-			return null; //Neither lookup returned an (unexpected) exception, assume the object cannot be found in this IObjectLocator.
+			return null; // Neither lookup returned an (unexpected) exception, assume the object cannot be found in this IObjectLocator.
 		}
 	}
 

--- a/core/src/test/java/org/frankframework/jdbc/datasource/ResourceObjectLocatorTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/datasource/ResourceObjectLocatorTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 public class ResourceObjectLocatorTest {
 
@@ -36,5 +38,26 @@ public class ResourceObjectLocatorTest {
 
 		Object obj = locator.lookup("idonotexist/qwerty", null, Object.class);
 		assertNull(obj);
+	}
+
+	@Test
+	public void testNonInitializedLocator() throws Exception {
+		ResourceObjectLocator locator = new ResourceObjectLocator();
+		locator.setResourceFile("blaat");
+		locator.afterPropertiesSet();
+
+		Object obj = locator.lookup("idonotexist/qwerty", null, Object.class);
+		assertNull(obj);
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	public void validEmptyLookup(String lookupString) throws Exception {
+		ResourceObjectLocator locator = new ResourceObjectLocator();
+		locator.setResourceFile("ResourceLocator/validResources.yml");
+		locator.afterPropertiesSet();
+
+		IllegalStateException e = assertThrows(IllegalStateException.class, () -> locator.lookup(lookupString, null, Object.class));
+		assertTrue(e.getMessage().contains("invalid resource"));
 	}
 }

--- a/core/src/test/java/org/frankframework/jdbc/datasource/ResourceObjectLocatorTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/datasource/ResourceObjectLocatorTest.java
@@ -1,6 +1,7 @@
 package org.frankframework.jdbc.datasource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,5 +26,15 @@ public class ResourceObjectLocatorTest {
 
 		IllegalStateException e = assertThrows(IllegalStateException.class, locator::afterPropertiesSet);
 		assertTrue(e.getMessage().contains("[ResourceLocator/invalidResources.yml]"));
+	}
+
+	@Test
+	public void testNonExistingPrefix() throws Exception {
+		ResourceObjectLocator locator = new ResourceObjectLocator();
+		locator.setResourceFile("ResourceLocator/validResources.yml");
+		locator.afterPropertiesSet();
+
+		Object obj = locator.lookup("idonotexist/qwerty", null, Object.class);
+		assertNull(obj);
 	}
 }

--- a/core/src/test/resources/ResourceLocator/validResources.yml
+++ b/core/src/test/resources/ResourceLocator/validResources.yml
@@ -2,3 +2,10 @@ jdbc:
   - name: "H2"
     type: "org.h2.jdbcx.JdbcDataSource"
     url: "jdbc:h2:mem:test;NON_KEYWORDS=VALUE;TRACE_LEVEL_FILE=0;"
+jms:
+  - name: "im-a-QueueConnectionFactory"
+    type: "jakarta.jms.ConnectionFactory"
+    url: "jms:abc:mem:tralala;propert"
+ldap:
+  - name: "company-ldap"
+    url: "ldaps://comp.org/"


### PR DESCRIPTION
We used to keep a list of predefined resources that could be located via the ResourceLocator.
This allows any lookup-prefix to be used, which allows ObjectFactories to be dynamically loaded.