### PR TITLE
Update ladybug CXF dependency version

### DIFF
--- a/ladybug/common/pom.xml
+++ b/ladybug/common/pom.xml
@@ -12,6 +12,19 @@
 	<artifactId>frankframework-ladybug-common</artifactId>
 	<name>Frank!Framework Ladybug Commons</name>
 
+	<!-- Update the transitive CXF dependency by importing the cxf BOM of the correct version -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-bom</artifactId>
+				<version>4.0.6</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.ibissource</groupId>


### PR DESCRIPTION
Should be what we need, `mvn dependency:tree` says that the version is updated in the common module:

```
[INFO] org.frankframework:frankframework-ladybug-common:jar:9.0.1-SNAPSHOT
[INFO] +- org.ibissource:ibis-ladybug:jar:3.0-20250107.001038:compile
[INFO] |  +- org.wearefrank:ladybug-frontend:jar:0.1.0-20241213.164256:compile
[INFO] |  +- org.apache.cxf:cxf-rt-rs-client:jar:4.0.6:compile
[INFO] |  |  +- org.apache.cxf:cxf-rt-transports-http:jar:4.0.6:compile
[INFO] |  |  +- org.apache.cxf:cxf-core:jar:4.0.6:compile
```