### PR TITLE
Workaround for bug in IntelliJ 2025.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -780,26 +780,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>log4j2-plugin-processor</id>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-						<phase>process-classes</phase>
-						<configuration>
-							<proc>only</proc>
-							<compileSourceRoots>${project.build.outputDirectory}</compileSourceRoots>
-							<annotationProcessors>
-								<annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</annotationProcessor>
-							</annotationProcessors>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>


### PR DESCRIPTION
Workaround for this bug in IntelliJ 2025.1: https://youtrack.jetbrains.com/issue/IDEA-368907/Annotation-Processor-configuration-is-misinterpreted