### PR TITLE
Ignore the ComponentLoaderTest when running tests within IntelliJ

### DIFF
--- a/core/src/test/java/org/frankframework/components/ComponentLoaderTest.java
+++ b/core/src/test/java/org/frankframework/components/ComponentLoaderTest.java
@@ -1,8 +1,10 @@
 package org.frankframework.components;
 
+import static org.frankframework.testutil.TestAssertions.isTestRunningWithIntelliJ;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.IOException;
 import java.net.URL;
@@ -23,6 +25,9 @@ public class ComponentLoaderTest {
 	@Tag("integration") // This test fails when running just 'mvn test'. Tagged as integration to work around that in the Github Smoketest workflow
 	public void locateCommonsModule() {
 		List<Module> modules = ComponentLoader.findAllModules();
+		if (isTestRunningWithIntelliJ()) {
+			assumeFalse(modules.isEmpty());
+		}
 		assertFalse(modules.isEmpty(), "no modules found, failing!");
 
 		long foundCoreModule = modules.stream().filter(module -> {

--- a/core/src/test/java/org/frankframework/testutil/TestAssertions.java
+++ b/core/src/test/java/org/frankframework/testutil/TestAssertions.java
@@ -166,6 +166,10 @@ public class TestAssertions extends org.junit.jupiter.api.Assertions {
 		return System.getProperty("sun.java.command").contains("surefire");
 	}
 
+	public static boolean isTestRunningWithIntelliJ() {
+		return System.getProperty("sun.java.command").contains("intellij");
+	}
+
 	public static boolean isTestRunningOnWindows() {
 		return System.getProperty("os.name").startsWith("Windows");
 	}


### PR DESCRIPTION
When running tests in IntelliJ the ComponentLoaderTest cannot find the generated pom.properties file in modules.
Ignore it so that there is not always a failing test.