### PR TITLE
Fix 'time' in parameter pattern (#8632)

### DIFF
--- a/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
@@ -633,7 +633,7 @@ public abstract class AbstractParameter implements IConfigurable, IWithParameter
 			String namelc=name.toLowerCase();
 			switch (namelc) {
 				case "now":
-					if ("date".equals(formatType)) {
+					if ("date".equalsIgnoreCase(formatType) || "time".equalsIgnoreCase(formatType)) {
 						substitutionValue = new Date();
 					} else{
 						substitutionValue = formatDateToString(new Date(), formatString);

--- a/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
@@ -418,4 +418,87 @@ public class DateParameterTest {
 		assertEquals(date, result);
 	}
 
+	@Test
+	public void testTimeParameterWithTimePatternWithoutFormat() throws Exception {
+
+		// Arrange
+		DateParameter parameter = new DateParameter();
+		parameter.setName("time");
+		parameter.setFormatType(DateFormatType.TIME);
+		parameter.setPattern("{now,time}"); // Does not work if you do not specify 'time' in the pattern. Seems like a bug to me, inconsistent with how DateFormatType.DATE works
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertInstanceOf(Date.class, result);
+	}
+
+	@Test
+	public void testTimeParameterWithTimePatternWithFormat() throws Exception {
+
+		// Arrange
+		DateParameter parameter = new DateParameter();
+		parameter.setName("time");
+		parameter.setFormatType(DateFormatType.TIME);
+		parameter.setPattern("{now,time,HH:mm:ss}"); // Does not work if you do not specify 'time' in the pattern. If you specify a format, it HAS to be this format.
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertInstanceOf(Date.class, result);
+	}
+
+	@Test
+	public void testDateParameterWithDatePatternWithoutFormat() throws Exception {
+
+		// Arrange
+		DateParameter parameter = new DateParameter();
+		parameter.setName("date");
+		parameter.setFormatType(DateFormatType.DATE);
+		parameter.setPattern("{now}"); // Specifying just 'date' here does not work. Not consistent with DateFormatType.TIME
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertInstanceOf(Date.class, result);
+	}
+
+	@Test
+	public void testDateParameterWithDatePatternWithFormat() throws Exception {
+
+		// Arrange
+		DateParameter parameter = new DateParameter();
+		parameter.setName("date");
+		parameter.setFormatType(DateFormatType.DATE);
+		parameter.setPattern("{now,date,yyyy-MM-dd}"); // Specifying full date format makes it work, but it HAS to be this format
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertInstanceOf(Date.class, result);
+	}
 }

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -1523,4 +1523,45 @@ public class ParameterTest {
 
 		assertEquals("hallo", p.getValue(alreadyResolvedParameters, input, session, false));
 	}
+
+	@Test
+	public void testParameterWithTimePattern() throws Exception {
+
+		// Arrange
+		Parameter parameter = new Parameter();
+		parameter.setName("time");
+		parameter.setPattern("{now,time,HH:mm}");
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertInstanceOf(String.class, result);
+		assertTrue(((String)result).matches("\\d{1,2}:\\d{2}"));
+	}
+
+	@Test
+	public void testParameterWithDatePattern() throws Exception {
+
+		// Arrange
+		Parameter parameter = new Parameter();
+		parameter.setName("time");
+		parameter.setPattern("{now,date,HH:mm}");
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = new Message("fakeMessage");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertTrue(((String)result).matches("\\d{1,2}:\\d{2}"));
+	}
 }


### PR DESCRIPTION
Fixes #8603.
Backport to 8.3.
