### PR TITLE
Skip copy-test-resources when skipTests is true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -777,6 +777,11 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.3.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.4.2</version>
 					<configuration>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -161,10 +161,11 @@
 
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>copy-files</id>
+						<id>copy-frontend-to-TestClasses</id>
 						<phase>process-test-resources</phase>
 						<goals>
 							<goal>copy-resources</goal>
@@ -179,6 +180,7 @@
 									<targetPath>e2e</targetPath>
 								</resource>
 							</resources>
+							<skip>${maven.test.skip}</skip> <!-- A bit hacky way to prevent this execution from running when tests are skipped. -->
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
Hacky tacky way to disable test resources from being copied when maven tests are skipped.

See:
- https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html
- https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html