### PR TITLE
Replace some thread.setNames with closable-log-context

### DIFF
--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -844,8 +844,7 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 			// Cannot use a closable ThreadContext as it's cleared in the Receiver STOP method.
 			@Override
 			public void run() {
-				Thread.currentThread().setName("stopping Adapter " +getName());
-				try {
+				try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_ADAPTER_KEY, getName())) {
 					log.trace("Adapter.stopRunning - stop adapter thread for [{}] starting", () -> getName());
 
 					// See also Receiver.stopRunning()
@@ -928,7 +927,7 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 	 */
 	@Override
 	public void stop() {
-		stop(() -> log.debug("stopped adapter [{}]", getName()));
+		stop(() -> log.info("stopped adapter [{}]", getName()));
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/RestServiceDispatcher.java
+++ b/core/src/main/java/org/frankframework/http/RestServiceDispatcher.java
@@ -160,7 +160,7 @@ public class RestServiceDispatcher {
 			context.put("principal", principal.getName());
 		}
 
-		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put("listener", listener.getName())) {
+		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_LISTENER_KEY, listener.getName())) {
 			boolean writeToSecLog = false;
 			if (listener.isRetrieveMultipart() && MultipartUtils.isMultipart(httpServletRequest)) {
 				try {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -40,6 +40,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.http.HttpEntity;
+import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.springframework.util.InvalidMimeTypeException;
@@ -269,7 +270,10 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 		/*
 		 * Initiate and populate messageContext
 		 */
-		try (PipeLineSession pipelineSession = new PipeLineSession()) {
+
+		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_LISTENER_KEY, listener.getName());
+				final PipeLineSession pipelineSession = new PipeLineSession()) {
+
 			pipelineSession.put(PipeLineSession.HTTP_METHOD_KEY, method);
 			pipelineSession.put(PipeLineSession.HTTP_REQUEST_KEY, request);
 			pipelineSession.put(PipeLineSession.HTTP_RESPONSE_KEY, response);

--- a/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/MessageSendingPipe.java
@@ -647,7 +647,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender {
 				exitState = PRESUMED_TIMEOUT_FORWARD;
 				throw new TimeoutException(PRESUMED_TIMEOUT_FORWARD);
 			}
-			try (CloseableThreadContext.Instance ctc = CloseableThreadContext.put("sender", sender.getName())){
+			try (CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_SENDER_KEY, sender.getName())){
 				SenderResult senderResult = sender.sendMessage(input, session);
 				PipeForward forward = findForwardForResult(senderResult);
 				sendResult = new PipeRunResult(forward, senderResult.getResult());

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -73,7 +73,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 		Object preservedObject = message;
 		HasName owner = pipeLine.getOwner();
 
-		try (CloseableThreadContext.Instance ignored = CloseableThreadContext.put("pipe", pipe.getName())) {
+		try (CloseableThreadContext.Instance ignored = CloseableThreadContext.put(LogUtil.MDC_PIPE_KEY, pipe.getName())) {
 			if (StringUtils.isNotEmpty(pipe.getGetInputFromSessionKey())) {
 				log.debug("Pipeline of adapter [{}] replacing input for pipe [{}] with contents of sessionKey [{}]", owner::getName, pipe::getName, pipe::getGetInputFromSessionKey);
 				if (!Message.isNull(message)) message.closeOnCloseOf(pipeLineSession);

--- a/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
+++ b/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
@@ -297,7 +297,7 @@ public class PullingListenerContainer<M> implements IThreadCountControllable {
 							// found a message, process it
 							int tasks = tasksStarted.incrementAndGet();
 							log.debug("{} started ListenTask [{}]", receiver::getLogPrefix, () -> tasks);
-							Thread.currentThread().setName(receiver.getName() + "-listener[" + tasks + "]");
+							Thread.currentThread().setName(receiver.getName() + "-listener[" + tasks + "]"); // Becomes `MyReceiverListener-listener[123]`
 						} finally {
 							// release pollToken after message has been moved to inProcess, so it is not seen as 'available' by the next thread
 							pollTokenReleased=true;

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -217,7 +217,6 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	public static final TransactionDefinition TXNEW_CTRL = new DefaultTransactionDefinition(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
 	private TransactionDefinition txNewWithTimeout;
 
-	public static final String THREAD_CONTEXT_KEY_NAME = "listener";
 	public static final String THREAD_CONTEXT_KEY_TYPE = "listener.type";
 
 	public static final String RCV_CONFIGURED_MONITOR_EVENT = "Receiver Configured";
@@ -796,11 +795,11 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 			error("error occurred while starting", t);
 
 			runState.setRunState(RunState.EXCEPTION_STARTING);
-			closeAllResources(); //Close potential dangling resources, don't change state here..
+			closeAllResources(); // Close potential dangling resources, don't change state here..
 		}
 	}
 
-	//after successfully closing all resources the state should be set to stopped
+	// After successfully closing all resources the state should be set to stopped
 	@Override
 	public void stop() {
 		// See also Adapter.stopRunning() and PullingListenerContainer.ControllerTask
@@ -819,10 +818,9 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 					return;
 				case EXCEPTION_STARTING:
 					if (getListener() instanceof IPullingListener) {
-						runState.setRunState(RunState.STOPPING); //Nothing ever started, directly go to stopped
+						runState.setRunState(RunState.STOPPING); // Nothing ever started, directly go to stopped
 						closeAllResources();
-						ThreadContext.clearAll(); //Clean up receiver ThreadContext
-						return; //Prevent tellResourcesToStop from being called
+						return; // Prevent tellResourcesToStop from being called
 					}
 					runState.setRunState(RunState.STOPPING);
 					break;
@@ -830,7 +828,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 					runState.setRunState(RunState.STOPPING);
 					break;
 				case ERROR:
-					//Don't change the runstate when in ERROR
+					// Don't change the runstate when in ERROR
 					break;
 				default:
 					throw new IllegalStateException("Runstate [" + currentRunState + "] not handled in Stopping Receiver");
@@ -839,7 +837,6 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 		log.trace("{} Receiver StopRunning - lock on Receiver runState[{}] released", this::getLogPrefix, runState::toString);
 
 		tellResourcesToStop();
-		ThreadContext.clearAll(); //Clean up receiver ThreadContext
 	}
 
 	@Override
@@ -1130,7 +1127,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 
 	private CloseableThreadContext.Instance getLoggingContext(@Nonnull IListener<M> listener, @Nonnull PipeLineSession session) {
 		CloseableThreadContext.Instance result = LogUtil.getThreadContext(adapter, session.getMessageId(), session);
-		result.put(THREAD_CONTEXT_KEY_NAME, listener.getName());
+		result.put(LogUtil.MDC_LISTENER_KEY, listener.getName());
 		result.put(THREAD_CONTEXT_KEY_TYPE, ClassUtils.classNameOf(listener));
 		return result;
 	}

--- a/core/src/main/java/org/frankframework/scheduler/NamedThreadFactory.java
+++ b/core/src/main/java/org/frankframework/scheduler/NamedThreadFactory.java
@@ -21,8 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.frankframework.util.ClassUtils;
-
 public class NamedThreadFactory implements ThreadFactory {
 	private @Setter int threadPriority = Thread.NORM_PRIORITY;
 	private @Getter @Setter ThreadGroup threadGroup;
@@ -39,10 +37,7 @@ public class NamedThreadFactory implements ThreadFactory {
 	}
 
 	private String getThreadName(Runnable runnable) {
-		String threadName = ClassUtils.nameOf(runnable);
-		threadName += "-"+this.threadCount.incrementAndGet();
-
-		return threadName;
+		return "FF-Worker-"+this.threadCount.incrementAndGet();
 	}
 
 	public void setThreadGroupName(String name) {

--- a/core/src/main/java/org/frankframework/scheduler/job/SendMessageJob.java
+++ b/core/src/main/java/org/frankframework/scheduler/job/SendMessageJob.java
@@ -72,8 +72,10 @@ public class SendMessageJob extends AbstractJobDef {
 
 			localSender.start();
 			try (Message result = localSender.sendMessageOrThrow(toSendMessage, session)) {
-				// The result needs to be read, to make sure the StreamCaptureUtils sees this stream as read and will display the return value in Ladybug.
-				// This is part of the close method of captureReader and captureInputStream.
+				// NB for the Ladybug:
+				// The Message `result` needs to be read, so it's displayed as the return value in Ladybug.
+				// This is part of the close method of StreamCaptureUtils#captureReader() and StreamCaptureUtils#captureInputStream() which is only active when the Ladybug is present.
+				// We therefor do not need to read the stream here!
 				log.debug("SendMessageJob [{}] executed succesfully with result [{}]", this::getName, result::toString);
 			}
 		} catch (LifecycleException | SenderException e) {

--- a/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
+++ b/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
@@ -15,24 +15,21 @@
 */
 package org.frankframework.threading;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import jakarta.annotation.Nonnull;
 
 import org.springframework.core.task.TaskDecorator;
 
-import org.frankframework.util.ClassUtils;
-
 public class ThreadNamingTaskDecorator implements TaskDecorator {
-	private final AtomicLong counter = new AtomicLong();
 
+	/**
+	 * Reverts the thread-name back to the original.
+	 */
 	@Override
 	public @Nonnull Runnable decorate(@Nonnull Runnable runnable) {
 		return () -> {
 			final String threadName = Thread.currentThread().getName();
 			try {
 				// Give thread some name when we start a task on it
-				Thread.currentThread().setName(ClassUtils.nameOf(runnable) + "-FFWorker-" + counter.incrementAndGet());
 				runnable.run();
 			} finally {
 				// Restore the original name

--- a/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
+++ b/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
@@ -33,7 +33,6 @@ public class ThreadNamingTaskDecorator implements TaskDecorator {
 				// Ensure the context-stack is empty before executing the new Thread to ensure a clean slate
 				ThreadContext.clearAll();
 
-				// Give thread some name when we start a task on it
 				runnable.run();
 			} finally {
 				// Ensure the context-stack is empty after executing the new Thread to prevent leaks

--- a/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
+++ b/core/src/main/java/org/frankframework/threading/ThreadNamingTaskDecorator.java
@@ -17,6 +17,7 @@ package org.frankframework.threading;
 
 import jakarta.annotation.Nonnull;
 
+import org.apache.logging.log4j.ThreadContext;
 import org.springframework.core.task.TaskDecorator;
 
 public class ThreadNamingTaskDecorator implements TaskDecorator {
@@ -29,9 +30,15 @@ public class ThreadNamingTaskDecorator implements TaskDecorator {
 		return () -> {
 			final String threadName = Thread.currentThread().getName();
 			try {
+				// Ensure the context-stack is empty before executing the new Thread to ensure a clean slate
+				ThreadContext.clearAll();
+
 				// Give thread some name when we start a task on it
 				runnable.run();
 			} finally {
+				// Ensure the context-stack is empty after executing the new Thread to prevent leaks
+				ThreadContext.clearAll();
+
 				// Restore the original name
 				Thread.currentThread().setName(threadName);
 			}

--- a/core/src/main/java/org/frankframework/util/LogUtil.java
+++ b/core/src/main/java/org/frankframework/util/LogUtil.java
@@ -33,6 +33,9 @@ public class LogUtil {
 
 	public static final String MESSAGE_LOGGER = "MSG";
 
+	public static final String MDC_PIPE_KEY = "pipe";
+	public static final String MDC_SENDER_KEY = "sender";
+	public static final String MDC_LISTENER_KEY = "listener";
 	public static final String MDC_ADAPTER_KEY = "adapter";
 
 	public static final String MDC_EXIT_STATE_KEY = "exit.state";

--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -109,9 +109,11 @@
 		<property name="threadFactory" ref="namedThreadFactory"/>
 		<property name="queueCapacity" value="0"/>
 		<property name="phase" value="-2147483648"/>
-		<property name="acceptTasksAfterContextClose" value="true"/>
+		<property name="acceptTasksAfterContextClose" value="false"/>
 		<property name="waitForTasksToCompleteOnShutdown" value="true"/>
-		<property name="taskDecorator"><bean class="org.frankframework.threading.ThreadNamingTaskDecorator"/> </property>
+		<property name="taskDecorator">
+			<bean class="org.frankframework.threading.ThreadNamingTaskDecorator"/>
+		</property>
 	</bean>
 
 	<bean

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -112,6 +112,7 @@
 		<Logger name="org.springframework.security.ldap" level="WARN" />
 		<Logger name="org.frankframework.management.gateway" level="INFO" />
 		<Logger name="com.hazelcast" level="WARN" />
+		<Logger name="snakeyaml.introspector" level="ERROR" />
 
 		<Logger name="liquibase.migrationLog" level="INFO">
 			<AppenderRef ref="application-log-appender"/>

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -5,7 +5,7 @@
 	<Appenders>
 		<Appender name="stdout" type="Console">
 			<Layout type="IbisPatternLayout">
-				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %X{mid,cid} %c{2} - %m%n%xEx{short}</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %c{2} - %m%n%xEx{short}</Pattern>
 			</Layout>
 		</Appender>
 		<Appender name="application-log-appender" type="Console">
@@ -26,7 +26,7 @@
 				<Filter type="IbisThreadFilter" onMatch="DENY" onMismatch="NEUTRAL" regex="${ctx:log.thread.rejectRegex:-}" />
 			</Filters>
 			<Layout type="IbisPatternLayout">
-				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %X{mid,cid,adapter,pipe,sender} %c{2} - %m%n%xEx{filters(${ctx:log.stacktrace.filters})}</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %X{mid,cid,listener,adapter,pipe,sender} %c{2} - %m%n%xEx{filters(${ctx:log.stacktrace.filters})}</Pattern>
 			</Layout>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="${ctx:log.maxFileSize}" />

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -112,7 +112,7 @@
 		<Logger name="org.springframework.security.ldap" level="WARN" />
 		<Logger name="org.frankframework.management.gateway" level="INFO" />
 		<Logger name="com.hazelcast" level="WARN" />
-		<Logger name="snakeyaml.introspector" level="ERROR" />
+		<Logger name="org.yaml.snakeyaml.introspector" level="ERROR" />
 
 		<Logger name="liquibase.migrationLog" level="INFO">
 			<AppenderRef ref="application-log-appender"/>

--- a/core/src/main/resources/quartz.properties
+++ b/core/src/main/resources/quartz.properties
@@ -3,7 +3,7 @@
 # Configure Main Scheduler Properties  
 #============================================================================
 
-org.quartz.scheduler.instanceName = IbisScheduler
+org.quartz.scheduler.instanceName = FF-Scheduler
 org.quartz.scheduler.instanceId = one
 
 #============================================================================

--- a/example/src/main/resources/ConfigurationHelloWorlds.xml
+++ b/example/src/main/resources/ConfigurationHelloWorlds.xml
@@ -6,6 +6,7 @@
 				name="HelloWorlds"
 				className="org.frankframework.http.rest.ApiListener"
 				uriPattern="hello-worlds"
+				allowAllParams="false"
 			/>
 		</receiver>
 		<receiver name="HelloWorlds">


### PR DESCRIPTION
`Receiver#stop()` contains the following code: `ThreadContext.clearAll();` which prevents me from using the closable-logcontext in `Adapter#stop()`.

<img width="277" alt="image" src="https://github.com/user-attachments/assets/35089efa-ae58-40e1-ae37-15a0aeb44b4f" />
