### PR TITLE
fix: AppConstants.properties formatting

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -486,8 +486,7 @@ msg.log.keys=conversationId
 
 ## Define xPath for key conversationId
 msg.log.xPath.conversationId=*[local-name()='Envelope']/*[local-name()='Header']/*[local-name()='MessageHeader']/*[local-name()='HeaderFields']/*[local-name()='ConversationId']
-#
-# Display duration in human-readable format by appending a duration letter such as 'S' (second) or 'M' (minute)
+## Display duration in human-readable format by appending a duration letter such as 'S' (second) or 'M' (minute)
 msg.log.humanReadable=false
 
 sec.log.includeMessage=false

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -790,7 +790,7 @@ migration.rewriteLegacyClassNames=true
 ## [Deprecated]
 #ldap.auth.url
 
-# [Deprecated]
+## [Deprecated]
 #ldap.props.file
 
 ####


### PR DESCRIPTION
* Adds a second '#' to a description line, so it will not be parsed as a property.
* Fixes an unintentional newline causing a deprecation tag to appear in the docs.
![image](https://github.com/user-attachments/assets/5b83e09c-a16c-42ae-854d-1cc229b44cb5)
