### PR TITLE
Allow JWT Token to omit "Bearer" when it is a non-standard header.

### DIFF
--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.MimeType;
 
 import com.nimbusds.jose.proc.SecurityContext;
@@ -96,7 +97,6 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * These are names that are never allowed as HTTP parameters, because the Frank!Framework sets these names as session variables.
 	 */
 	public static final Set<String> RESERVED_NAMES = Set.of(PipeLineSession.ORIGINAL_MESSAGE_KEY, PipeLineSession.API_PRINCIPAL_KEY, PipeLineSession.HTTP_METHOD_KEY, PipeLineSession.HTTP_REQUEST_KEY, PipeLineSession.HTTP_RESPONSE_KEY, PipeLineSession.SECURITY_HANDLER_KEY, "ClaimsSet", "allowedMethods", "headers", ApiListenerServlet.UPDATE_ETAG_CONTEXT_KEY, "uri", "remoteAddr", ApiListenerServlet.AUTHENTICATION_COOKIE_NAME, MultipartUtils.MULTIPART_ATTACHMENTS_SESSION_KEY);
-	public static final String DEFAULT_AUTHORIZATION_HEADER = "Authorization";
 
 	private final @Getter String domain = "Http";
 	private @Getter String uriPattern;
@@ -130,7 +130,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	// for jwt validation
 	private @Getter String requiredIssuer = null;
 	private @Getter String jwksUrl = null;
-	private @Getter String jwtHeader = DEFAULT_AUTHORIZATION_HEADER;
+	private @Getter String jwtHeader = HttpHeaders.AUTHORIZATION;
 	private @Getter String requiredClaims = null;
 	private @Getter String exactMatchClaims = null;
 	private @Getter String anyMatchClaims = null;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -96,6 +96,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * These are names that are never allowed as HTTP parameters, because the Frank!Framework sets these names as session variables.
 	 */
 	public static final Set<String> RESERVED_NAMES = Set.of(PipeLineSession.ORIGINAL_MESSAGE_KEY, PipeLineSession.API_PRINCIPAL_KEY, PipeLineSession.HTTP_METHOD_KEY, PipeLineSession.HTTP_REQUEST_KEY, PipeLineSession.HTTP_RESPONSE_KEY, PipeLineSession.SECURITY_HANDLER_KEY, "ClaimsSet", "allowedMethods", "headers", ApiListenerServlet.UPDATE_ETAG_CONTEXT_KEY, "uri", "remoteAddr", ApiListenerServlet.AUTHENTICATION_COOKIE_NAME, MultipartUtils.MULTIPART_ATTACHMENTS_SESSION_KEY);
+	public static final String DEFAULT_AUTHORIZATION_HEADER = "Authorization";
 
 	private final @Getter String domain = "Http";
 	private @Getter String uriPattern;
@@ -129,7 +130,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	// for jwt validation
 	private @Getter String requiredIssuer = null;
 	private @Getter String jwksUrl = null;
-	private @Getter String jwtHeader = "Authorization";
+	private @Getter String jwtHeader = DEFAULT_AUTHORIZATION_HEADER;
 	private @Getter String requiredClaims = null;
 	private @Getter String exactMatchClaims = null;
 	private @Getter String anyMatchClaims = null;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -297,7 +297,7 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 						}
 						break;
 					case HEADER:
-						authorizationToken = request.getHeader("Authorization");
+						authorizationToken = request.getHeader(ApiListener.DEFAULT_AUTHORIZATION_HEADER);
 						break;
 					case AUTHROLE:
 						List<String> roles = listener.getAuthenticationRoleList();
@@ -310,9 +310,11 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 						break;
 					case JWT:
 						String authorizationHeader = request.getHeader(listener.getJwtHeader());
-						if (StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.contains("Bearer")) {
+						boolean isNonStandardJwtAuthHeader = !ApiListener.DEFAULT_AUTHORIZATION_HEADER.equalsIgnoreCase(listener.getJwtHeader());
+						if (StringUtils.isNotEmpty(authorizationHeader) && (authorizationHeader.startsWith("Bearer") || isNonStandardJwtAuthHeader)) {
 							try {
-								Map<String, Object> claimsSet = listener.getJwtValidator().validateJWT(authorizationHeader.substring(7));
+								String jwtToken = StringUtils.removeStartIgnoreCase(authorizationHeader, "Bearer ");
+								Map<String, Object> claimsSet = listener.getJwtValidator().validateJWT(jwtToken);
 								pipelineSession.setSecurityHandler(new JwtSecurityHandler(claimsSet, listener.getRoleClaim(), listener.getPrincipalNameClaim()));
 								pipelineSession.put("ClaimsSet", JSONObjectUtils.toJSONString(claimsSet));
 							} catch (Exception e) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -43,6 +43,7 @@ import org.apache.http.HttpEntity;
 import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeType;
 
@@ -297,7 +298,7 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 						}
 						break;
 					case HEADER:
-						authorizationToken = request.getHeader(ApiListener.DEFAULT_AUTHORIZATION_HEADER);
+						authorizationToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 						break;
 					case AUTHROLE:
 						List<String> roles = listener.getAuthenticationRoleList();
@@ -310,7 +311,7 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 						break;
 					case JWT:
 						String authorizationHeader = request.getHeader(listener.getJwtHeader());
-						boolean isNonStandardJwtAuthHeader = !ApiListener.DEFAULT_AUTHORIZATION_HEADER.equalsIgnoreCase(listener.getJwtHeader());
+						boolean isNonStandardJwtAuthHeader = !HttpHeaders.AUTHORIZATION.equalsIgnoreCase(listener.getJwtHeader());
 						if (StringUtils.isNotEmpty(authorizationHeader) && (authorizationHeader.startsWith("Bearer") || isNonStandardJwtAuthHeader)) {
 							try {
 								String jwtToken = StringUtils.removeStartIgnoreCase(authorizationHeader, "Bearer ");

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -78,6 +78,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -1688,7 +1689,7 @@ public class ApiListenerServletTest {
 				.setAuthenticationMethod(AuthenticationMethods.JWT)
 				.build();
 
-		Response result = service(prepareJWTRequest(null, ApiListener.DEFAULT_AUTHORIZATION_HEADER, false));
+		Response result = service(prepareJWTRequest(null, HttpHeaders.AUTHORIZATION, false));
 
 		assertEquals(401, result.getStatus());
 		assertEquals("JWT is not provided as bearer token",result.getErrorMessage());
@@ -2039,7 +2040,7 @@ public class ApiListenerServletTest {
 	}
 
 	public @Nonnull MockHttpServletRequest prepareJWTRequest(@Nullable String token) throws Exception {
-		return prepareJWTRequest(token, ApiListener.DEFAULT_AUTHORIZATION_HEADER, true);
+		return prepareJWTRequest(token, HttpHeaders.AUTHORIZATION, true);
 	}
 	public @Nonnull MockHttpServletRequest prepareJWTRequest(@Nullable String token, @Nonnull String header) throws Exception {
 		return prepareJWTRequest(token, header, true);

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.spy;
 
 import java.io.ByteArrayInputStream;
@@ -56,6 +55,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.X509KeyManager;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.Cookie;
@@ -1345,11 +1345,9 @@ public class ApiListenerServletTest {
 	}
 
 	@ParameterizedTest
-	@EnumSource(HttpMethod.class)
+	//you may not set the OPTIONS method on an ApiListener, the Servlet should handle this without calling the adapter
+	@EnumSource(value = HttpMethod.class, mode = EnumSource.Mode.EXCLUDE, names = { "OPTIONS" })
 	public void testRequestWithAccept(HttpMethod method) throws Exception {
-		//you may not set the OPTIONS method on an ApiListener, the Servlet should handle this without calling the adapter
-		assumeFalse(method == HttpMethod.OPTIONS);
-
 		// Arrange
 		String uri = "/messageWithJson2XmlValidator";
 		new ApiListenerBuilder(uri, List.of(method), null, MediaTypes.XML).build();
@@ -1662,6 +1660,38 @@ public class ApiListenerServletTest {
 		assertEquals(PAYLOAD, session.get("ClaimsSet"));
 		assertTrue(result.containsHeader("Allow"));
 		assertNull(result.getErrorMessage());
+	}
+
+	@Test
+	public void testJwtTokenParsingWithNonStandardJwtHeaderNoBearerToken() throws Exception {
+		final String JWT_HEADER = "X-JWT-Assertion";
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(HttpMethod.GET))
+				.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
+				.setRequiredIssuer("JWTPipeTest")
+				.setAuthenticationMethod(AuthenticationMethods.JWT)
+				.setJwtHeader(JWT_HEADER)
+				.build();
+
+		Response result = service(prepareJWTRequest(null, JWT_HEADER, false));
+
+		assertEquals(200, result.getStatus());
+		assertEquals(PAYLOAD, session.get("ClaimsSet"));
+		assertTrue(result.containsHeader("Allow"));
+		assertNull(result.getErrorMessage());
+	}
+
+	@Test
+	public void testJwtTokenParsingWithStandardJwtHeaderNoBearerToken() throws Exception {
+		new ApiListenerBuilder(JWT_VALIDATION_URI, List.of(HttpMethod.GET))
+				.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
+				.setRequiredIssuer("JWTPipeTest")
+				.setAuthenticationMethod(AuthenticationMethods.JWT)
+				.build();
+
+		Response result = service(prepareJWTRequest(null, ApiListener.DEFAULT_AUTHORIZATION_HEADER, false));
+
+		assertEquals(401, result.getStatus());
+		assertEquals("JWT is not provided as bearer token",result.getErrorMessage());
 	}
 
 	@Test
@@ -2008,12 +2038,15 @@ public class ApiListenerServletTest {
 		return signedJWT.serialize();
 	}
 
-	public MockHttpServletRequest prepareJWTRequest(String token) throws Exception {
-		return prepareJWTRequest(token, "Authorization");
+	public @Nonnull MockHttpServletRequest prepareJWTRequest(@Nullable String token) throws Exception {
+		return prepareJWTRequest(token, ApiListener.DEFAULT_AUTHORIZATION_HEADER, true);
 	}
-	public MockHttpServletRequest prepareJWTRequest(String token, String header) throws Exception {
+	public @Nonnull MockHttpServletRequest prepareJWTRequest(@Nullable String token, @Nonnull String header) throws Exception {
+		return prepareJWTRequest(token, header, true);
+	}
+	public @Nonnull MockHttpServletRequest prepareJWTRequest(@Nullable String token, @Nonnull String header, boolean isBearerToken) throws Exception {
 		Map<String, String> headers = new HashMap<>();
-		headers.put(header, "Bearer "+ (token != null ? token : createJWT()) );
+		headers.put(header, (isBearerToken ? "Bearer " : "") + (token != null ? token : createJWT()) );
 
 		return createRequest(JWT_VALIDATION_URI, HttpMethod.GET, null, headers);
 	}


### PR DESCRIPTION
Fixes #8773.