### PR TITLE
MessageStoreListener only supports BLOB, forbid other message field types

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -301,28 +301,14 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 		}
 	}
 
-	protected String getKeyFromRawMessage(RawMessageWrapper<M> rawMessage) throws ListenerException {
+	protected String getKeyFromRawMessage(RawMessageWrapper<M> rawMessage) {
 
 		Map<String, Object> mwContext = rawMessage.getContext();
 		String key = (String) mwContext.get(PipeLineSession.STORAGE_ID_KEY);
 		if (StringUtils.isNotEmpty(key)) {
 			return key;
 		}
-
-		// TESTCOVERAGE: TODO: Below code appears untouched in our unit tests and IAF-Test but might be needed for some stored messages?
-		if (rawMessage.getId() != null) {
-			return rawMessage.getId();
-		} else if (rawMessage instanceof MessageWrapper) {
-			try {
-				return ((MessageWrapper<M>) rawMessage).getMessage().asString();
-			} catch (IOException e) {
-				throw new ListenerException(e);
-			}
-		} else if (rawMessage.getRawMessage() != null) {
-			return rawMessage.getRawMessage().toString();
-		} else {
-			throw new IllegalArgumentException("Cannot extract JDBC message key from raw message [" + rawMessage + "]");
-		}
+		throw new IllegalArgumentException("Cannot extract JDBC message key from raw message [" + rawMessage + "]");
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -263,21 +263,18 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	 * @throws JdbcException If loading the message resulted in a database exception.
 	 */
 	protected RawMessageWrapper<M> extractRawMessage(ResultSet rs) throws JdbcException {
-		// TODO: This needs to be reviewed, if all complications are needed. Some branches are never touched in tests.
 		try {
 			String key = rs.getString(getKeyField());
 			Message message;
 			if (StringUtils.isNotEmpty(getMessageField())) {
 				switch (getMessageFieldType()) {
 					case CLOB:
-						// TESTCOVERAGE: Untested branch
 						message = new Message(getDbmsSupport().getClobReader(rs, getMessageField()));
 						break;
 					case BLOB:
 						if (isBlobSmartGet() || StringUtils.isNotEmpty(getBlobCharset())) { // in this case blob contains a String
 							message = new Message(JdbcUtil.getBlobAsString(getDbmsSupport(), rs,getMessageField(), getBlobCharset(), isBlobsCompressed(), isBlobSmartGet(),false));
 						} else {
-							// TESTCOVERAGE: Untested branch
 							try (InputStream blobStream = JdbcUtil.getBlobInputStream(getDbmsSupport(), rs, getMessageField(), isBlobsCompressed())) {
 								message = new Message(blobStream);
 								message.preserve();

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -41,6 +41,7 @@ import org.frankframework.core.ProcessState;
 import org.frankframework.dbms.JdbcException;
 import org.frankframework.doc.Default;
 import org.frankframework.doc.Optional;
+import org.frankframework.doc.Protected;
 import org.frankframework.receivers.MessageWrapper;
 import org.frankframework.receivers.RawMessageWrapper;
 import org.frankframework.stream.Message;
@@ -286,7 +287,7 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 	}
 
 	@Override
-	@Deprecated
+	@Protected
 	public void setMessageFieldType(MessageFieldType fieldtype) {
 		throw new UnsupportedOperationException("MessageFieldType is always BLOB for the MessageStoreListener, use a JdbcTableListener instead if you need CLOB of VARCHAR support");
 	}

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -102,13 +102,13 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 
 	private List<String> sessionKeysList;
 
-	{
+	public MessageStoreListener() {
 		setTableName(DEFAULT_TABLE_NAME);
 		setKeyField(DEFAULT_KEY_FIELD);
 		setMessageField(DEFAULT_MESSAGE_FIELD);
 		setMessageIdField(DEFAULT_MESSAGEID_FIELD);
 		setCorrelationIdField(DEFAULT_CORRELATIONID_FIELD);
-		setMessageFieldType(MessageFieldType.BLOB);
+		super.setMessageFieldType(MessageFieldType.BLOB);
 		setBlobSmartGet(true);
 		setStatusField(DEFAULT_STATUS_FIELD);
 		setTimestampField(DEFAULT_TIMESTAMP_FIELD);
@@ -161,7 +161,6 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 		} catch (Exception e) {
 			throw new JdbcException(e);
 		}
-
 	}
 
 	private String getStringFieldOrNull(ResultSet rs, String columnLabel) throws SQLException {
@@ -287,9 +286,9 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 	}
 
 	@Override
-	@Default ("BLOB")
+	@Deprecated
 	public void setMessageFieldType(MessageFieldType fieldtype) {
-		super.setMessageFieldType(fieldtype);
+		throw new UnsupportedOperationException("MessageFieldType is always BLOB for the MessageStoreListener, use a JdbcTableListener instead if you need CLOB of VARCHAR support");
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreSender.java
@@ -74,10 +74,10 @@ import org.frankframework.util.StringUtil;
 public class MessageStoreSender extends JdbcTransactionalStorage<Serializable> implements ISenderWithParameters {
 	public static final String PARAM_MESSAGEID = "messageId";
 
-	private @Nonnull ParameterList paramList = new ParameterList();
+	private final @Nonnull ParameterList paramList = new ParameterList();
 	private @Getter String sessionKeys = null;
 
-	{
+	public MessageStoreSender() {
 		setOnlyStoreWhenMessageIdUnique(true);
 	}
 

--- a/core/src/main/java/org/frankframework/pipes/AbstractValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/AbstractValidator.java
@@ -95,7 +95,7 @@ public abstract class AbstractValidator extends FixedForwardPipe implements IDua
 	protected abstract PipeForward validate(Message messageToValidate, PipeLineSession session, boolean responseMode, String messageRoot) throws PipeRunException, XmlValidatorException, ConfigurationException;
 
 
-	protected final PipeForward determineForward(ValidationResult validationResult, PipeLineSession session, boolean responseMode, Supplier<String> errorMessageProvider) throws PipeRunException {
+	protected final PipeForward determineForward(ValidationResult validationResult, boolean responseMode, Supplier<String> errorMessageProvider) throws PipeRunException {
 		throwEvent(validationResult.getEvent());
 		PipeForward forward = null;
 		switch(validationResult) {

--- a/core/src/main/java/org/frankframework/pipes/JsonValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/JsonValidator.java
@@ -112,7 +112,7 @@ public class JsonValidator extends AbstractValidator {
 			if (StringUtils.isNotEmpty(getReasonSessionKey())) {
 				session.put(getReasonSessionKey(), problems.toString());
 			}
-			return determineForward(resultEvent, session, responseMode, problems::toString);
+			return determineForward(resultEvent, responseMode, problems::toString);
 		} catch (IOException e) {
 			throw new PipeRunException(this, "cannot validate", e);
 		}

--- a/core/src/main/java/org/frankframework/pipes/XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/XmlValidator.java
@@ -246,7 +246,7 @@ public class XmlValidator extends AbstractValidator implements SchemasProvider, 
 	}
 
 	protected PipeForward determineForward(ValidationResult validationResult, PipeLineSession session, boolean responseMode) throws PipeRunException {
-		return determineForward(validationResult, session, responseMode, ()-> {
+		return determineForward(validationResult, responseMode, ()-> {
 			String errorMessage=session.get(getReasonSessionKey(), null);
 			if (StringUtils.isEmpty(errorMessage)) {
 				errorMessage = session.get(getXmlReasonSessionKey(), "unknown error");

--- a/core/src/main/java/org/frankframework/soap/SoapValidator.java
+++ b/core/src/main/java/org/frankframework/soap/SoapValidator.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.doc.Protected;
 import org.frankframework.pipes.Json2XmlValidator;
 import org.frankframework.validation.RootValidations;
 
@@ -101,13 +102,14 @@ public class SoapValidator extends Json2XmlValidator {
 		return StringUtils.isNotEmpty(getOutputSoapBody());
 	}
 
-	@Deprecated
+	@Protected
 	@Override
 	public void setSchema(String schema) {
 		throw new IllegalArgumentException("The schema attribute isn't supported");
 	}
 
 	@Override
+	@Protected
 	public void setNoNamespaceSchemaLocation(String noNamespaceSchemaLocation) {
 		throw new IllegalArgumentException("The noNamespaceSchemaLocation attribute isn't supported");
 	}
@@ -132,7 +134,7 @@ public class SoapValidator extends Json2XmlValidator {
 	 * @ff.default envelope
 	 */
 	@Override
-	@Deprecated
+	@Protected
 	public void setRoot(String r) {
 		throw new IllegalArgumentException("The root element of a soap envelope is always " + getRoot());
 	}

--- a/core/src/test/resources/Migrator/ChangelogBlobTests.xml
+++ b/core/src/test/resources/Migrator/ChangelogBlobTests.xml
@@ -17,7 +17,8 @@
 			<column name="TDATE" type="DATE"/>
 			<column name="TDATETIME" type="DATETIME"/>
 			<column name="TBOOLEAN" type="java.sql.Types.BOOLEAN"/>
-			<column name="TCLOB" type="CLOB"/> <!-- LONGBLOB required for MySQL and MariaDB, compatible with BLOB for other dbmses -->
+			<column name="TCLOB" type="CLOB"/>
+			<!-- LONGBLOB required for MySQL and MariaDB, compatible with BLOB for other dbmses -->
 			<column name="TBLOB" type="LONGBLOB"/>
 		</createTable>
 <!--		<createIndex tableName="${tableName}" indexName="IX_${tableName}">-->


### PR DESCRIPTION
MessageStoreSender only ever supported inserting message as BLOB, so I concluded that supporting anything else than BLOB in the MessageStoreListener doesn't actually make sense.

Also some cleanups in JDBC tests, remove unused parameter in AbstractValidator.

Make tests in PushingJmsListenerTest more stable.