### PR TITLE
Improved caching of TransformerPools

### DIFF
--- a/core/src/main/java/org/frankframework/documentbuilder/json/JsonUtils.java
+++ b/core/src/main/java/org/frankframework/documentbuilder/json/JsonUtils.java
@@ -24,14 +24,14 @@ import jakarta.json.stream.JsonParser;
 import jakarta.json.stream.JsonParser.Event;
 import jakarta.json.stream.JsonParserFactory;
 
-import org.apache.logging.log4j.Logger;
 import org.xml.sax.SAXException;
 
-import org.frankframework.documentbuilder.JsonEventHandler;
-import org.frankframework.util.LogUtil;
+import lombok.extern.log4j.Log4j2;
 
+import org.frankframework.documentbuilder.JsonEventHandler;
+
+@Log4j2
 public class JsonUtils {
-	private static final Logger log = LogUtil.getLogger(JsonUtils.class);
 
 	public static void parseJson(String json, JsonEventHandler handler) throws SAXException {
 		parseJson(new StringReader(json),handler);

--- a/core/src/main/java/org/frankframework/pipes/JsonPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/JsonPipe.java
@@ -47,6 +47,7 @@ import org.frankframework.documentbuilder.IDocumentBuilder;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageBuilder;
 import org.frankframework.util.TransformerPool;
+import org.frankframework.util.XmlUtils;
 
 /**
  * JSON is not aware of the element order. This pipe performs a <strong>best effort</strong> JSON to XML transformation.
@@ -93,7 +94,7 @@ public class JsonPipe extends FixedForwardPipe {
 			addXmlRootElement = dir == Direction.JSON2XML;
 		}
 		if (dir == Direction.XML2JSON) {
-			tpXml2Json = TransformerPool.configureStyleSheetTransformer(this, "/xml/xsl/xml2json.xsl", 2); // shouldn't this be a utility transformer?
+			tpXml2Json = XmlUtils.getUtilityTransformerPool("/xml/xsl/xml2json.xsl", true, true, 2);
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -95,7 +95,7 @@ public class SoapWrapper {
 		JCEMapper.registerDefaultAlgorithms();
 	}
 
-	private void init() throws ConfigurationException {
+	private static synchronized void initTransformerPools() throws ConfigurationException {
 		if (extractBodySoap11 == null) {
 			try {
 				extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
@@ -114,10 +114,10 @@ public class SoapWrapper {
 		}
 	}
 
-	public static SoapWrapper getInstance() throws ConfigurationException {
+	public static synchronized SoapWrapper getInstance() throws ConfigurationException {
+		initTransformerPools();
 		if (self == null) {
 			self = new SoapWrapper();
-			self.init();
 		}
 		return self;
 	}

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -45,6 +45,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+import lombok.Setter;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
@@ -55,8 +57,6 @@ import org.frankframework.util.StreamUtil;
 import org.frankframework.util.TransformerPool;
 import org.frankframework.util.XmlUtils;
 
-import lombok.Setter;
-
 /**
  * Utility class that wraps and unwraps messages from (and into) a SOAP Envelope.
  *
@@ -65,16 +65,16 @@ import lombok.Setter;
 public class SoapWrapper {
 	protected Logger log = LogUtil.getLogger(this);
 
-	private TransformerPool extractBodySoap11;
-	private TransformerPool extractBodySoap12;
-	private TransformerPool extractHeaderSoap11;
-	private TransformerPool extractHeaderSoap12;
-	private TransformerPool extractFaultCount11;
-	private TransformerPool extractFaultCount12;
-	private TransformerPool extractFaultCode11;
-	private TransformerPool extractFaultCode12;
-	private TransformerPool extractFaultString11;
-	private TransformerPool extractFaultString12;
+	private static TransformerPool extractBodySoap11;
+	private static TransformerPool extractBodySoap12;
+	private static TransformerPool extractHeaderSoap11;
+	private static TransformerPool extractHeaderSoap12;
+	private static TransformerPool extractFaultCount11;
+	private static TransformerPool extractFaultCount12;
+	private static TransformerPool extractFaultCode11;
+	private static TransformerPool extractFaultCode12;
+	private static TransformerPool extractFaultString11;
+	private static TransformerPool extractFaultString12;
 	private static final String NAMESPACE_DEFS_SOAP11 = "soapenv=" + SoapVersion.SOAP11.namespace;
 	private static final String NAMESPACE_DEFS_SOAP12 = "soapenv=" + SoapVersion.SOAP12.namespace;
 	private static final String EXTRACT_BODY_XPATH = "/soapenv:Envelope/soapenv:Body/*";
@@ -96,19 +96,21 @@ public class SoapWrapper {
 	}
 
 	private void init() throws ConfigurationException {
-		try {
-			extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractHeaderSoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractHeaderSoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultCount11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultCount12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultCode11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCODE_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultCode12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCODE_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultString11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTSTRING_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-			extractFaultString12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTSTRING_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
-		} catch (TransformerConfigurationException e) {
-			throw new ConfigurationException("cannot create SOAP transformer", e);
+		if (extractBodySoap11 == null) {
+			try {
+				extractBodySoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractBodySoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_BODY_XPATH, TransformerPool.OutputType.XML, false, false), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractHeaderSoap11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractHeaderSoap12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_HEADER_XPATH, TransformerPool.OutputType.XML), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultCount11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultCount12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCOUNTER_XPATH, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultCode11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTCODE_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultCode12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTCODE_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultString11 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP11, EXTRACT_FAULTSTRING_XPATH_SOAP11, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+				extractFaultString12 = TransformerPool.getUtilityInstance(XmlUtils.createXPathEvaluatorSource(NAMESPACE_DEFS_SOAP12, EXTRACT_FAULTSTRING_XPATH_SOAP12, TransformerPool.OutputType.TEXT), XmlUtils.DEFAULT_XSLT_VERSION);
+			} catch (TransformerConfigurationException e) {
+				throw new ConfigurationException("cannot create SOAP transformer", e);
+			}
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/util/TransformerPool.java
+++ b/core/src/main/java/org/frankframework/util/TransformerPool.java
@@ -49,6 +49,8 @@ import org.springframework.http.MediaType;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import lombok.Getter;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.core.FrankElement;
@@ -64,8 +66,6 @@ import org.frankframework.xml.ClassLoaderURIResolver;
 import org.frankframework.xml.NonResolvingURIResolver;
 import org.frankframework.xml.ThreadConnectingFilter;
 import org.frankframework.xml.TransformerFilter;
-
-import lombok.Getter;
 
 /**
  * Pool of transformers. As of IBIS 4.2.e the Templates object is used to

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -182,18 +182,17 @@ public class XmlUtils {
 	}
 
 	public static TransformerPool getUtilityTransformerPool(String xsltPath, boolean omitXmlDeclaration, boolean indent, int xsltVersion) throws ConfigurationException {
-		Supplier<String> xsltSupplier = () -> {
-			URL resourceURL = ClassLoaderUtils.getResourceURL(xsltPath);
-			if (resourceURL == null) {
-				throw Lombok.sneakyThrow(new ConfigurationException("Could not find resource ["+xsltPath+"]"));
-			}
-			try {
-				return StreamUtil.resourceToString(resourceURL);
-			} catch (IOException e) {
-				throw Lombok.sneakyThrow(e);
-			}
-		};
-		return getUtilityTransformerPool(xsltSupplier, xsltPath, omitXmlDeclaration, indent, xsltVersion);
+		String xslt;
+		URL resourceURL = ClassLoaderUtils.getResourceURL(xsltPath);
+		if (resourceURL == null) {
+			throw new ConfigurationException("Could not find resource ["+xsltPath+"]");
+		}
+		try {
+			xslt = StreamUtil.resourceToString(resourceURL);
+		} catch (IOException e) {
+			throw new ConfigurationException("Could not load classpath resource [" + xsltPath + "]", e);
+		}
+		return getUtilityTransformerPool(() -> (xslt), xsltPath, omitXmlDeclaration, indent, xsltVersion);
 	}
 
 	private static String makeDetectXsltVersionXslt() {

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -168,13 +168,17 @@ public class XmlUtils {
 
 	private static TransformerPool getUtilityTransformerPool(Supplier<String> xsltSupplier, String key, boolean omitXmlDeclaration, boolean indent, int xsltVersion) throws ConfigurationException {
 		String fullKey = key + "-" + omitXmlDeclaration + "-" + indent;
-		return utilityTPs.computeIfAbsent(fullKey, ignored -> {
-			try {
-				return TransformerPool.getUtilityInstance(xsltSupplier.get(), xsltVersion);
-			} catch (TransformerConfigurationException te) {
-				throw Lombok.sneakyThrow(new ConfigurationException("Could not create TransformerPool for ["+key+"]", te));
-			}
-		});
+		try {
+			return utilityTPs.computeIfAbsent(fullKey, ignored -> {
+				try {
+					return TransformerPool.getUtilityInstance(xsltSupplier.get(), xsltVersion);
+				} catch (TransformerConfigurationException te) {
+					throw Lombok.sneakyThrow(te);
+				}
+			});
+		} catch (Exception e) {
+			throw new ConfigurationException("Could not create TransformerPool for [" + key + "]", e);
+		}
 	}
 
 	public static TransformerPool getUtilityTransformerPool(String xsltPath, boolean omitXmlDeclaration, boolean indent, int xsltVersion) throws ConfigurationException {
@@ -186,7 +190,7 @@ public class XmlUtils {
 			try {
 				return StreamUtil.resourceToString(resourceURL);
 			} catch (IOException e) {
-				throw Lombok.sneakyThrow(new ConfigurationException("Could not read resource ["+xsltPath+"]"));
+				throw Lombok.sneakyThrow(e);
 			}
 		};
 		return getUtilityTransformerPool(xsltSupplier, xsltPath, omitXmlDeclaration, indent, xsltVersion);

--- a/core/src/test/java/org/frankframework/pipes/JsonPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/JsonPipeTest.java
@@ -42,7 +42,7 @@ public class JsonPipeTest extends PipeTestBase<JsonPipe> {
 	public void doPipeIntegerInput() throws Exception {
 		pipe.configure();
 		pipe.start();
-		Integer input = Integer.valueOf(1);
+		Integer input = 1;
 		PipeRunResult prr = doPipe(pipe, input, session);
 
 		String result = prr.getResult().asString();


### PR DESCRIPTION
- Cache utility transformer-pools created by the SoapWrapper (as they should be!)
- Cache the transformer-pool in the JsonPipe as a utility transformer-pool
- Clean up the code that creates and caches the utility transformer pools.