### PR TITLE
Fixes for several more JDBC test related issues

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -270,6 +270,7 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 				switch (getMessageFieldType()) {
 					case CLOB:
 						message = new Message(getDbmsSupport().getClobReader(rs, getMessageField()));
+						message.preserve(); // Prevent problems with stream closed after ResultSet is closed. Needed for MS SQL, Oracle
 						break;
 					case BLOB:
 						if (isBlobSmartGet() || StringUtils.isNotEmpty(getBlobCharset())) { // in this case blob contains a String

--- a/core/src/test/java/org/frankframework/jdbc/FixedQuerySenderTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/FixedQuerySenderTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
@@ -131,6 +132,8 @@ public class FixedQuerySenderTest {
 
 	@DatabaseTest
 	public void testUseNamedParametersStringValueContains_unp_start_resolveParam() throws Exception {
+		assumeFalse(databaseUnderTest == Dbms.MARIADB, "MariaDB JDBC driver appears to allow setting parameters with index higher than parameter count in the prepared statement so the test fails");
+
 		fixedQuerySender.setQuery("INSERT INTO " + TABLE_NAME + " (tKEY, tVARCHAR) VALUES ('1', '?{param}')");
 
 		fixedQuerySender.addParameter(new Parameter("param", "value"));
@@ -138,7 +141,8 @@ public class FixedQuerySenderTest {
 		fixedQuerySender.configure();
 		fixedQuerySender.start();
 
-		assertThrows(SenderException.class, () -> fixedQuerySender.sendMessage(new Message("dummy"), session));
+		SenderException senderException = assertThrows(SenderException.class, () -> fixedQuerySender.sendMessage(new Message("dummy"), session));
+		assertThat(senderException.getMessage(), containsString("Could not set parameter [param] with type [STRING] at position 0, exception"));
 	}
 
 	@DatabaseTest

--- a/core/src/test/java/org/frankframework/jdbc/JdbcTableListenerTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcTableListenerTest.java
@@ -344,7 +344,13 @@ public class JdbcTableListenerTest {
 		listener.start();
 
 		try(Connection connection = env.getConnection()) {
-			JdbcTestUtil.executeStatement(env.getDbmsSupport(), connection, "INSERT INTO " + TEST_TABLE + " (TKEY,TINT,TBLOB) VALUES (10,1,'TEST')", null, new PipeLineSession());
+			if (env.getDbmsSupport().getDbms() == Dbms.MSSQL) {
+				JdbcTestUtil.executeStatement(env.getDbmsSupport(), connection, "INSERT INTO " + TEST_TABLE + " (TKEY,TINT,TBLOB) VALUES (10,1,CONVERT(VARBINARY,'TEST'))", null, new PipeLineSession());
+			} else if (env.getDbmsSupport().getDbms() == Dbms.ORACLE) {
+				JdbcTestUtil.executeStatement(env.getDbmsSupport(), connection, "INSERT INTO " + TEST_TABLE + " (TKEY,TINT,TBLOB) VALUES (10,1,utl_raw.cast_to_raw('TEST'))", null, new PipeLineSession());
+			} else {
+				JdbcTestUtil.executeStatement(env.getDbmsSupport(), connection, "INSERT INTO " + TEST_TABLE + " (TKEY,TINT,TBLOB) VALUES (10,1,'TEST')", null, new PipeLineSession());
+			}
 		}
 
 		RawMessageWrapper<String> rawMessage = listener.getRawMessage(new HashMap<>());

--- a/core/src/test/java/org/frankframework/jdbc/datasource/TestBlobs.java
+++ b/core/src/test/java/org/frankframework/jdbc/datasource/TestBlobs.java
@@ -17,6 +17,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.commons.io.input.ReaderInputStream;
+import org.junit.jupiter.api.Timeout;
 
 import org.frankframework.dbms.Dbms;
 import org.frankframework.dbms.IDbmsSupport;
@@ -40,7 +41,7 @@ public class TestBlobs {
 	}
 
 	public static int readStream(InputStream inputStream) throws IOException {
-		byte[] buffer = new byte[1000];
+		byte[] buffer = new byte[100_000];
 		int result = 0;
 		int bytesRead=0;
 		while (bytesRead>=0) {
@@ -55,7 +56,7 @@ public class TestBlobs {
 		String insertQuery = "INSERT INTO " + TABLE_NAME + " (TKEY,TBLOB) VALUES (20,?)";
 		String selectQuery = "SELECT TBLOB FROM " + TABLE_NAME + " WHERE TKEY=20";
 		try (Connection conn = databaseTestEnvironment.getConnection(); PreparedStatement stmt = conn.prepareStatement(insertQuery)) {
-			stmt.setBinaryStream(1, new ByteArrayInputStream(blobContents.getBytes("UTF-8")));
+			stmt.setBinaryStream(1, new ByteArrayInputStream(blobContents.getBytes(StandardCharsets.UTF_8)));
 			stmt.execute();
 		}
 
@@ -186,6 +187,7 @@ public class TestBlobs {
 	}
 
 	@DatabaseTest
+	@Timeout(60)
 	public void testWriteAndReadClobUsingDbmsSupport15MB(DatabaseTestEnvironment databaseTestEnvironment) throws Exception {
 		testWriteAndReadClobUsingDbmsSupport(10000, 1500, databaseTestEnvironment);
 	}

--- a/management-gateway/src/test/java/org/frankframework/management/gateway/HazelcastEndToEndTest.java
+++ b/management-gateway/src/test/java/org/frankframework/management/gateway/HazelcastEndToEndTest.java
@@ -120,7 +120,7 @@ public class HazelcastEndToEndTest {
 			assertEquals("load-resp-"+i, response.getPayload());
 		}
 		long duration = (System.currentTimeMillis() - start);
-		assertTrue(duration < 10_000L, "it took ["+duration+"]ms, max is 10 seconds"); // Typically takes < 5s.
+		assertTrue(duration < 15_000L, "it took ["+duration+"]ms, max is 15 seconds"); // Typically takes < 5s.
 	}
 
 	@Test


### PR DESCRIPTION
Includes "fix" for #6910 and several other fixes including some fixes that are also part of PR #8659 already.

This is the last PR needed to make all tests work with all databases, _except_ DB2 which I currently cannot get to connect to at all.

Lastly includes a HazelCast test change that increases the timeout because locally for me, sometimes this test takes a bit longer for some reason.