### PR TITLE
Remove JMS dependency from ReceiverTest

### DIFF
--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -1829,7 +1829,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	 * Suspend the receiver for {@code delayTimeInSeconds} seconds
 	 * @param delayTimeInSeconds Number of seconds the receiver thread should be suspended from processing new messages.
 	 */
-	protected void suspendReceiverThread(int delayTimeInSeconds) {
+	public void suspendReceiverThread(int delayTimeInSeconds) {
 		int currentInterval = delayTimeInSeconds;
 		while (isInRunState(RunState.STARTED) && currentInterval-- > 0) {
 			try {

--- a/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
+++ b/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
@@ -1,0 +1,310 @@
+package org.frankframework.jms;
+
+import static org.awaitility.Awaitility.await;
+import static org.frankframework.testutil.mock.WaitUtils.waitForState;
+import static org.frankframework.testutil.mock.WaitUtils.waitWhileInState;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.jms.Destination;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.core.Adapter;
+import org.frankframework.core.IListener;
+import org.frankframework.core.IListenerConnector;
+import org.frankframework.core.PipeLine;
+import org.frankframework.core.PipeLineExit;
+import org.frankframework.core.PipeLineResult;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.management.Action;
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.receivers.RawMessageWrapper;
+import org.frankframework.receivers.Receiver;
+import org.frankframework.testutil.TestConfiguration;
+import org.frankframework.testutil.TransactionManagerType;
+import org.frankframework.util.RunState;
+
+@Log4j2
+public class PushingJmsListenerTest {
+	private TestConfiguration configuration;
+	private String adapterName;
+
+
+	@BeforeEach
+	public void beforeEach(TestInfo testInfo) {
+		adapterName = testInfo.getDisplayName().replace('/', '_');
+	}
+
+	private static TestConfiguration buildConfiguration(TransactionManagerType txManagerType) {
+		TestConfiguration configuration;
+		if (txManagerType != null) {
+			configuration = txManagerType.create(false);
+		} else {
+			configuration = new TestConfiguration(false);
+		}
+
+		log.info("!Configuration Context for [{}] has been created.", txManagerType);
+		return configuration;
+	}
+
+	private void createMessagingSource(PushingJmsListener listener) throws NoSuchFieldException, IllegalAccessException {
+		Field messagingSourceField = JMSFacade.class.getDeclaredField("messagingSource");
+		messagingSourceField.setAccessible(true);
+		MessagingSource messagingSource = mock(MessagingSource.class);
+		messagingSourceField.set(listener, messagingSource);
+	}
+
+	protected SlowListenerWithPollGuard createSlowListenerWithPollGuard(int startupDelay, int shutdownDelay) {
+		SlowListenerWithPollGuard listener = configuration.createBean(SlowListenerWithPollGuard.class);
+		listener.setStartupDelay(startupDelay);
+		listener.setShutdownDelay(shutdownDelay);
+		return listener;
+	}
+
+	public <M> Receiver<M> setupReceiver(IListener<M> listener) {
+		@SuppressWarnings("unchecked")
+		Receiver<M> receiver = spy(configuration.createBean(Receiver.class));
+		receiver.setListener(listener);
+		receiver.setName("receiver");
+		receiver.setStartTimeout(2);
+		receiver.setStopTimeout(2);
+		// To speed up test, we don't actually sleep
+		doNothing().when(receiver).suspendReceiverThread(anyInt());
+		return receiver;
+	}
+
+	public <M> Adapter setupAdapter(Receiver<M> receiver) throws Exception {
+		return setupAdapter(receiver, PipeLine.ExitState.SUCCESS);
+	}
+
+	public <M> Adapter setupAdapter(Receiver<M> receiver, PipeLine.ExitState exitState) throws Exception {
+		Adapter adapter = spy(configuration.createBean(Adapter.class));
+		adapter.setName(adapterName);
+
+		PipeLine pl = spy(configuration.createBean(PipeLine.class));
+		doAnswer(p -> {
+			PipeLineResult plr = new PipeLineResult();
+			plr.setState(exitState);
+			plr.setResult(p.getArgument(1));
+			return plr;
+		}).when(pl).process(anyString(), any(org.frankframework.stream.Message.class), any(PipeLineSession.class));
+		pl.setFirstPipe("dummy");
+
+		EchoPipe pipe = new EchoPipe();
+		pipe.setName("dummy");
+		pl.addPipe(pipe);
+
+		PipeLineExit ple = new PipeLineExit();
+		ple.setName("success");
+		ple.setState(exitState);
+		pl.addPipeLineExit(ple);
+		adapter.setPipeLine(pl);
+
+		adapter.addReceiver(receiver);
+		configuration.addAdapter(adapter);
+		return adapter;
+	}
+
+	@Test
+	void testJmsMessageWithExceptionUntransactedAckModeClientShouldAckMsgWhenRejected() throws Exception {
+		// TODO: This test should be moved to JMS module, since it tests some JMS Listener specific features and not a receiver specific feature
+		// Arrange
+		configuration = buildConfiguration(TransactionManagerType.DATASOURCE);
+		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));
+		listener.setTransacted(false);
+		listener.setAcknowledgeMode(JMSFacade.AcknowledgeMode.CLIENT_ACKNOWLEDGE);
+		doReturn(mock(Destination.class)).when(listener).getDestination();
+		doNothing().when(listener).start();
+		doNothing().when(listener).configure();
+
+		createMessagingSource(listener);
+
+		@SuppressWarnings("unchecked")
+		IListenerConnector<Message> jmsConnectorMock = mock(IListenerConnector.class);
+		listener.setJmsConnector(jmsConnectorMock);
+		Receiver<Message> receiver = setupReceiver(listener);
+		receiver.setMaxRetries(1);
+
+		Adapter adapter = setupAdapter(receiver, PipeLine.ExitState.ERROR);
+
+		assertEquals(RunState.STOPPED, adapter.getRunState());
+		assertEquals(RunState.STOPPED, receiver.getRunState());
+
+		// start adapter
+		configuration.configure();
+		configuration.start();
+
+		waitWhileInState(adapter, RunState.STOPPED);
+		waitWhileInState(adapter, RunState.STARTING);
+
+		TextMessage jmsMessage = mock(TextMessage.class);
+		doReturn("dummy-message-id").when(jmsMessage).getJMSMessageID();
+		doAnswer(invocation -> receiver.getMaxRetries() + 2).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		doReturn(Collections.emptyEnumeration()).when(jmsMessage).getPropertyNames();
+		doReturn("message").when(jmsMessage).getText();
+		RawMessageWrapper<Message> messageWrapper = new RawMessageWrapper<>(jmsMessage, "dummy-message-id", "dummy-cid");
+
+		final Semaphore semaphore = new Semaphore(0);
+		Thread mockListenerThread = new Thread("mock-listener-thread") {
+			@Override
+			public void run() {
+				try (PipeLineSession session = new PipeLineSession()) {
+					receiver.processRawMessage(listener, messageWrapper, session, false);
+				} catch (Exception e) {
+					log.warn("Caught exception in Receiver:", e);
+				} finally {
+					semaphore.release();
+				}
+			}
+		};
+
+		// Act
+		mockListenerThread.start();
+		semaphore.acquire(); // Wait until thread is finished.
+
+		// Assert
+		verify(jmsMessage, atLeastOnce()).acknowledge();
+	}
+
+
+	@Test
+	public void testPollGuardStartTimeout() throws Exception {
+		// TODO: This test should test the actual PullingJmsListener with SpringJmsConnector
+		// Arrange
+		configuration = buildConfiguration(TransactionManagerType.NARAYANA);
+
+		// Create listener without any delays in starting or stopping, they will be set later
+		SlowListenerWithPollGuard listener = createSlowListenerWithPollGuard(0, 0);
+		listener.setPollGuardInterval(1_000);
+		listener.setMockLastPollDelayMs(10_000); // Last Poll always before PollGuard triggered
+
+		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Adapter adapter = setupAdapter(receiver);
+
+		assertEquals(RunState.STOPPED, adapter.getRunState());
+		assertEquals(RunState.STOPPED, receiver.getRunState());
+
+		// start adapter
+		configuration.configure();
+		configuration.start();
+
+		waitWhileInState(adapter, RunState.STOPPED);
+		waitWhileInState(adapter, RunState.STARTING);
+
+		log.info("Adapter RunState: {}", adapter.getRunState());
+		log.info("Receiver RunState: {}", receiver.getRunState());
+		assertEquals(RunState.STARTED, adapter.getRunState());
+
+		waitForState(receiver, RunState.STARTED); // Don't continue until the receiver has been started.
+
+		// Act
+		// From here the PollGuard should be triggering startup-delay timeout-guard
+		listener.setStartupDelay(100_000);
+
+		log.warn("Test sleeping to let poll guard timer run and do its work for a while");
+		await().atMost(5, TimeUnit.SECONDS)
+				.until(receiver::getRunState, equalTo(RunState.EXCEPTION_STARTING));
+
+		// Assert
+		assertEquals(RunState.EXCEPTION_STARTING, receiver.getRunState());
+
+		List<String> errors = new ArrayList<>(adapter.getMessageKeeper())
+				.stream()
+				.filter(msg -> msg != null && "ERROR".equals(msg.getMessageLevel()))
+				.map(Object::toString)
+				.toList();
+
+		assertThat(errors, hasItem(containsString("Failed to restart receiver")));
+
+		// After
+		configuration.getIbisManager().handleAction(Action.STOPRECEIVER, configuration.getName(), adapter.getName(), receiver.getName(), null, true);
+
+		waitWhileInState(receiver, RunState.STARTED);
+		waitWhileInState(receiver, RunState.STOPPING);
+		log.info("Receiver RunState: {}", receiver.getRunState());
+
+		assertEquals(RunState.STOPPED, receiver.getRunState());
+	}
+
+	@Test
+	public void testPollGuardStopTimeout() throws Exception {
+		// TODO: This test should test the actual PullingJmsListener with SpringJmsConnector
+		configuration = buildConfiguration(TransactionManagerType.NARAYANA);
+		// Create listener without any delays in starting or stopping, they will be set later
+		SlowListenerWithPollGuard listener = createSlowListenerWithPollGuard(0, 0);
+		listener.setPollGuardInterval(1_000);
+		listener.setMockLastPollDelayMs(10_000); // Last Poll always before PollGuard triggered
+
+		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Adapter adapter = setupAdapter(receiver);
+
+		assertEquals(RunState.STOPPED, adapter.getRunState());
+		assertEquals(RunState.STOPPED, receiver.getRunState());
+
+		// start adapter
+		configuration.configure();
+		configuration.start();
+
+		waitWhileInState(adapter, RunState.STOPPED);
+		waitWhileInState(adapter, RunState.STARTING);
+
+		log.info("Adapter RunState: {}", adapter.getRunState());
+		log.info("Receiver RunState: {}", receiver.getRunState());
+		assertEquals(RunState.STARTED, adapter.getRunState());
+
+		waitForState(receiver, RunState.STARTED); // Don't continue until the receiver has been started.
+
+		// From here the PollGuard should be triggering stop-delay timeout-guard
+		listener.setShutdownDelay(100_000);
+
+//		log.warn("Test sleeping to let poll guard timer run and do its work for a while");
+//		Thread.sleep(5_000);
+//		log.warn("Test resuming");
+
+		// Receiver may be in state "stopping" (by PollGuard) or in state "starting" while we come out of sleep, so wait until it's started
+		waitForState(receiver, RunState.STARTED);
+
+		configuration.getIbisManager().handleAction(Action.STOPRECEIVER, configuration.getName(), adapter.getName(), receiver.getName(), null, true);
+
+		waitWhileInState(receiver, RunState.STARTED);
+		waitWhileInState(receiver, RunState.STOPPING);
+		log.info("Receiver RunState: {}", receiver.getRunState());
+
+		assertEquals(RunState.EXCEPTION_STOPPING, receiver.getRunState());
+
+		List<String> warnings = new ArrayList<>(adapter.getMessageKeeper())
+				.stream()
+				.filter(msg -> msg != null && "WARN".equals(msg.getMessageLevel()))
+				.map(Object::toString)
+				.toList();
+		assertThat(warnings, everyItem(containsString("JMS poll timeout")));
+	}
+}

--- a/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
+++ b/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
@@ -135,7 +135,6 @@ public class PushingJmsListenerTest {
 
 	@Test
 	void testJmsMessageWithExceptionUntransactedAckModeClientShouldAckMsgWhenRejected() throws Exception {
-		// TODO: This test should be moved to JMS module, since it tests some JMS Listener specific features and not a receiver specific feature
 		// Arrange
 		configuration = buildConfiguration(TransactionManagerType.DATASOURCE);
 		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));

--- a/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
+++ b/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
@@ -73,7 +73,7 @@ public class PushingJmsListenerTest {
 			configuration = new TestConfiguration(false);
 		}
 
-		log.info("!Configuration Context for [{}] has been created.", txManagerType);
+		log.info("Configuration Context for [{}] has been created.", txManagerType);
 		return configuration;
 	}
 

--- a/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
+++ b/core/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
@@ -32,6 +32,7 @@ import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -52,6 +53,7 @@ import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TransactionManagerType;
 import org.frankframework.util.RunState;
 
+@Tag("slow")
 @Log4j2
 public class PushingJmsListenerTest {
 	private TestConfiguration configuration;

--- a/core/src/test/java/org/frankframework/jms/SlowListenerWithPollGuard.java
+++ b/core/src/test/java/org/frankframework/jms/SlowListenerWithPollGuard.java
@@ -1,4 +1,4 @@
-package org.frankframework.receivers;
+package org.frankframework.jms;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -24,6 +24,8 @@ import org.frankframework.core.IPushingListener;
 import org.frankframework.core.IbisExceptionListener;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.receivers.RawMessageWrapper;
+import org.frankframework.receivers.Receiver;
 import org.frankframework.unmanaged.PollGuard;
 import org.frankframework.unmanaged.SpringJmsConnector;
 

--- a/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
@@ -2,6 +2,7 @@ package org.frankframework.receivers;
 
 import lombok.Setter;
 
+import org.frankframework.core.IKnowsDeliveryCount;
 import org.frankframework.core.IMessageHandler;
 import org.frankframework.core.IPushingListener;
 import org.frankframework.core.IbisExceptionListener;
@@ -9,9 +10,10 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
 
-public class MockPushingListener extends MockListenerBase implements IPushingListener<String> {
+public class MockPushingListener extends MockListenerBase implements IPushingListener<String>, IKnowsDeliveryCount<String> {
 	private @Setter IMessageHandler<String> handler;
 	private @Setter IbisExceptionListener exceptionListener;
+	private @Setter int mockedDeliveryCount;
 
 	@Override
 	public void offerMessage(String text) throws ListenerException {
@@ -24,5 +26,10 @@ public class MockPushingListener extends MockListenerBase implements IPushingLis
 	@Override
 	public RawMessageWrapper<String> wrapRawMessage(String rawMessage, PipeLineSession session) {
 		return new RawMessageWrapper<>(rawMessage, session.getMessageId(), session.getCorrelationId());
+	}
+
+	@Override
+	public int getDeliveryCount(RawMessageWrapper<String> rawMessage) {
+		return mockedDeliveryCount;
 	}
 }

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -285,7 +285,7 @@ public class ReceiverTest {
 			configuration = new TestConfiguration(false);
 		}
 
-		log.info("!Configuration Context for [{}] has been created.", txManagerType);
+		log.info("Configuration Context for [{}] has been created.", txManagerType);
 		return configuration;
 	}
 

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -65,7 +65,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import jakarta.jms.Destination;
-import jakarta.jms.JMSException;
 import jakarta.jms.TextMessage;
 
 import org.apache.logging.log4j.Logger;
@@ -138,7 +137,6 @@ import org.frankframework.testutil.TestAppender;
 import org.frankframework.testutil.TestAssertions;
 import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TransactionManagerType;
-import org.frankframework.testutil.mock.ConnectionFactoryFactoryMock;
 import org.frankframework.testutil.mock.DataSourceFactoryMock;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.RunState;
@@ -189,6 +187,13 @@ public class ReceiverTest {
 
 	protected <T extends SlowListenerBase> T createSlowListener(Class<T> cls, int startupDelay, int shutdownDelay) {
 		T listener = configuration.createBean(cls);
+		listener.setStartupDelay(startupDelay);
+		listener.setShutdownDelay(shutdownDelay);
+		return listener;
+	}
+
+	protected SlowListenerWithPollGuard createSlowListenerWithPollGuard(int startupDelay, int shutdownDelay) {
+		SlowListenerWithPollGuard listener = configuration.createBean(SlowListenerWithPollGuard.class);
 		listener.setStartupDelay(startupDelay);
 		listener.setShutdownDelay(shutdownDelay);
 		return listener;
@@ -308,23 +313,16 @@ public class ReceiverTest {
 
 	@ParameterizedTest
 	@MethodSource("transactionManagers")
-	void testJmsMessageWithHighDeliveryCount(Supplier<TestConfiguration> configurationSupplier) throws Exception {
+	void testMessageWithHighDeliveryCount(Supplier<TestConfiguration> configurationSupplier) throws Exception {
 		// Arrange
 		configuration = configurationSupplier.get();
-		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));
-		doReturn(mock(Destination.class)).when(listener).getDestination();
+		MockPushingListener listener = spy(configuration.createBean(MockPushingListener.class));
 		doNothing().when(listener).start();
 		doNothing().when(listener).configure();
 
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> errorStorage = mock(ITransactionalStorage.class);
-
-		createMessagingSource(listener);
-
-		@SuppressWarnings("unchecked")
-		IListenerConnector<jakarta.jms.Message> jmsConnectorMock = mock(IListenerConnector.class);
-		listener.setJmsConnector(jmsConnectorMock);
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		receiver.setErrorStorage(errorStorage);
 
 		final PlatformTransactionManager txManager = configuration.getBean("txManagerReal", PlatformTransactionManager.class);
@@ -344,13 +342,8 @@ public class ReceiverTest {
 		waitWhileInState(adapter, RunState.STOPPED);
 		waitWhileInState(adapter, RunState.STARTING);
 
-		TextMessage jmsMessage = mock(TextMessage.class);
-		doReturn("dummy-message-id").when(jmsMessage).getJMSMessageID();
-		doReturn(receiver.getMaxRetries() + 2).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
-		doReturn(Collections.emptyEnumeration()).when(jmsMessage).getPropertyNames();
-		doReturn("message").when(jmsMessage).getText();
-		RawMessageWrapper<jakarta.jms.Message> messageWrapper = new RawMessageWrapper<>(jmsMessage, "dummy-message-id", "dummy-cid");
-
+		RawMessageWrapper<String> messageWrapper = new RawMessageWrapper<>("dummy-message", "dummy-message-id", "dummy-cid");
+		listener.setMockedDeliveryCount(receiver.getMaxRetries() + 2);
 
 		final int NR_TIMES_MESSAGE_OFFERED = 5;
 		final AtomicInteger rolledBackTXCounter = new AtomicInteger();
@@ -436,24 +429,17 @@ public class ReceiverTest {
 
 	@ParameterizedTest
 	@MethodSource("transactionManagers")
-	void testJmsMessageWithException(Supplier<TestConfiguration> configurationSupplier) throws Exception {
+	void testMessageWithException(Supplier<TestConfiguration> configurationSupplier) throws Exception {
 		// Arrange
 		configuration = configurationSupplier.get();
-		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));
-		doReturn(mock(Destination.class)).when(listener).getDestination();
-		doNothing().when(listener).start();
-		doNothing().when(listener).configure();
+		MockPushingListener listener = spy(configuration.createBean(MockPushingListener.class));
 
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> errorStorage = mock(ITransactionalStorage.class);
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> messageLog = mock(ITransactionalStorage.class);
-		createMessagingSource(listener);
 
-		@SuppressWarnings("unchecked")
-		IListenerConnector<jakarta.jms.Message> jmsConnectorMock = mock(IListenerConnector.class);
-		listener.setJmsConnector(jmsConnectorMock);
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		receiver.setErrorStorage(errorStorage);
 		receiver.setMessageLog(messageLog);
 
@@ -487,12 +473,7 @@ public class ReceiverTest {
 		final AtomicInteger processedNoException = new AtomicInteger();
 		final AtomicInteger txNotCompletedAfterReceiverEnds = new AtomicInteger();
 
-		TextMessage jmsMessage = mock(TextMessage.class);
-		doReturn("dummy-message-id").when(jmsMessage).getJMSMessageID();
-		doReturn(Collections.emptyEnumeration()).when(jmsMessage).getPropertyNames();
-		doReturn("message").when(jmsMessage).getText();
-
-		RawMessageWrapper<jakarta.jms.Message> messageWrapper = new RawMessageWrapper<>(jmsMessage, "dummy-message-id", "dummy-cid");
+		RawMessageWrapper<String> messageWrapper = new RawMessageWrapper<>("message", "dummy-message-id", "dummy-cid");
 
 		ArgumentCaptor<String> messageIdCaptor = forClass(String.class);
 		ArgumentCaptor<String> correlationIdCaptor = forClass(String.class);
@@ -506,7 +487,7 @@ public class ReceiverTest {
 					int nrTries = 0;
 					while (nrTries++ < MAX_NR_TIMES_MESSAGE_OFFERED && movedToErrorStorage.get() == 0) {
 						final int deliveryCount = nrTries;
-						doAnswer(invocation -> deliveryCount).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+						listener.setMockedDeliveryCount(deliveryCount);
 
 						LOG.info("Nr tries: {}, Nr rolled back transactions: {}, delivery count: {}", nrTries, rolledBackTXCounter.get(), receiver.getDeliveryCount(messageWrapper));
 						final TransactionStatus tx = txManager.getTransaction(TX_REQUIRES_NEW);
@@ -541,7 +522,7 @@ public class ReceiverTest {
 							}
 						}
 					}
-				} catch (SenderException | IllegalArgumentException | JMSException e) {
+				} catch (SenderException | IllegalArgumentException e) {
 					throw Lombok.sneakyThrow(e);
 				} finally {
 					semaphore.release();
@@ -575,6 +556,7 @@ public class ReceiverTest {
 
 	@Test
 	void testJmsMessageWithExceptionUntransactedAckModeClientShouldAckMsgWhenRejected() throws Exception {
+		// TODO: This test should be moved to JMS module, since it tests some JMS Listener specific features and not a receiver specific feature
 		// Arrange
 		configuration = buildDataSourceTransactionManagerConfiguration();
 		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));
@@ -694,30 +676,17 @@ public class ReceiverTest {
 	}
 
 	@Test
-	void testGetDeliveryCountWithJmsListener() throws Exception {
+	void testGetDeliveryCountWithListenerThatKnowsDeliveryCount() throws Exception {
 		// Arrange
 		configuration = buildDataSourceTransactionManagerConfiguration();
-		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));
-		doReturn(mock(Destination.class)).when(listener).getDestination();
-		doNothing().when(listener).start();
+		MockPushingListener listener = spy(configuration.createBean(MockPushingListener.class));
 
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> errorStorage = mock(ITransactionalStorage.class);
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> messageLog = mock(ITransactionalStorage.class);
 
-		createMessagingSource(listener);
-
-		@SuppressWarnings("unchecked")
-		IListenerConnector<jakarta.jms.Message> jmsConnectorMock = mock(IListenerConnector.class);
-		listener.setJmsConnector(jmsConnectorMock);
-		ConnectionFactoryFactoryMock connectionFactoryFactoryMock = new ConnectionFactoryFactoryMock();
-		listener.setConnectionFactoryFactory(connectionFactoryFactoryMock);
-		listener.setQueueConnectionFactoryName(ConnectionFactoryFactoryMock.MOCK_CONNECTION_FACTORY_NAME);
-		listener.setDestinationName("jms/dest_fake");
-		listener.setLookupDestination(false);
-
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		receiver.setErrorStorage(errorStorage);
 		receiver.setMessageLog(messageLog);
 		receiver.configure();
@@ -725,14 +694,9 @@ public class ReceiverTest {
 		// Should have 3 retries with JMS listeners
 		assertEquals(3, receiver.getMaxRetries());
 
-		TextMessage jmsMessage = mock(TextMessage.class);
-		doReturn("dummy-message-id").when(jmsMessage).getJMSMessageID();
-		doReturn(Collections.emptyEnumeration()).when(jmsMessage).getPropertyNames();
-		doReturn("message").when(jmsMessage).getText();
-		RawMessageWrapper<jakarta.jms.Message> rawMessage = new RawMessageWrapper<>(jmsMessage, "dummy-message-id", "dummy-cid");
-		MessageWrapper<jakarta.jms.Message> messageWrapper = new MessageWrapper<>(rawMessage, Message.nullMessage());
-
-		doAnswer(invocation -> 5).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		RawMessageWrapper<String> rawMessage = new RawMessageWrapper<>("message", "dummy-message-id", "dummy-cid");
+		MessageWrapper<String> messageWrapper = new MessageWrapper<>(rawMessage, Message.nullMessage());
+		listener.setMockedDeliveryCount(5);
 
 		// Act / Assert
 		assertAll(
@@ -741,7 +705,7 @@ public class ReceiverTest {
 				()-> assertTrue(receiver.isDeliveryRetryLimitExceededAfterMessageProcessed(messageWrapper))
 		);
 
-		doAnswer(invocation -> receiver.getMaxRetries()).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		listener.setMockedDeliveryCount(receiver.getMaxRetries());
 		receiver.updateMessageReceiveCount(messageWrapper);
 
 		assertAll(
@@ -749,7 +713,7 @@ public class ReceiverTest {
 				()-> assertFalse(receiver.isDeliveryRetryLimitExceededAfterMessageProcessed(messageWrapper))
 		);
 
-		doAnswer(invocation -> receiver.getMaxRetries()-1).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		listener.setMockedDeliveryCount(receiver.getMaxRetries() - 1);
 		receiver.updateMessageReceiveCount(messageWrapper);
 
 		assertAll(
@@ -757,7 +721,7 @@ public class ReceiverTest {
 				()-> assertFalse(receiver.isDeliveryRetryLimitExceededAfterMessageProcessed(messageWrapper))
 		);
 
-		doAnswer(invocation -> receiver.getMaxRetries()+1).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		listener.setMockedDeliveryCount(receiver.getMaxRetries() + 1);
 		receiver.updateMessageReceiveCount(messageWrapper);
 
 		assertAll(
@@ -765,7 +729,7 @@ public class ReceiverTest {
 				()-> assertTrue(receiver.isDeliveryRetryLimitExceededAfterMessageProcessed(messageWrapper))
 		);
 
-		doAnswer(invocation -> receiver.getMaxRetries()+2).when(jmsMessage).getIntProperty("JMSXDeliveryCount");
+		listener.setMockedDeliveryCount(receiver.getMaxRetries() + 2);
 		receiver.updateMessageReceiveCount(messageWrapper);
 
 		assertAll(
@@ -778,8 +742,7 @@ public class ReceiverTest {
 	void testGetDeliveryCount() throws Exception {
 		// Arrange
 		configuration = buildNarayanaTransactionManagerConfiguration();
-		MockPushingListener listener = spy(configuration.createBean(MockPushingListener.class));
-		doNothing().when(listener).start();
+		MockPullingListener listener = spy(configuration.createBean(MockPullingListener.class));
 
 		@SuppressWarnings("unchecked")
 		ITransactionalStorage<Serializable> errorStorage = mock(ITransactionalStorage.class);
@@ -1016,7 +979,7 @@ public class ReceiverTest {
 	}
 
 	public void testStartNoTimeout(SlowListenerBase listener) throws Exception {
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		Adapter adapter = setupAdapter(receiver);
 
 		assertEquals(RunState.STOPPED, adapter.getRunState());
@@ -1054,7 +1017,7 @@ public class ReceiverTest {
 	}
 
 	public void testStartTimeout(SlowListenerBase listener) throws Exception {
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		receiver.setStartTimeout(1);
 		Adapter adapter = setupAdapter(receiver);
 
@@ -1104,7 +1067,7 @@ public class ReceiverTest {
 		// Arrange
 		configuration = buildDataSourceTransactionManagerConfiguration();
 		SlowListenerBase listener = setupSlowStartPushingListener(1_000);
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		Adapter adapter = setupAdapter(receiver);
 
 		try (TestAppender appender = TestAppender.newBuilder().build()) {
@@ -1159,7 +1122,7 @@ public class ReceiverTest {
 	@Test
 	public void testStopAdapterAfterStopReceiverWithException() throws Exception {
 		configuration = buildNarayanaTransactionManagerConfiguration();
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(setupSlowStopPushingListener(100_000));
+		Receiver<String> receiver = setupReceiver(setupSlowStopPushingListener(100_000));
 		Adapter adapter = setupAdapter(receiver);
 
 		assertEquals(RunState.STOPPED, adapter.getRunState());
@@ -1198,7 +1161,7 @@ public class ReceiverTest {
 	}
 
 	public void testStopTimeout(SlowListenerBase listener) throws Exception {
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(listener);
+		Receiver<String> receiver = setupReceiver(listener);
 		Adapter adapter = setupAdapter(receiver);
 		receiver.setStopTimeout(1);
 
@@ -1227,11 +1190,12 @@ public class ReceiverTest {
 
 	@Test
 	public void testPollGuardStartTimeout() throws Exception {
+		// TODO: This test needs to be moved to the JMS module
 		// Arrange
 		configuration = buildNarayanaTransactionManagerConfiguration();
 
 		// Create listener without any delays in starting or stopping, they will be set later
-		SlowListenerWithPollGuard listener = createSlowListener(SlowListenerWithPollGuard.class, 0, 0);
+		SlowListenerWithPollGuard listener = createSlowListenerWithPollGuard(0, 0);
 		listener.setPollGuardInterval(1_000);
 		listener.setMockLastPollDelayMs(10_000); // Last Poll always before PollGuard triggered
 
@@ -1285,9 +1249,10 @@ public class ReceiverTest {
 
 	@Test
 	public void testPollGuardStopTimeout() throws Exception {
+		// TODO: This test needs to be moved to the JMS module
 		configuration = buildNarayanaTransactionManagerConfiguration();
 		// Create listener without any delays in starting or stopping, they will be set later
-		SlowListenerWithPollGuard listener = createSlowListener(SlowListenerWithPollGuard.class, 0, 0);
+		SlowListenerWithPollGuard listener = createSlowListenerWithPollGuard(0, 0);
 		listener.setPollGuardInterval(1_000);
 		listener.setMockLastPollDelayMs(10_000); // Last Poll always before PollGuard triggered
 
@@ -1339,7 +1304,7 @@ public class ReceiverTest {
 	@Test
 	public void startReceiver() throws Exception {
 		configuration = buildDataSourceTransactionManagerConfiguration();
-		Receiver<jakarta.jms.Message> receiver = setupReceiver(setupSlowStartPullingListener(10_000));
+		Receiver<String> receiver = setupReceiver(setupSlowStartPullingListener(10_000));
 		receiver.setStartTimeout(1);
 		Adapter adapter = setupAdapter(receiver);
 
@@ -1466,6 +1431,7 @@ public class ReceiverTest {
 	@ParameterizedTest
 	@MethodSource("transactionManagers")
 	void testJmsMessageTransactionRollbackAfterListenerCompleted(Supplier<TestConfiguration> configurationSupplier) throws Exception {
+		// TODO: Check this can be done properly without the JMS listener
 		// Arrange
 		configuration = configurationSupplier.get();
 		PushingJmsListener listener = spy(configuration.createBean(PushingJmsListener.class));

--- a/core/src/test/java/org/frankframework/receivers/SlowListenerBase.java
+++ b/core/src/test/java/org/frankframework/receivers/SlowListenerBase.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2023 WeAreFrank!
+   Copyright 2022-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
 import org.frankframework.util.LogUtil;
 
-public abstract class SlowListenerBase implements IListener<jakarta.jms.Message> {
+public abstract class SlowListenerBase implements IListener<String> {
 	protected Logger log = LogUtil.getLogger(this);
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
@@ -47,12 +47,12 @@ public abstract class SlowListenerBase implements IListener<jakarta.jms.Message>
 	}
 
 	@Override
-	public void afterMessageProcessed(PipeLineResult processResult, RawMessageWrapper<jakarta.jms.Message> rawMessage, PipeLineSession pipeLineSession) {
+	public void afterMessageProcessed(PipeLineResult processResult, RawMessageWrapper<String> rawMessage, PipeLineSession pipeLineSession) {
 		// No-op
 	}
 
 	@Override
-	public Message extractMessage(@Nonnull RawMessageWrapper<jakarta.jms.Message> rawMessage, @Nonnull Map<String, Object> context) {
+	public Message extractMessage(@Nonnull RawMessageWrapper<String> rawMessage, @Nonnull Map<String, Object> context) {
 		return Message.asMessage(rawMessage.getRawMessage());
 	}
 

--- a/core/src/test/java/org/frankframework/receivers/SlowListenerBase.java
+++ b/core/src/test/java/org/frankframework/receivers/SlowListenerBase.java
@@ -19,21 +19,20 @@ import java.util.Map;
 
 import jakarta.annotation.Nonnull;
 
-import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IListener;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
 
+@Log4j2
 public abstract class SlowListenerBase implements IListener<String> {
-	protected Logger log = LogUtil.getLogger(this);
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 	private @Getter @Setter String name;

--- a/core/src/test/java/org/frankframework/receivers/SlowPullingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/SlowPullingListener.java
@@ -20,8 +20,11 @@ import java.util.Map;
 
 import jakarta.annotation.Nonnull;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.core.IPullingListener;
 
+@Log4j2
 public class SlowPullingListener extends SlowListenerBase implements IPullingListener<String> {
 
 	@Nonnull

--- a/core/src/test/java/org/frankframework/receivers/SlowPullingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/SlowPullingListener.java
@@ -19,11 +19,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import jakarta.annotation.Nonnull;
-import jakarta.jms.Message;
 
 import org.frankframework.core.IPullingListener;
 
-public class SlowPullingListener extends SlowListenerBase implements IPullingListener<jakarta.jms.Message> {
+public class SlowPullingListener extends SlowListenerBase implements IPullingListener<String> {
 
 	@Nonnull
 	@Override
@@ -37,7 +36,7 @@ public class SlowPullingListener extends SlowListenerBase implements IPullingLis
 	}
 
 	@Override
-	public RawMessageWrapper<Message> getRawMessage(@Nonnull Map<String, Object> threadContext) {
+	public RawMessageWrapper<String> getRawMessage(@Nonnull Map<String, Object> threadContext) {
 		return null;
 	}
 }

--- a/core/src/test/java/org/frankframework/receivers/SlowPushingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/SlowPushingListener.java
@@ -15,17 +15,15 @@
 */
 package org.frankframework.receivers;
 
-import jakarta.jms.Message;
-
 import org.frankframework.core.IMessageHandler;
 import org.frankframework.core.IPushingListener;
 import org.frankframework.core.IbisExceptionListener;
 import org.frankframework.core.PipeLineSession;
 
-public class SlowPushingListener extends SlowListenerBase implements IPushingListener<Message> {
+public class SlowPushingListener extends SlowListenerBase implements IPushingListener<String> {
 
 	@Override
-	public void setHandler(IMessageHandler<Message> handler) {
+	public void setHandler(IMessageHandler<String> handler) {
 		// No-op
 	}
 
@@ -35,7 +33,7 @@ public class SlowPushingListener extends SlowListenerBase implements IPushingLis
 	}
 
 	@Override
-	public RawMessageWrapper<Message> wrapRawMessage(Message rawMessage, PipeLineSession session) {
+	public RawMessageWrapper<String> wrapRawMessage(String rawMessage, PipeLineSession session) {
 		return null;
 	}
 }


### PR DESCRIPTION
Move some tests to new JmsPushingListenerTest (with a TODO for future improvement).

Remove all JMS dependencies from other tests, cleaning them up a bit.