### PR TITLE
Refactor InputOutputPipeProcessor

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -183,8 +183,9 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	 * @return {@code true} if {@code value} is not a {@link Message}, or if it is a Message with a request that is not a scalar or array type. Returns {@code false} otherwise.
 	 */
 	private static boolean isValueToBeClosed(AutoCloseable value) {
-		if (!(value instanceof Message message)) return true; // Should be closed, but is not a message
-		if (message.isNull()) return false; // Null message doesn't have to be closed
+		if (!(value instanceof Message message)) return true; // Should be closed, value is not a message.
+		if (message.isNull()) return false; // NULL message doesn't have to be closed.
+
 		return !(message.isRequestOfType(String.class) ||
 				message.isRequestOfType(Number.class) ||
 				message.isRequestOfType(Date.class) ||

--- a/core/src/main/java/org/frankframework/util/CleanerProvider.java
+++ b/core/src/main/java/org/frankframework/util/CleanerProvider.java
@@ -133,7 +133,7 @@ public class CleanerProvider {
 			this.cleaningAction = cleaningAction;
 			actionId = getActionId(cleaningAction);
 			owningClassName = owner.getClass().getName();
-			isProxyClass = Proxy.isProxyClass(owner.getClass()) || owningClassName.contains("$$");
+			isProxyClass = Proxy.isProxyClass(owner.getClass()) || owningClassName.contains(org.springframework.util.ClassUtils.CGLIB_CLASS_SEPARATOR);
 			creationTrace = new LeakedResourceException(owner);
 		}
 

--- a/core/src/main/java/org/frankframework/util/XmlUtils.java
+++ b/core/src/main/java/org/frankframework/util/XmlUtils.java
@@ -1132,7 +1132,9 @@ public class XmlUtils {
 	}
 
 	public static boolean isWellFormed(String input, String root) {
-		return isWellFormed(new Message(input), root);
+		try (Message message = new Message(input)) {
+		return isWellFormed(message, root);
+		}
 	}
 
 	public static boolean isWellFormed(Message input, String root) {

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -83,6 +83,7 @@ public class InputOutputPipeProcessorTest {
 	// ensure that no files are in the 'restoreMovedElements' folder
 	@AfterEach
 	public void teardown() throws IOException {
+		session.close();
 		Path tempDirectory = TemporaryDirectoryUtils.getTempDirectory(SerializableFileReference.TEMP_MESSAGE_DIRECTORY);
 		assertEquals(0, Files.list(tempDirectory).count());
 	}

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -17,6 +17,8 @@ import jakarta.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.util.FileSystemUtils;
 
 import net.jcip.annotations.NotThreadSafe;
@@ -337,7 +339,8 @@ public class InputOutputPipeProcessorTest {
 		String expectedValue = "session-key-value";
 		session.put("the-session-key", expectedValue);
 
-		// This should be true, b/c input message is empty
+		// This should be true, b/c input message is empty, but code point
+		// should not be triggered because it is replaced by the session key.
 		assertTrue(pipe.skipPipe(input, session));
 
 		// Act
@@ -345,6 +348,66 @@ public class InputOutputPipeProcessorTest {
 
 		// Assert
 		assertEquals(expectedValue, prr.getResult().asString());
+	}
+
+	@ParameterizedTest // SessionKey exists but is empty
+	@NullAndEmptySource
+	public void testSkipOnEmptyInputAfterGetInputFromSessionKey(String sessionValue) throws Exception {
+		// Arrange
+		pipe.setGetInputFromSessionKey("the-session-key");
+		pipe.setSkipOnEmptyInput(true);
+		pipe.configure();
+		pipe.start();
+
+		Message input = Message.nullMessage();
+		session.put("the-session-key", sessionValue);
+
+		// This should be true
+		assertTrue(pipe.skipPipe(input, session));
+
+		// Act
+		PipeRunResult prr = processor.processPipe(pipeLine, pipe, input, session);
+
+		// Assert
+		assertEquals(sessionValue, prr.getResult().asString());
+	}
+
+	@Test
+	public void testGetInputFromSessionKeyAndFixedValue() throws Exception {
+		// Arrange
+		pipe.setSkipOnEmptyInput(true);
+		pipe.setGetInputFromSessionKey("the-session-key");
+		pipe.setGetInputFromFixedValue("fixed-value");
+		pipe.configure();
+		pipe.start();
+
+		Message input = Message.nullMessage();
+		session.put("the-session-key", "session-value"); // This value is overwritten by the fixed value
+
+		// Act
+		PipeRunResult prr = processor.processPipe(pipeLine, pipe, input, session);
+
+		// Assert
+		assertEquals("fixed-value", prr.getResult().asString());
+	}
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	public void testGetInputFromEmptyFixedValue(String fixedValue) throws Exception {
+		// Arrange
+		pipe.setSkipOnEmptyInput(true);
+		pipe.setGetInputFromFixedValue(fixedValue);
+		pipe.setEmptyInputReplacement("tralala");
+		pipe.configure();
+		pipe.start();
+
+		Message input = Message.nullMessage();
+
+		// Act
+		PipeRunResult prr = processor.processPipe(pipeLine, pipe, input, session);
+
+		// Assert
+		assertEquals("tralala", prr.getResult().asString());
 	}
 
 	@Test


### PR DESCRIPTION
This PR started off as me trying to add more test coverage and reduce the brain method in the `InputOutputPipeProcessor`.
I noticed some leaks in the leak log and added the values to the closeables list, however since they are String based messages, they are never closed.

Not sure what the way forward is here, do we trust the leak log, do we ignore String messages in there? Do we call close on Message but not set the value to null??