### PR TITLE
Take advantage of the logcontext in pipe processors

### DIFF
--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -148,7 +148,7 @@ public interface IPipe extends IConfigurable, IForwardTarget, FrankElement, Name
 	void setRestoreMovedElements(boolean restoreMovedElements);
 	boolean isRestoreMovedElements();
 
-	/** If durationThreshold >=0 and the duration of the message processing exceeded the value specified (in milliseconds) the message is logged informatory to be analyzed
+	/** If durationThreshold >=0 and the duration of the message processing exceeded the value specified (in milliseconds) the message will be logged and a monitor event will be fired.
 	 * @ff.default -1
 	 */
 	void setDurationThreshold(long maxDuration);

--- a/core/src/main/java/org/frankframework/core/PipeRunResult.java
+++ b/core/src/main/java/org/frankframework/core/PipeRunResult.java
@@ -15,6 +15,8 @@
 */
 package org.frankframework.core;
 
+import jakarta.annotation.Nonnull;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import lombok.Getter;
@@ -70,6 +72,7 @@ public class PipeRunResult implements AutoCloseable {
 		this.result = result;
 	}
 
+	@Nonnull
 	public Message getResult() {
 		if (result == null) {
 			return Message.nullMessage();

--- a/core/src/main/java/org/frankframework/processors/AbstractPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/AbstractPipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package org.frankframework.processors;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
-import org.apache.logging.log4j.Logger;
-
 import lombok.Setter;
 
 import org.frankframework.core.IPipe;
@@ -30,7 +28,6 @@ import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.functional.ThrowingFunction;
 import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
 
 /**
  * Baseclass for PipeProcessors.
@@ -39,7 +36,6 @@ import org.frankframework.util.LogUtil;
  * @since   4.11
  */
 public abstract class AbstractPipeProcessor implements PipeProcessor {
-	protected Logger log = LogUtil.getLogger(this);
 
 	@Setter private PipeProcessor pipeProcessor;
 

--- a/core/src/main/java/org/frankframework/processors/AbstractPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/AbstractPipeProcessor.java
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import lombok.Setter;
 
@@ -39,15 +38,15 @@ public abstract class AbstractPipeProcessor implements PipeProcessor {
 
 	@Setter private PipeProcessor pipeProcessor;
 
-	protected abstract PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException;
+	protected abstract PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException;
 
 	@Override
-	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
+	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return processPipe(pipeLine, pipe, message, pipeLineSession, m -> pipeProcessor.processPipe(pipeLine, pipe, m, pipeLineSession));
 	}
 
 	@Override
-	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
+	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
 		return processPipe(pipeLine, validator, message, pipeLineSession, m -> pipeProcessor.validate(pipeLine, validator, m, pipeLineSession, messageRoot));
 	}
 

--- a/core/src/main/java/org/frankframework/processors/CheckMessageSizePipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CheckMessageSizePipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.frankframework.processors;
 import jakarta.annotation.Nonnull;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeLine;
@@ -27,9 +28,7 @@ import org.frankframework.functional.ThrowingFunction;
 import org.frankframework.stream.Message;
 import org.frankframework.util.Misc;
 
-/**
- * @author Jaco de Groot
- */
+@Log4j2
 public class CheckMessageSizePipeProcessor extends AbstractPipeProcessor {
 
 	@Override
@@ -55,7 +54,7 @@ public class CheckMessageSizePipeProcessor extends AbstractPipeProcessor {
 			}
 
 			if (pipeLine.getMessageSizeWarnNum() >= 0 && messageLength >= pipeLine.getMessageSizeWarnNum()) {
-				log.warn("pipe [{}] of adapter [{}], {} message size [{}] exceeds [{}]", pipe.getName(), pipeLine.getOwner().getName(), (input ? "input" : "result"), Misc.toFileSize(messageLength), Misc.toFileSize(pipeLine.getMessageSizeWarnNum()));
+				log.warn("{} message size [{}] exceeds [{}]", ()-> (input ? "input" : "result"), () -> Misc.toFileSize(messageLength), () -> Misc.toFileSize(pipeLine.getMessageSizeWarnNum()));
 				pipe.throwEvent(IPipe.MESSAGE_SIZE_MONITORING_EVENT);
 			}
 		}

--- a/core/src/main/java/org/frankframework/processors/CheckMessageSizePipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CheckMessageSizePipeProcessor.java
@@ -32,7 +32,7 @@ import org.frankframework.util.Misc;
 public class CheckMessageSizePipeProcessor extends AbstractPipeProcessor {
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 		checkMessageSize(message.size(), pipeLine, pipe, true);
 		PipeRunResult pipeRunResult = chain.apply(message);
 

--- a/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
@@ -18,6 +18,8 @@ package org.frankframework.processors;
 
 import java.util.Map;
 
+import jakarta.annotation.Nonnull;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -60,7 +62,7 @@ public class CorePipeLineProcessor implements PipeLineProcessor, ApplicationCont
 	}
 
 	@Override
-	public PipeLineResult processPipeLine(PipeLine pipeLine, String messageId, Message message, PipeLineSession pipeLineSession, String firstPipe) throws PipeRunException {
+	public PipeLineResult processPipeLine(PipeLine pipeLine, String messageId, @Nonnull Message message, PipeLineSession pipeLineSession, String firstPipe) throws PipeRunException {
 
 		if (message.isEmpty() && StringUtils.isNotEmpty(pipeLine.getAdapterToRunBeforeOnEmptyInput())) {
 			log.debug("running adapterBeforeOnEmptyInput");

--- a/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
@@ -50,6 +50,7 @@ public class CorePipeLineProcessor implements PipeLineProcessor, ApplicationCont
 	private @Setter PipeProcessor pipeProcessor;
 	private Configuration configuration;
 
+	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		if (applicationContext instanceof Configuration config) {
 			configuration = config;

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.Map;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -39,7 +38,7 @@ import org.frankframework.stream.Message;
 public class ExceptionHandlingPipeProcessor extends AbstractPipeProcessor {
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 		try {
 			return chain.apply(message);
 		} catch (Exception e) {

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.core.HasName;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeForward;
@@ -33,6 +35,7 @@ import org.frankframework.functional.ThrowingFunction;
 import org.frankframework.pipes.ExceptionPipe;
 import org.frankframework.stream.Message;
 
+@Log4j2
 public class ExceptionHandlingPipeProcessor extends AbstractPipeProcessor {
 
 	@Override

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -59,7 +59,7 @@ public class ExceptionHandlingPipeProcessor extends AbstractPipeProcessor {
 					HasName location = exception.getPipeInError();
 					errorMessage = emf.format(null, e.getCause(), location, message, pipeLineSession.getMessageId(), tsReceivedLong);
 				} else {
-					errorMessage = emf.format(null, e, pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
+					errorMessage = emf.format(null, e, pipeLine.getAdapter(), message, pipeLineSession.getMessageId(), tsReceivedLong);
 				}
 
 				log.info("exception occurred, forwarding to exception-forward [{}]", PipeForward.EXCEPTION_FORWARD_NAME, e);

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -62,7 +62,7 @@ public class ExceptionHandlingPipeProcessor extends AbstractPipeProcessor {
 					errorMessage = emf.format(null, e, pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
 				}
 
-				log.info("exception occured, forwarding to exception-forward [{}], exception:\n", PipeForward.EXCEPTION_FORWARD_NAME, e);
+				log.info("exception occured, forwarding to exception-forward [{}]", PipeForward.EXCEPTION_FORWARD_NAME, e);
 				return new PipeRunResult(pipe.getForwards().get(PipeForward.EXCEPTION_FORWARD_NAME), errorMessage);
 			}
 			throw e;

--- a/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ExceptionHandlingPipeProcessor.java
@@ -62,7 +62,7 @@ public class ExceptionHandlingPipeProcessor extends AbstractPipeProcessor {
 					errorMessage = emf.format(null, e, pipeLine.getOwner(), message, pipeLineSession.getMessageId(), tsReceivedLong);
 				}
 
-				log.info("exception occured, forwarding to exception-forward [{}]", PipeForward.EXCEPTION_FORWARD_NAME, e);
+				log.info("exception occurred, forwarding to exception-forward [{}]", PipeForward.EXCEPTION_FORWARD_NAME, e);
 				return new PipeRunResult(pipe.getForwards().get(PipeForward.EXCEPTION_FORWARD_NAME), errorMessage);
 			}
 			throw e;

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeLineProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeLineProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden
+   Copyright 2013, 2020 Nationale-Nederlanden, 2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
 */
 package org.frankframework.processors;
 
+import org.apache.logging.log4j.CloseableThreadContext;
+
 import org.frankframework.core.PipeLine;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.stream.Message;
+import org.frankframework.util.LogUtil;
 import org.frankframework.util.UUIDUtil;
 
 /**
@@ -27,21 +30,27 @@ import org.frankframework.util.UUIDUtil;
  */
 public class InputOutputPipeLineProcessor extends AbstractPipeLineProcessor {
 
+	// We have tests to validate that the messageId, if already set in the LogContext, is technically overwritten, but not removed upon the try-with-resources closure.
 	@Override
 	public PipeLineResult processPipeLine(PipeLine pipeLine, String messageId, Message message, PipeLineSession pipeLineSession, String firstPipe) throws PipeRunException {
-		// reset the PipeLineSession and store the message and its id in the session
-		if (messageId==null) {
-				messageId= UUIDUtil.createSimpleUUID();
-			log.error("null value for messageId, setting to [{}]", messageId);
-
+		// Reset the PipeLineSession and store the message and its id in the session
+		if (messageId == null) {
+			messageId = UUIDUtil.createSimpleUUID();
+			log.error("messageId not set, creating synthetic id [{}]", messageId);
 		}
+
 		if (message == null) {
 			throw new PipeRunException(null, "Pipeline of adapter ["+ pipeLine.getOwner().getName()+"] received null message");
 		}
-		// store message and messageId in the pipeLineSession
+
+		// Store message and messageId in the pipeLineSession
 		pipeLineSession.put(PipeLineSession.ORIGINAL_MESSAGE_KEY, message);
 		pipeLineSession.put(PipeLineSession.MESSAGE_ID_KEY, messageId);
-		return pipeLineProcessor.processPipeLine(pipeLine, messageId, message, pipeLineSession, firstPipe);
+
+		// Store messageId in the LogContext, it may already be present but we want to make sure it is set for log traceability.
+		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_MESSAGE_ID_KEY, messageId)) {
+			return pipeLineProcessor.processPipeLine(pipeLine, messageId, message, pipeLineSession, firstPipe);
+		}
 	}
 
 }

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -252,7 +252,8 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 		}
 	}
 
-	@Override // method needs to be overridden to enable AOP for debugger
+	@Override
+	@SuppressWarnings("java:S1185") // method needs to be overridden to enable AOP for debugger
 	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return super.processPipe(pipeLine, pipe, message, pipeLineSession);
 	}

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -72,7 +71,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	// Message should not be nullable?
 	// Should the skipPipe be handled before getInputFrom?
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable final Message inputMessage, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull final Message inputMessage, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 		Message originalMessage = inputMessage;
 
 		// Get the input message for the pipe to be processed, does not return null.
@@ -104,7 +103,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 			return postProcessPipeResult(pipe, pipeLineSession, pipeRunResult, originalMessage);
 		} finally {
 			if (pipe.isWriteToSecLog()) {
-				SEC_LOG.info("adapter [{}] pipe [{}]{}", () -> pipeLine.getAdapter(), pipe::getName, () -> computeSessionKeys(pipeLineSession, pipe));
+				SEC_LOG.info("adapter [{}] pipe [{}]{}", pipeLine::getAdapter, pipe::getName, () -> computeSessionKeys(pipeLineSession, pipe));
 			}
 		}
 	}
@@ -153,7 +152,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	 * Registers the original message to be closed, as we're not using it.
 	 */
 	@Nonnull
-	private Message getInputFrom(@Nonnull final IPipe pipe, @Nullable final Message message, @Nonnull final PipeLineSession pipeLineSession) throws PipeRunException {
+	private Message getInputFrom(@Nonnull final IPipe pipe, @Nonnull final Message message, @Nonnull final PipeLineSession pipeLineSession) throws PipeRunException {
 		// The order of these two methods has been changed to make it backwards compatible.
 		if (StringUtils.isNotEmpty(pipe.getGetInputFromFixedValue())) {
 			log.debug("replacing input with fixed value [{}]", pipe::getGetInputFromFixedValue);
@@ -183,7 +182,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 			}
 		}
 
-		return message == null ? Message.nullMessage() : message;
+		return message;
 	}
 
 	private void processMessageCompaction(IPipe pipe, PipeLineSession pipeLineSession, PipeRunResult pipeRunResult) throws PipeRunException {
@@ -254,7 +253,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	}
 
 	@Override // method needs to be overridden to enable AOP for debugger
-	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
+	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return super.processPipe(pipeLine, pipe, message, pipeLineSession);
 	}
 

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -104,7 +104,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 			return postProcessPipeResult(pipe, pipeLineSession, pipeRunResult, originalMessage);
 		} finally {
 			if (pipe.isWriteToSecLog()) {
-				SEC_LOG.info("adapter [{}] pipe [{}]{}", () -> pipeLine.getOwner().getName(), pipe::getName, () -> computeSessionKeys(pipeLineSession, pipe));
+				SEC_LOG.info("adapter [{}] pipe [{}]{}", () -> pipeLine.getAdapter(), pipe::getName, () -> computeSessionKeys(pipeLineSession, pipe));
 			}
 		}
 	}

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -27,6 +27,8 @@ import org.apache.logging.log4j.Logger;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeLine;
 import org.frankframework.core.PipeLineSession;
@@ -51,6 +53,7 @@ import org.frankframework.xml.XmlWriter;
  *
  * @author Jaco de Groot
  */
+@Log4j2
 public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	private static final Logger SEC_LOG = LogUtil.getLogger("SEC");
 
@@ -68,6 +71,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	 * @throws PipeRunException if there is an error during processing.
 	 */
 	// Message should not be nullable?
+	// Should the skipPipe be handled before getInputFrom?
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable final Message inputMessage, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 		Message originalMessage = inputMessage;
@@ -117,6 +121,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 				Collectors.joining(",")) + "]";
 	}
 
+	// TODO restore MessageContext#CONTEXT_PREVIOUS_PIPE && MessageContext#CONTEXT_PIPELINE_CALLER
 	private PipeRunResult postProcessPipeResult(IPipe pipe, PipeLineSession pipeLineSession, PipeRunResult pipeRunResult, Message originalMessage) throws PipeRunException {
 		if (pipe.isRestoreMovedElements()) {
 			processRestoreMovedElements(pipe, pipeLineSession, pipeRunResult);
@@ -246,7 +251,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 		try {
 			// Preserve the message so that it can be read again, in case there was an error during compacting
 			result.preserve();
- 			return result.asInputSource();
+			return result.asInputSource();
 		} catch (IOException e) {
 			throw new PipeRunException(pipe, "could not read received message during restoring/compaction of moved elements", e);
 		}

--- a/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
@@ -69,14 +69,14 @@ public class LimitingParallelExecutionPipeProcessor extends AbstractPipeProcesso
 		}
 	}
 
-	// Method needs to be overridden to enable AOP for debugger
 	@Override
+	@SuppressWarnings("java:S1185") // method needs to be overridden to enable AOP for debugger
 	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return super.processPipe(pipeLine, pipe, message, pipeLineSession);
 	}
 
-	// Method needs to be overridden to enable AOP for debugger
 	@Override
+	@SuppressWarnings("java:S1185") // method needs to be overridden to enable AOP for debugger
 	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
 		return super.validate(pipeLine, validator, message, pipeLineSession, messageRoot);
 	}

--- a/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import lombok.extern.log4j.Log4j2;
@@ -43,7 +42,7 @@ public class LimitingParallelExecutionPipeProcessor extends AbstractPipeProcesso
 	private final Map<IPipe, ResourceLimiter> pipeThreadCounts = new ConcurrentHashMap<>();
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		ResourceLimiter threadCountLimiter = getThreadLimiter(pipe);
 		if (threadCountLimiter == null) { // no restrictions on the maximum number of threads
 			return chain.apply(message);
@@ -72,13 +71,13 @@ public class LimitingParallelExecutionPipeProcessor extends AbstractPipeProcesso
 
 	// Method needs to be overridden to enable AOP for debugger
 	@Override
-	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
+	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return super.processPipe(pipeLine, pipe, message, pipeLineSession);
 	}
 
 	// Method needs to be overridden to enable AOP for debugger
 	@Override
-	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
+	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
 		return super.validate(pipeLine, validator, message, pipeLineSession, messageRoot);
 	}
 

--- a/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2024 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.IValidator;
@@ -35,8 +36,8 @@ import org.frankframework.stream.Message;
 
 /**
  * Processor that limits the number of parallel pipe threads.
- * @author Jaco de Groot
  */
+@Log4j2
 public class LimitingParallelExecutionPipeProcessor extends AbstractPipeProcessor {
 
 	private final Map<IPipe, ResourceLimiter> pipeThreadCounts = new ConcurrentHashMap<>();
@@ -47,30 +48,35 @@ public class LimitingParallelExecutionPipeProcessor extends AbstractPipeProcesso
 		if (threadCountLimiter == null) { // no restrictions on the maximum number of threads
 			return chain.apply(message);
 		}
-		long waitingDuration;
+
+		final long waitingDuration;
 		try {
 			// keep waiting statistics for thread-limited pipes
 			long startWaiting = System.currentTimeMillis();
 			threadCountLimiter.acquire();
+
+			// If a ResourceLimiter is present, we need to wait for the thread to be available.
+			log.trace("ResourceLimiter acquired a thread");
 			waitingDuration = System.currentTimeMillis() - startWaiting;
 			DistributionSummary summary = pipeLine.getPipeWaitStatistics(pipe);
 			summary.record(waitingDuration);
 			return chain.apply(message);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			throw new PipeRunException(pipe, "Interrupted acquiring Pipe thread count limiter", e);
+			throw new PipeRunException(pipe, "interrupted acquiring pipe thread count limiter", e);
 		} finally {
 			threadCountLimiter.release();
+			log.trace("ResourceLimiter released a thread");
 		}
 	}
 
-	// method needs to be overridden to enable AOP for debugger
+	// Method needs to be overridden to enable AOP for debugger
 	@Override
 	public PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException {
 		return super.processPipe(pipeLine, pipe, message, pipeLineSession);
 	}
 
-	// method needs to be overridden to enable AOP for debugger
+	// Method needs to be overridden to enable AOP for debugger
 	@Override
 	public PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException {
 		return super.validate(pipeLine, validator, message, pipeLineSession, messageRoot);

--- a/core/src/main/java/org/frankframework/processors/LockerPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LockerPipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeLine;
@@ -33,8 +32,7 @@ import org.frankframework.util.Locker;
 public class LockerPipeProcessor extends AbstractPipeProcessor {
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
-		PipeRunResult pipeRunResult;
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		String objectId;
 		Locker locker = pipe.getLocker();
 		if (locker == null) {
@@ -50,7 +48,7 @@ public class LockerPipeProcessor extends AbstractPipeProcessor {
 			throw new PipeRunException(pipe, "could not obtain lock [" + locker + "]");
 		}
 		try {
-			pipeRunResult = chain.apply(message);
+			return chain.apply(message);
 		} finally {
 			try {
 				locker.release(objectId);
@@ -58,7 +56,6 @@ public class LockerPipeProcessor extends AbstractPipeProcessor {
 				throw new PipeRunException(pipe, "error while removing lock", e);
 			}
 		}
-		return pipeRunResult;
 	}
 
 }

--- a/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
@@ -33,7 +33,7 @@ import org.frankframework.util.AppConstants;
 
 @Log4j2
 public class LogPipeProcessor extends AbstractPipeProcessor {
-	private static final boolean LOG_INTERMEDIARY_RESULTS = AppConstants.getInstance().getBoolean("log.logIntermediaryResults", false);
+	private static final boolean LOG_INTERMEDIARY_RESULTS = AppConstants.getInstance().getBoolean("log.logIntermediaryResults", true);
 
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {

--- a/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
@@ -1,0 +1,61 @@
+/*
+   Copyright 2025 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.processors;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.core.IPipe;
+import org.frankframework.core.PipeLine;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.PipeRunException;
+import org.frankframework.core.PipeRunResult;
+import org.frankframework.functional.ThrowingFunction;
+import org.frankframework.stream.Message;
+import org.frankframework.util.AppConstants;
+
+@Log4j2
+public class LogPipeProcessor extends AbstractPipeProcessor {
+
+	@Override
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
+		if (!log.isDebugEnabled()) {
+			doDebugLogging(pipeLine, pipe, message, pipeLineSession);
+		}
+
+		return chain.apply(message);
+	}
+
+	private void doDebugLogging(final PipeLine pipeLine, final IPipe pipe, Message message, PipeLineSession pipeLineSession) {
+		String ownerName = pipeLine.getOwner() == null ? "<null>" : pipeLine.getOwner().getName();
+		StringBuilder sb = new StringBuilder();
+		sb.append("Pipeline of adapter [").append(ownerName).append("] messageId [").append(pipeLineSession.getMessageId()).append("] is about to call pipe [").append(pipe.getName()).append("]");
+
+		boolean lir = AppConstants.getInstance().getBoolean("log.logIntermediaryResults", false);
+		if (StringUtils.isNotEmpty(pipe.getLogIntermediaryResults())) {
+			lir = Boolean.parseBoolean(pipe.getLogIntermediaryResults());
+		}
+		if (lir) {
+			sb.append(" current result ").append(message == null ? "<null>" : "(" + message.getClass().getSimpleName() + ") [" + message + "]").append(" ");
+		}
+		log.debug(sb.toString());
+	}
+
+}

--- a/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/LogPipeProcessor.java
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.CloseableThreadContext;
@@ -45,9 +44,9 @@ public class LogPipeProcessor extends AbstractPipeProcessor {
 	private static final boolean LOG_INTERMEDIARY_RESULTS = AppConstants.getInstance().getBoolean("log.logIntermediaryResults", true);
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		if (log.isDebugEnabled() && logIntermediaryResults(pipe)) {
-			log.debug("pipeline process is about to call pipe [{}] current result [{}]", pipe::getName, () -> (message == null ? "<null>" : message.toString()));
+			log.debug("pipeline process is about to call pipe [{}] current result [{}]", pipe::getName, message::toString);
 		} else {
 			log.info("pipeline process is about to call pipe [{}]", pipe::getName);
 		}

--- a/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import io.micrometer.core.instrument.DistributionSummary;
 import lombok.extern.log4j.Log4j2;
@@ -33,7 +32,7 @@ import org.frankframework.stream.Message;
 public class MonitoringPipeProcessor extends AbstractPipeProcessor {
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		long pipeStartTime = System.currentTimeMillis();
 
 		try {

--- a/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
@@ -18,9 +18,8 @@ package org.frankframework.processors;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
-import org.apache.logging.log4j.Logger;
-
 import io.micrometer.core.instrument.DistributionSummary;
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeLine;
@@ -29,13 +28,9 @@ import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.functional.ThrowingFunction;
 import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
 
-/**
- * @author Jaco de Groot
- */
+@Log4j2
 public class MonitoringPipeProcessor extends AbstractPipeProcessor {
-	private static final Logger DURATION_LOG = LogUtil.getLogger("LongDurationMessages");
 
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
@@ -55,8 +50,8 @@ public class MonitoringPipeProcessor extends AbstractPipeProcessor {
 			summary.record(pipeDuration);
 
 			if (pipe.getDurationThreshold() >= 0 && pipeDuration > pipe.getDurationThreshold()) {
-				DURATION_LOG.info("Pipe [{}] of [{}] duration [{}] ms exceeds max [{}], message [{}]", pipe::getName, () -> pipeLine.getOwner().getName(), () -> pipeDuration, pipe::getDurationThreshold, () -> message);
-				pipe.throwEvent(IPipe.LONG_DURATION_MONITORING_EVENT);
+				log.warn("message [{}] duration [{}] ms exceeds maximum allowed threshold of [{}]", message::getObjectId, () -> pipeDuration, pipe::getDurationThreshold);
+				pipe.throwEvent(IPipe.LONG_DURATION_MONITORING_EVENT, message);
 			}
 		}
 	}

--- a/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2024 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.frankframework.util.LogUtil;
  * @author Jaco de Groot
  */
 public class MonitoringPipeProcessor extends AbstractPipeProcessor {
-	private final Logger durationLog = LogUtil.getLogger("LongDurationMessages");
+	private static final Logger DURATION_LOG = LogUtil.getLogger("LongDurationMessages");
 
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
@@ -51,14 +51,14 @@ public class MonitoringPipeProcessor extends AbstractPipeProcessor {
 			throw pre;
 		} catch (RuntimeException re) {
 			pipe.throwEvent(IPipe.PIPE_EXCEPTION_MONITORING_EVENT);
-			throw new PipeRunException(pipe, "Uncaught runtime exception running pipe '" + pipe.getName() + "'", re);
+			throw new PipeRunException(pipe, "uncaught runtime exception while executing pipe", re);
 		} finally {
 			long pipeDuration = System.currentTimeMillis() - pipeStartTime;
 			DistributionSummary summary = pipeLine.getPipeStatistics(pipe);
 			summary.record(pipeDuration);
 
 			if (pipe.getDurationThreshold() >= 0 && pipeDuration > pipe.getDurationThreshold()) {
-				durationLog.info("Pipe [{}] of [{}] duration [{}] ms exceeds max [{}], message [{}]", pipe::getName, () -> pipeLine.getOwner().getName(), () -> pipeDuration, pipe::getDurationThreshold, () -> message);
+				DURATION_LOG.info("Pipe [{}] of [{}] duration [{}] ms exceeds max [{}], message [{}]", pipe::getName, () -> pipeLine.getOwner().getName(), () -> pipeDuration, pipe::getDurationThreshold, () -> message);
 				pipe.throwEvent(IPipe.LONG_DURATION_MONITORING_EVENT);
 			}
 		}

--- a/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/MonitoringPipeProcessor.java
@@ -18,7 +18,6 @@ package org.frankframework.processors;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import io.micrometer.core.instrument.DistributionSummary;
@@ -30,7 +29,6 @@ import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.functional.ThrowingFunction;
 import org.frankframework.stream.Message;
-import org.frankframework.util.AppConstants;
 import org.frankframework.util.LogUtil;
 
 /**
@@ -42,7 +40,6 @@ public class MonitoringPipeProcessor extends AbstractPipeProcessor {
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		long pipeStartTime = System.currentTimeMillis();
-		doDebugLogging(pipeLine, pipe, message, pipeLineSession);
 
 		try {
 			return chain.apply(message);
@@ -63,23 +60,4 @@ public class MonitoringPipeProcessor extends AbstractPipeProcessor {
 			}
 		}
 	}
-
-	private void doDebugLogging(final PipeLine pipeLine, final IPipe pipe, Message message, PipeLineSession pipeLineSession) {
-		if (!log.isDebugEnabled()) {
-			return;
-		}
-		String ownerName = pipeLine.getOwner() == null ? "<null>" : pipeLine.getOwner().getName();
-		StringBuilder sb = new StringBuilder();
-		sb.append("Pipeline of adapter [").append(ownerName).append("] messageId [").append(pipeLineSession.getMessageId()).append("] is about to call pipe [").append(pipe.getName()).append("]");
-
-		boolean lir = AppConstants.getInstance().getBoolean("log.logIntermediaryResults", false);
-		if (StringUtils.isNotEmpty(pipe.getLogIntermediaryResults())) {
-			lir = Boolean.parseBoolean(pipe.getLogIntermediaryResults());
-		}
-		if (lir) {
-			sb.append(" current result ").append(message == null ? "<null>" : "(" + message.getClass().getSimpleName() + ") [" + message + "]").append(" ");
-		}
-		log.debug(sb.toString());
-	}
-
 }

--- a/core/src/main/java/org/frankframework/processors/PipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/PipeProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2013, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.IValidator;
@@ -31,7 +30,7 @@ import org.frankframework.stream.Message;
  */
 public interface PipeProcessor {
 
-	PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException;
-	PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException;
+	PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession) throws PipeRunException;
+	PipeRunResult validate(@Nonnull PipeLine pipeLine, @Nonnull IValidator validator, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, String messageRoot) throws PipeRunException;
 
 }

--- a/core/src/main/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2024 WeAreFrank!
+   Copyright 2024-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.frankframework.processors;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 
 import org.frankframework.core.IPipe;
 import org.frankframework.core.PipeLine;
@@ -36,7 +35,7 @@ import org.frankframework.stream.MessageContext;
 public class TrackPreviousPipeInMetadataProcessor extends AbstractPipeProcessor {
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession,
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession,
 										@Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 
 		PipeRunResult pipeRunResult = chain.apply(message);

--- a/core/src/main/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessor.java
@@ -24,7 +24,6 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.functional.ThrowingFunction;
-import org.frankframework.pipes.FixedForwardPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
 
@@ -39,21 +38,10 @@ public class TrackPreviousPipeInMetadataProcessor extends AbstractPipeProcessor 
 	@Override
 	protected PipeRunResult processPipe(@Nonnull PipeLine pipeLine, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession,
 										@Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
-		PipeRunResult pipeRunResult = chain.apply(message);
 
-		if (message != null && logPreviousPipe(pipe, message, pipeLineSession)) {
-			message.getContext().put(MessageContext.CONTEXT_PREVIOUS_PIPE, pipe.getName());
-		}
+		PipeRunResult pipeRunResult = chain.apply(message);
+		pipeRunResult.getResult().getContext().put(MessageContext.CONTEXT_PREVIOUS_PIPE, pipe.getName());
 
 		return pipeRunResult;
-	}
-
-	private boolean logPreviousPipe(IPipe pipe, Message message, PipeLineSession pipeLineSession) throws PipeRunException {
-		// FixedForwardPipe pipes can be skipped, if it's skipped, we don't need to update the 'previous pipe' value
-		if (pipe instanceof FixedForwardPipe ffPipe) {
-			return !ffPipe.skipPipe(message, pipeLineSession);
-		} else {
-			return true;
-		}
 	}
 }

--- a/core/src/main/java/org/frankframework/processors/TransactionAttributePipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/TransactionAttributePipeProcessor.java
@@ -15,6 +15,15 @@
 */
 package org.frankframework.processors;
 
+import jakarta.annotation.Nonnull;
+
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.core.HasSender;
 import org.frankframework.core.HasTransactionAttribute;
 import org.frankframework.core.IPipe;
@@ -29,14 +38,6 @@ import org.frankframework.jta.SpringTxManagerProxy;
 import org.frankframework.stream.Message;
 import org.frankframework.task.TimeoutGuard;
 import org.frankframework.util.ClassUtils;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class TransactionAttributePipeProcessor extends AbstractPipeProcessor {
@@ -44,7 +45,7 @@ public class TransactionAttributePipeProcessor extends AbstractPipeProcessor {
 	private @Getter @Setter PlatformTransactionManager txManager;
 
 	@Override
-	protected PipeRunResult processPipe(@Nonnull PipeLine pipeline, @Nonnull IPipe pipe, @Nullable Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@Nonnull PipeLine pipeline, @Nonnull IPipe pipe, @Nonnull Message message, @Nonnull PipeLineSession pipeLineSession, @Nonnull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
 		TransactionDefinition txDef;
 		int txTimeout = 0;
 		if(pipe instanceof HasTransactionAttribute taPipe) {

--- a/core/src/main/java/org/frankframework/processors/TransactionAttributePipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/TransactionAttributePipeProcessor.java
@@ -56,7 +56,7 @@ public class TransactionAttributePipeProcessor extends AbstractPipeProcessor {
 
 		IbisTransaction itx = new IbisTransaction(txManager, txDef, "pipe [" + pipe.getName() + "]");
 		boolean isTxCapable = hasTxCapableSender(pipe);
-		log.debug("executing pipe with transaction definition [{}] in {} TX environment", txDef, isTxCapable ? "GLOBAL (XA)" : "LOCAL");
+		log.debug("executing pipe with transaction definition [{}] in {} TX environment with timeout [{}]", txDef, (isTxCapable ? "global" : "local"), txTimeout);
 		try {
 			if(isTxCapable && itx.isRollbackOnly()) {
 				throw new PipeRunException(pipe, "unable to execute SQL statement, transaction has been marked as failed by an earlier sender");

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -856,7 +856,7 @@ public class Message implements Serializable, Closeable {
 		}
 	}
 
-	public static boolean isNull(Message message) {
+	public static boolean isNull(@Nullable Message message) {
 		return message == null || message.isNull();
 	}
 

--- a/core/src/main/resources/SpringConfigurationContext.xml
+++ b/core/src/main/resources/SpringConfigurationContext.xml
@@ -88,58 +88,66 @@
 
 		<bean
 			name="pipeProcessor,inputValidatorProcessor,outputValidatorProcessor,inputWrapperProcessor,outputWrapperProcessor"
-			class="org.frankframework.processors.MonitoringPipeProcessor"
+			class="org.frankframework.processors.LogPipeProcessor"
 			autowire="byName"
 			scope="prototype"
 			>
 			<property name="pipeProcessor">
-				<!-- allows a managed exception to be stored in the session -->
 				<bean
-					class="org.frankframework.processors.InputOutputPipeProcessor"
+					class="org.frankframework.processors.MonitoringPipeProcessor"
 					autowire="byName"
 					scope="prototype"
 					>
 					<property name="pipeProcessor">
+						<!-- allows a managed exception to be stored in the session -->
 						<bean
-							class="org.frankframework.processors.ExceptionHandlingPipeProcessor"
+							class="org.frankframework.processors.InputOutputPipeProcessor"
 							autowire="byName"
 							scope="prototype"
 							>
 							<property name="pipeProcessor">
 								<bean
-									class="org.frankframework.processors.LimitingParallelExecutionPipeProcessor"
+									class="org.frankframework.processors.ExceptionHandlingPipeProcessor"
 									autowire="byName"
 									scope="prototype"
 									>
 									<property name="pipeProcessor">
 										<bean
-											class="org.frankframework.processors.TransactionAttributePipeProcessor"
+											class="org.frankframework.processors.LimitingParallelExecutionPipeProcessor"
 											autowire="byName"
 											scope="prototype"
 											>
 											<property name="pipeProcessor">
 												<bean
-													class="org.frankframework.processors.LockerPipeProcessor"
+													class="org.frankframework.processors.TransactionAttributePipeProcessor"
 													autowire="byName"
 													scope="prototype"
 													>
 													<property name="pipeProcessor">
 														<bean
-															class="org.frankframework.processors.CheckMessageSizePipeProcessor"
+															class="org.frankframework.processors.LockerPipeProcessor"
 															autowire="byName"
 															scope="prototype"
 															>
 															<property name="pipeProcessor">
 																<bean
-																	class="org.frankframework.processors.TrackPreviousPipeInMetadataProcessor"
+																	class="org.frankframework.processors.CheckMessageSizePipeProcessor"
 																	autowire="byName"
-																	scope="prototype">
+																	scope="prototype"
+																	>
 																	<property name="pipeProcessor">
 																		<bean
-																			class="org.frankframework.processors.CorePipeProcessor"
+																			class="org.frankframework.processors.TrackPreviousPipeInMetadataProcessor"
 																			autowire="byName"
-																			scope="prototype"
-																		/>
+																			scope="prototype">
+																			<property name="pipeProcessor">
+																				<bean
+																					class="org.frankframework.processors.CorePipeProcessor"
+																					autowire="byName"
+																					scope="prototype"
+																				/>
+																			</property>
+																		</bean>
 																	</property>
 																</bean>
 															</property>

--- a/core/src/main/resources/SpringConfigurationContext.xml
+++ b/core/src/main/resources/SpringConfigurationContext.xml
@@ -87,7 +87,7 @@
 		</bean>
 
 		<bean
-			name="pipeProcessor,inputValidatorProcessor,outputValidatorProcessor,inputWrapperProcessor,outputWrapperProcessor"
+			name="pipeProcessor"
 			class="org.frankframework.processors.LogPipeProcessor"
 			autowire="byName"
 			scope="prototype"

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -51,7 +51,7 @@
 			<RolloverStrategy type="DefaultRolloverStrategy" max="${ctx:log.msg.maxBackupIndex}" fileIndex="min" />
 		</Appender>
 		<Appender name="security" type="RollingFile" fileName="${ctx:log.dir}/${ctx:instance.name.lc}-security.log" filePattern="${ctx:log.dir}/${ctx:instance.name.lc}-security.log.%i">
-			<Layout type="PatternLayout" pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} [%t] %m%n"/>
+			<Layout type="PatternLayout" pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %X{adapter} - %m%n"/>
 			<Policies>
 				<SizeBasedTriggeringPolicy size="${ctx:log.maxFileSize}" />
 				<OnStartupTriggeringPolicy />

--- a/core/src/test/java/org/frankframework/processors/CheckMessageSizePipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/CheckMessageSizePipeProcessorTest.java
@@ -1,0 +1,34 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
+import org.frankframework.testutil.TestAppender;
+
+public class CheckMessageSizePipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void testLogMessage() throws Exception {
+		configurePipeLine(pipeline -> {
+			pipeline.setMessageSizeWarn("1kb");
+		});
+
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+			assertTrue(appender.contains("input message size [25KiB] exceeds [1KiB]"));
+			assertTrue(appender.contains("result message size [25KiB] exceeds [1KiB]"));
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/CheckMessageSizePipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/CheckMessageSizePipeProcessorTest.java
@@ -1,5 +1,6 @@
 package org.frankframework.processors;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import org.frankframework.pipes.EchoPipe;
 import org.frankframework.stream.Message;
+import org.frankframework.stream.MessageContext;
 import org.frankframework.testutil.MessageTestUtils;
 import org.frankframework.testutil.MessageTestUtils.MessageType;
 import org.frankframework.testutil.TestAppender;
@@ -14,7 +16,7 @@ import org.frankframework.testutil.TestAppender;
 public class CheckMessageSizePipeProcessorTest extends PipeProcessorTestBase {
 
 	@Test
-	void testLogMessage() throws Exception {
+	void shouldLogMessageWhenMessageSizeTooLarge() throws Exception {
 		configurePipeLine(pipeline -> {
 			pipeline.setMessageSizeWarn("1kb");
 		});
@@ -29,6 +31,64 @@ public class CheckMessageSizePipeProcessorTest extends PipeProcessorTestBase {
 			assertNotNull(result);
 			assertTrue(appender.contains("input message size [25KiB] exceeds [1KiB]"));
 			assertTrue(appender.contains("result message size [25KiB] exceeds [1KiB]"));
+		}
+	}
+
+	@Test
+	void shouldLogMessageWhenSizeStatisticsIsDisabled() throws Exception {
+		configurePipeLine(pipeline -> {
+			pipeline.setMessageSizeWarn("1kb");
+		});
+
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe", pipe -> {
+			pipe.setSizeStatistics(false);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+			assertTrue(appender.contains("input message size [25KiB] exceeds [1KiB]"));
+			assertTrue(appender.contains("result message size [25KiB] exceeds [1KiB]"));
+		}
+	}
+
+	@Test
+	void shouldNotLogMessageWhenSizeSmallerThenAllowed() throws Exception {
+		configurePipeLine(pipeline -> {
+			pipeline.setMessageSizeWarn("1mb");
+		});
+
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+			assertFalse(appender.contains(" exceeds [1MiB]"));
+		}
+	}
+
+	@Test
+	void shouldNotCauseExceptionsOrLogAnythingWhenNoSize() throws Exception {
+		configurePipeLine(pipeline -> {
+			pipeline.setMessageSizeWarn("1kb");
+		});
+
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+
+		Message message = new Message("");
+		message.getContext().put(MessageContext.METADATA_SIZE, -1L);
+
+		try (TestAppender appender = TestAppender.newBuilder().build()) {
+			Message result = processPipeLine(message);
+
+			assertNotNull(result);
+			assertFalse(appender.contains(" exceeds [1KiB]"));
 		}
 	}
 }

--- a/core/src/test/java/org/frankframework/processors/ExceptionHandlingPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/ExceptionHandlingPipeProcessorTest.java
@@ -1,0 +1,122 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.core.PipeForward;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.PipeRunException;
+import org.frankframework.core.PipeRunResult;
+import org.frankframework.pipes.AbstractPipe;
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.pipes.ExceptionPipe;
+import org.frankframework.stream.Message;
+import org.frankframework.util.DateFormatUtils;
+
+public class ExceptionHandlingPipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void testWithoutExceptionExit() throws Exception {
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+		createPipe(ExceptionPipe.class, "Exception pipe", "success");
+
+		PipeRunException ex = assertThrows(PipeRunException.class, () -> processPipeLine(new Message("i'm an exception!")));
+
+		assertEquals("Pipe [Exception pipe] i'm an exception!", ex.getMessage());
+	}
+
+	@Test
+	void testWithExceptionExitAndExceptionPipe() throws Exception {
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+		createPipe(ExceptionPipe.class, "Exception pipe", "success", pipe -> {
+			PipeForward exceptionForward = new PipeForward("exception", "exit");
+			pipe.addForward(exceptionForward);
+		});
+
+		// Should still trigger an exception as the ExceptionPipe should be ignored!
+		PipeRunException ex = assertThrows(PipeRunException.class, () -> processPipeLine(new Message("i'm an exception!")));
+
+		assertEquals("Pipe [Exception pipe] i'm an exception!", ex.getMessage());
+	}
+
+	@Test
+	void testWithPipeRunExceptionExitAndNormalPipe() throws Exception {
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+		createPipe(ThrowExceptionPipe.class, "Exception pipe", "success", pipe -> {
+			PipeForward exceptionForward = new PipeForward("exception", "exit");
+			pipe.addForward(exceptionForward);
+		});
+
+		Message result = processPipeLine(new Message("PipeRun"));
+
+		assertEquals("""
+				<errorMessage timestamp="IGNORE" originator="IAF " message="ThrowExceptionPipe [Exception pipe]">
+					<location class="org.frankframework.processors.ExceptionHandlingPipeProcessorTest$ThrowExceptionPipe" name="Exception pipe"/>
+					<originalMessage>PipeRun</originalMessage>
+				</errorMessage>""", result.asString().replaceAll("timestamp=\"[A-Za-z0-9: ]+\"", "timestamp=\"IGNORE\""));
+	}
+
+	@Test
+	void testWithPipeRunExceptionExitAndNormalPipeAndTsReceived() throws Exception {
+		Instant tsReceived = Instant.ofEpochMilli(1234567890L);
+		session.put(PipeLineSession.TS_RECEIVED_KEY, DateFormatUtils.format(tsReceived, DateFormatUtils.FULL_GENERIC_FORMATTER));
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+		createPipe(ThrowExceptionPipe.class, "Exception pipe", "success", pipe -> {
+			PipeForward exceptionForward = new PipeForward("exception", "exit");
+			pipe.addForward(exceptionForward);
+		});
+
+		Message result = processPipeLine(new Message("PipeRun"));
+
+		assertEquals("""
+				<errorMessage timestamp="IGNORE" originator="IAF " message="ThrowExceptionPipe [Exception pipe]">
+					<location class="org.frankframework.processors.ExceptionHandlingPipeProcessorTest$ThrowExceptionPipe" name="Exception pipe"/>
+					<originalMessage receivedTime="Thu Jan 15 07:56:07 CET 1970">PipeRun</originalMessage>
+				</errorMessage>""", result.asString().replaceAll("timestamp=\"[A-Za-z0-9: ]+\"", "timestamp=\"IGNORE\""));
+	}
+
+	@Test
+	void testWithRuntimeExceptionExitAndNormalPipe() throws Exception {
+		createPipe(EchoPipe.class, "Echo pipe", "Exception pipe");
+		createPipe(ThrowExceptionPipe.class, "Exception pipe", "success", pipe -> {
+			PipeForward exceptionForward = new PipeForward("exception", "exit");
+			pipe.addForward(exceptionForward);
+		});
+
+		String pipelineResult = processPipeLine(new Message("Runtime")).asString();
+		Pattern pattern = Pattern.compile("<details>.*?</details>", Pattern.DOTALL);
+		Matcher matcher = pattern.matcher(pipelineResult);
+		String cleaned = matcher.replaceAll("<details>...</details>");
+		String result = cleaned.replaceAll("timestamp=\"[A-Za-z0-9: ]+\"", "timestamp=\"IGNORE\"");
+
+		assertEquals("""
+				<errorMessage timestamp="IGNORE" originator="IAF " message="Adapter [Adapter Name]: Runtime">
+					<location class="org.frankframework.core.Adapter" name="Adapter Name"/>
+					<details>...</details>
+					<originalMessage>Runtime</originalMessage>
+				</errorMessage>""", result);
+	}
+
+	private static class ThrowExceptionPipe extends AbstractPipe {
+
+		@Override
+		public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
+			try {
+				String messageString = message.asString();
+				if ("PipeRun".equals(messageString)) {
+					throw new PipeRunException(this, messageString);
+				}
+				throw new RuntimeException(messageString);
+			} catch (IOException e) {
+				throw new PipeRunException(this, "cannot open stream", e);
+			}
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/LimitingParallelExecutionPipeProcessorTest.java
@@ -1,0 +1,43 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
+
+/**
+ * For now this simply tests the 2 processing flow's and not the {@link ResourceLimiter} it self.
+ * Purely if all methods are called and if multiple messages may be processed.
+ */
+public class LimitingParallelExecutionPipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void testNormalExecution() throws Exception {
+		createPipe(EchoPipe.class, "my pipe", "success", pipe -> {
+			pipe.setMaxThreads(0);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+	}
+
+	@Test
+	void testOneThreadExecution() throws Exception {
+		createPipe(EchoPipe.class, "my pipe", "success", pipe -> {
+			pipe.setMaxThreads(1);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/LockerPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/LockerPipeProcessorTest.java
@@ -1,0 +1,110 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.PipeRunException;
+import org.frankframework.core.PipeRunResult;
+import org.frankframework.pipes.AbstractPipe;
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.receivers.ResourceLimiter;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
+import org.frankframework.util.Locker;
+
+/**
+ * For now this simply tests the 2 processing flow's and not the {@link ResourceLimiter} it self.
+ * Purely if all methods are called and if multiple messages may be processed.
+ */
+public class LockerPipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void testNormalExecution() throws Exception {
+		createPipe(EchoPipe.class, "my pipe", "success", pipe -> {
+			pipe.setLocker(null);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+	}
+
+	@Test
+	void testWithLockerExecution() throws Exception {
+		// Ensure only 1 process may execute at once, and that Locker.release is called
+		Locker locker = mock(Locker.class);
+		AtomicInteger guard = new AtomicInteger();
+		doAnswer(e -> "id-" + guard.incrementAndGet()).when(locker).acquire();
+		doAnswer(e -> guard.decrementAndGet()).when(locker).release(anyString());
+
+		createPipe(EchoPipe.class, "my pipe", "success", pipe -> {
+			pipe.setLocker(locker);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+		assertNotNull(processPipeLine(binaryInput));
+
+		assertEquals(0, guard.get());
+		verify(locker, times(3)).acquire();
+		verify(locker, times(3)).release(anyString());
+	}
+
+	@Test
+	void whenNoLockCanBeAquiredNoPipeExecution() throws Exception {
+		Locker locker = mock(Locker.class);
+		doThrow(IllegalStateException.class).when(locker).acquire();
+		doReturn("name").when(locker).toString();
+
+		createPipe(ThrowExceptionPipe.class, "my pipe", "success", pipe -> {
+			pipe.setLocker(locker);
+		});
+
+		Message binaryInput = new Message("input");
+
+		PipeRunException ex = assertThrows(PipeRunException.class, () -> processPipeLine(binaryInput));
+		assertEquals("Pipe [my pipe] error while trying to obtain lock [name]: (IllegalStateException)", ex.getMessage());
+	}
+
+	@Test
+	void whenEmptyLockCanBeAquiredNoPipeExecution() throws Exception {
+		Locker locker = mock(Locker.class);
+		doReturn(null).when(locker).acquire();
+		doReturn("name").when(locker).toString();
+
+		createPipe(ThrowExceptionPipe.class, "my pipe", "success", pipe -> {
+			pipe.setLocker(locker);
+		});
+
+		Message binaryInput = new Message("input");
+
+		PipeRunException ex = assertThrows(PipeRunException.class, () -> processPipeLine(binaryInput));
+		assertEquals("Pipe [my pipe] could not obtain lock [name]", ex.getMessage());
+	}
+
+	private static class ThrowExceptionPipe extends AbstractPipe {
+
+		@Override
+		public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
+			throw new PipeRunException(this, "this operation should not be called");
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/LogPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/LogPipeProcessorTest.java
@@ -1,0 +1,37 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
+import org.frankframework.testutil.TestAppender;
+
+public class LogPipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void testLogMessageAlwaysOnInfo() throws Exception {
+		createPipe(EchoPipe.class, "pipe1", "pipe2", pipe -> {
+			pipe.setLogIntermediaryResults("true"); // shouldn't this be a boolean?
+		});
+		createPipe(EchoPipe.class, "pipe2", "success", pipe -> {
+			pipe.setLogIntermediaryResults("false"); // shouldn't this be a boolean?
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().useIbisPatternLayout("%level %X{adapter,pipe} - %m").build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+
+			// Normally adapter is present in the ThreadContext, but this is not set by the pipe processors
+			assertTrue(appender.contains("DEBUG {} - pipeline process is about to call pipe [pipe1] current result ["));
+			assertTrue(appender.contains("INFO {} - pipeline process is about to call pipe [pipe2]"));
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/MonitoringPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/MonitoringPipeProcessorTest.java
@@ -1,0 +1,59 @@
+package org.frankframework.processors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.pipes.DelayPipe;
+import org.frankframework.pipes.EchoPipe;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.MessageTestUtils;
+import org.frankframework.testutil.MessageTestUtils.MessageType;
+import org.frankframework.testutil.TestAppender;
+
+/**
+ * Most cases are already tested in the {@link ExceptionHandlingPipeProcessorTest}.
+ */
+public class MonitoringPipeProcessorTest extends PipeProcessorTestBase {
+
+	@Test
+	void processorShouldLogWhenDurationTooLong() throws Exception {
+		createPipe(DelayPipe.class, "my pipe", "success", pipe -> {
+			pipe.setDurationThreshold(1L);
+			pipe.setDelayTime(20L);
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().useIbisPatternLayout("%level %X{adapter,pipe} - %m").minLogLevel(Level.WARN).build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+
+			// Normally adapter is present in the ThreadContext, but this is not set by the pipe processors
+			assertTrue(appender.contains("] ms exceeds maximum allowed threshold of [1]"));
+		}
+	}
+
+	@Test
+	void processorShouldNogLog() throws Exception {
+		createPipe(EchoPipe.class, "my pipe", "success", pipe -> {
+			pipe.setDurationThreshold(1000L);
+			// EchoPipe should have next to no delay
+		});
+
+		Message binaryInput = MessageTestUtils.getMessage(MessageType.BINARY);
+
+		try (TestAppender appender = TestAppender.newBuilder().useIbisPatternLayout("%level %X{adapter,pipe} - %m").minLogLevel(Level.WARN).build()) {
+			Message result = processPipeLine(binaryInput);
+
+			assertNotNull(result);
+
+			// Normally adapter is present in the ThreadContext, but this is not set by the pipe processors
+			assertFalse(appender.contains("] ms exceeds maximum allowed threshold of [1000]"));
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
+++ b/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
@@ -20,7 +20,6 @@ import org.frankframework.util.SpringUtils;
 
 public class PipeProcessorTestBase {
 
-	private PipeProcessor processor;
 	protected PipeLineSession session;
 	private TestConfiguration configuration;
 	private PipeLine pipeLine;
@@ -31,7 +30,6 @@ public class PipeProcessorTestBase {
 		configuration = new TestConfiguration();
 		TransactionManagerMock txManager = configuration.createBean(TransactionManagerMock.class);
 		SpringUtils.registerSingleton(configuration, "txManager", txManager);
-		processor = configuration.getBean(PipeProcessor.class);
 
 		createAdapterAndPipeLine();
 		session = new PipeLineSession();
@@ -60,12 +58,13 @@ public class PipeProcessorTestBase {
 	}
 
 	protected final Message processPipeLine(Message inputMessage) throws PipeRunException, ConfigurationException {
-		adapter.configure();
+		if (!adapter.isConfigured()) {
+			adapter.configure();
+		}
 
-		CorePipeLineProcessor cpp = configuration.createBean();
-		cpp.setPipeProcessor(processor);
+		PipeLineProcessor cpp = configuration.getBean("pipeLineProcessor", PipeLineProcessor.class);
 		String firstPipe = pipeLine.getPipe(0).getName();
-		PipeLineResult plr = cpp.processPipeLine(pipeLine, "mid", inputMessage, session, firstPipe);
+		PipeLineResult plr = cpp.processPipeLine(pipeLine, "fake-mid", inputMessage, session, firstPipe);
 		return plr.getResult();
 	}
 

--- a/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
+++ b/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
@@ -33,14 +33,15 @@ public class PipeProcessorTestBase {
 		SpringUtils.registerSingleton(configuration, "txManager", txManager);
 		processor = configuration.getBean(PipeProcessor.class);
 
-		pipeLine = createPipeLine();
+		createAdapterAndPipeLine();
 		session = new PipeLineSession();
 	}
 
-	private PipeLine createPipeLine() {
+	@SuppressWarnings("deprecation")
+	private void createAdapterAndPipeLine() {
 		adapter = configuration.createBean();
 		adapter.setName("Adapter Name");
-		PipeLine pipeLine = SpringUtils.createBean(adapter);
+		pipeLine = SpringUtils.createBean(adapter);
 		adapter.setPipeLine(pipeLine);
 
 		PipeLineExit errorExit = new PipeLineExit();
@@ -52,8 +53,10 @@ public class PipeProcessorTestBase {
 		successExit.setName("exit");
 		successExit.setState(PipeLine.ExitState.SUCCESS);
 		pipeLine.addPipeLineExit(successExit);
+	}
 
-		return pipeLine;
+	protected final void configurePipeLine(Consumer<PipeLine> additionalConfig) {
+		additionalConfig.accept(pipeLine);
 	}
 
 	protected final Message processPipeLine(Message inputMessage) throws PipeRunException, ConfigurationException {

--- a/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
+++ b/core/src/test/java/org/frankframework/processors/PipeProcessorTestBase.java
@@ -1,0 +1,91 @@
+package org.frankframework.processors;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.Adapter;
+import org.frankframework.core.IPipe;
+import org.frankframework.core.PipeForward;
+import org.frankframework.core.PipeLine;
+import org.frankframework.core.PipeLineExit;
+import org.frankframework.core.PipeLineResult;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.PipeRunException;
+import org.frankframework.stream.Message;
+import org.frankframework.testutil.TestConfiguration;
+import org.frankframework.testutil.mock.TransactionManagerMock;
+import org.frankframework.util.SpringUtils;
+
+public class PipeProcessorTestBase {
+
+	private PipeProcessor processor;
+	protected PipeLineSession session;
+	private TestConfiguration configuration;
+	private PipeLine pipeLine;
+	private Adapter adapter;
+
+	@BeforeEach
+	public void setUp() {
+		configuration = new TestConfiguration();
+		TransactionManagerMock txManager = configuration.createBean(TransactionManagerMock.class);
+		SpringUtils.registerSingleton(configuration, "txManager", txManager);
+		processor = configuration.getBean(PipeProcessor.class);
+
+		pipeLine = createPipeLine();
+		session = new PipeLineSession();
+	}
+
+	private PipeLine createPipeLine() {
+		adapter = configuration.createBean();
+		adapter.setName("Adapter Name");
+		PipeLine pipeLine = SpringUtils.createBean(adapter);
+		adapter.setPipeLine(pipeLine);
+
+		PipeLineExit errorExit = new PipeLineExit();
+		errorExit.setName("error");
+		errorExit.setState(PipeLine.ExitState.ERROR);
+		pipeLine.addPipeLineExit(errorExit);
+
+		PipeLineExit successExit = new PipeLineExit();
+		successExit.setName("exit");
+		successExit.setState(PipeLine.ExitState.SUCCESS);
+		pipeLine.addPipeLineExit(successExit);
+
+		return pipeLine;
+	}
+
+	protected final Message processPipeLine(Message inputMessage) throws PipeRunException, ConfigurationException {
+		adapter.configure();
+
+		CorePipeLineProcessor cpp = configuration.createBean();
+		cpp.setPipeProcessor(processor);
+		String firstPipe = pipeLine.getPipe(0).getName();
+		PipeLineResult plr = cpp.processPipeLine(pipeLine, "mid", inputMessage, session, firstPipe);
+		return plr.getResult();
+	}
+
+	protected final <T extends IPipe> T createPipe(Class<T> className, String pipeName, String forwardName) throws ConfigurationException {
+		return createPipe(className, pipeName, forwardName, null);
+	}
+
+	protected final <T extends IPipe> T createPipe(Class<T> className, String pipeName, String forwardName, Consumer<T> additionalConfig) throws ConfigurationException {
+		T pipe = SpringUtils.createBean(adapter, className);
+		pipe.setName(pipeName);
+
+		PipeForward forward = new PipeForward();
+		forward.setName(forwardName);
+		forward.setPath("exit");
+		pipe.addForward(forward);
+
+		if (additionalConfig != null) {
+			additionalConfig.accept(pipe);
+		}
+
+		pipe.setPipeLine(pipeLine);
+		pipeLine.addPipe(pipe);
+
+		return pipe;
+	}
+}

--- a/core/src/test/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/TrackPreviousPipeInMetadataProcessorTest.java
@@ -3,60 +3,34 @@ package org.frankframework.processors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.Adapter;
-import org.frankframework.core.PipeForward;
-import org.frankframework.core.PipeLine;
-import org.frankframework.core.PipeLineExit;
-import org.frankframework.core.PipeLineResult;
-import org.frankframework.core.PipeLineSession;
-import org.frankframework.core.PipeRunResult;
 import org.frankframework.parameters.Parameter;
 import org.frankframework.pipes.EchoPipe;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
-import org.frankframework.testutil.TestConfiguration;
-import org.frankframework.testutil.mock.TransactionManagerMock;
-import org.frankframework.util.SpringUtils;
 
-public class TrackPreviousPipeInMetadataProcessorTest {
+public class TrackPreviousPipeInMetadataProcessorTest extends PipeProcessorTestBase {
 	private static final String INPUT_MESSAGE_TEXT = "input message";
-
-	private PipeProcessor processor;
-	private PipeLineSession session;
-	private TestConfiguration configuration;
-
-	@BeforeEach
-	public void setUp() {
-		configuration = new TestConfiguration();
-		TransactionManagerMock txManager = configuration.createBean(TransactionManagerMock.class);
-		SpringUtils.registerSingleton(configuration, "txManager", txManager);
-		processor = configuration.getBean(PipeProcessor.class);
-		session = new PipeLineSession();
-	}
 
 	@Test
 	void testPreviousPipeValue() throws Exception {
-		EchoPipe pipe = getEchoPipe(getPipeLine(), "Echo pipe", "success", null);
+		EchoPipe pipe = createPipe(EchoPipe.class, "Echo pipe", "success");
 		pipe.configure();
 		pipe.start();
 
 		Message input = new Message(INPUT_MESSAGE_TEXT);
 
-		PipeRunResult prr = processor.processPipe(getPipeLine(), pipe, input, session);
+		Message result = processPipeLine(input);
 
-		assertTrue(prr.getResult().getContext().containsKey(MessageContext.CONTEXT_PREVIOUS_PIPE));
-		assertEquals("Echo pipe", prr.getResult().getContext().get(MessageContext.CONTEXT_PREVIOUS_PIPE));
-		assertEquals(INPUT_MESSAGE_TEXT, prr.getResult().asString());
+		assertTrue(result.getContext().containsKey(MessageContext.CONTEXT_PREVIOUS_PIPE));
+		assertEquals("Echo pipe", result.getContext().get(MessageContext.CONTEXT_PREVIOUS_PIPE));
+		assertEquals(INPUT_MESSAGE_TEXT, result.asString());
 	}
 
 	public static Stream<Arguments> conditionalIfParamArguments() {
@@ -71,40 +45,31 @@ public class TrackPreviousPipeInMetadataProcessorTest {
 	@MethodSource("conditionalIfParamArguments")
 	@ParameterizedTest
 	void testConditionalIfParamTrue(String ifValue, String expectedPreviousPipeValue) throws Exception {
-		PipeLine pipeLine = getPipeLine();
-
-		getEchoPipe(pipeLine, "echo1", "echo2", null);
+		createPipe(EchoPipe.class, "echo1", "echo2");
 
 		Parameter parameter = new Parameter();
 		parameter.setName("paramInput");
 		parameter.setContextKey(MessageContext.CONTEXT_PREVIOUS_PIPE);
 		parameter.configure();
 
-		getEchoPipe(pipeLine, "echo2", "exit", echoPipe -> {
+		createPipe(EchoPipe.class, "echo2", "exit", echoPipe -> {
 			// Provide parameter with value of context key for last pipe
 			echoPipe.addParameter(parameter);
 
 			echoPipe.setIfParam("paramInput");
 			echoPipe.setIfValue(ifValue);
-
-			return null;
 		});
 
-		pipeLine.configure();
-
-		CorePipeLineProcessor cpp = configuration.createBean();
-		cpp.setPipeProcessor(processor);
-		PipeLineResult pipeLineResult = cpp.processPipeLine(pipeLine, "id", new Message(INPUT_MESSAGE_TEXT), new PipeLineSession(), "echo1");
+		Message result = processPipeLine(new Message(INPUT_MESSAGE_TEXT));
 
 		// assert here that the previous pipe value equals expectedPreviousPipeValue
-		assertEquals(expectedPreviousPipeValue, pipeLineResult.getResult().getContext().get(MessageContext.CONTEXT_PREVIOUS_PIPE));
+		assertEquals(expectedPreviousPipeValue, result.getContext().get(MessageContext.CONTEXT_PREVIOUS_PIPE));
 	}
 
 	@Test
 	void testPreviousPipeValueInCombinationWithPostProcessPipeResult() throws Exception {
 		// Arrange
-		PipeLine pipeLine = getPipeLine();
-		EchoPipe pipe = getEchoPipe(pipeLine, "Echo pipe", "success", null);
+		EchoPipe pipe = createPipe(EchoPipe.class, "Echo pipe", "success");
 		pipe.setRestoreMovedElements(true);
 		pipe.configure();
 		pipe.start();
@@ -113,50 +78,13 @@ public class TrackPreviousPipeInMetadataProcessorTest {
 		Message input = new Message("<xml>{sessionKey:mineraalwater}</xml>");
 
 		// Act
-		PipeRunResult prr = processor.processPipe(pipeLine, pipe, input, session);
+		Message result = processPipeLine(input);
 
 		// Assert
-		assertEquals("<xml>water</xml>", prr.getResult().asString());
+		assertEquals("<xml>water</xml>", result.asString());
 
 // TODO fix this
 //		assertTrue(prr.getResult().getContext().containsKey(MessageContext.CONTEXT_PREVIOUS_PIPE));
 //		assertEquals("Echo pipe", prr.getResult().getContext().get(MessageContext.CONTEXT_PREVIOUS_PIPE));
-	}
-
-	private PipeLine getPipeLine() {
-		PipeLine pipeLine = configuration.createBean();
-		Adapter owner = configuration.createBean();
-		owner.setName("PipeLine owner");
-		pipeLine.setApplicationContext(owner);
-
-		PipeLineExit errorExit = new PipeLineExit();
-		errorExit.setName("error");
-		errorExit.setState(PipeLine.ExitState.ERROR);
-		pipeLine.addPipeLineExit(errorExit);
-
-		PipeLineExit successExit = new PipeLineExit();
-		successExit.setName("exit");
-		successExit.setState(PipeLine.ExitState.SUCCESS);
-		pipeLine.addPipeLineExit(successExit);
-
-		return pipeLine;
-	}
-
-	private EchoPipe getEchoPipe(PipeLine pipeLine, String pipeName, String forwardName, Function<EchoPipe, Void> additionalConfig) throws ConfigurationException {
-		EchoPipe pipe = configuration.createBean();
-		pipe.setName(pipeName);
-
-		PipeForward forward = new PipeForward();
-		forward.setName(forwardName);
-		pipe.addForward(forward);
-
-		if (additionalConfig != null) {
-			additionalConfig.apply(pipe);
-		}
-
-		pipe.setPipeLine(pipeLine);
-		pipeLine.addPipe(pipe);
-
-		return pipe;
 	}
 }

--- a/test/src/main/configurations/MainConfig/ConfigurationCompactMessage.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationCompactMessage.xml
@@ -44,7 +44,7 @@
 				<exit name="EXIT" state="success" />
 			</exits>
 			<pipe name="echo" className="org.frankframework.pipes.EchoPipe"
-				  elementToMoveChain="AuditLog_Action;Message;Text">
+				  elementToMoveChain="AuditLog_Action;Message;Text" durationThreshold="1">
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/main/configurations/MainConfig/ConfigurationCompactMessage.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationCompactMessage.xml
@@ -44,7 +44,7 @@
 				<exit name="EXIT" state="success" />
 			</exits>
 			<pipe name="echo" className="org.frankframework.pipes.EchoPipe"
-				  elementToMoveChain="AuditLog_Action;Message;Text" durationThreshold="1">
+				  elementToMoveChain="AuditLog_Action;Message;Text">
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/test/testtool/ForEachChildElementPipe/01/out.json
+++ b/test/src/test/testtool/ForEachChildElementPipe/01/out.json
@@ -1,13 +1,15 @@
 {
     "message": "<results>\n<result item=\"1\">\n<reply>goodbye</reply>\n</result>\n<result item=\"2\">\n<reply>ha</reply>\n</result>\n</results>",
-	"messageContext": {
-	},
+    "messageContext": {
+        "Pipeline.PreviousPipe": "ForEachChildElementPipe_Record"
+    },
     "logContext": {
         "listener.type": "JavaListener",
         "adapter": "ForEachChildElementPipe",
         "exit.state": "SUCCESS",
         "pipeline.duration": "4",
         "listener": "listener of [JavaListener]",
+        "mid": "synthetic-message-id-0a000a6f-65f825e8_1968bf8b863_-7ad3",
         "pipe": "echo",
         "cid": "Test Tool correlation id(6)"
     }

--- a/test/src/test/testtool/ForEachChildElementPipe/05/out.json
+++ b/test/src/test/testtool/ForEachChildElementPipe/05/out.json
@@ -1,6 +1,7 @@
 {
     "message": "<results>\n<result item=\"1\">\n<reply>goodbye</reply>\n</result>\n<result item=\"2\">\n<request>mdc local</request>\n</result>\n<result item=\"3\">\n<request>mdc export</request>\n</result>\n<result item=\"4\">\n<request>mdc local</request>\n</result>\n</results>",
 	"messageContext": {
+        "Pipeline.PreviousPipe": "ForEachChildElementPipe_Record"
 	},
     "logContext": {
         "listener.type": "JavaListener",
@@ -9,6 +10,7 @@
         "pipeline.duration": "3",
         "mdc1": "mdc1_value_export",
         "listener": "listener of [JavaListener]",
+        "mid": "synthetic-message-id-0a000a6f-65f825e8_1968bf8b863_-7ad3",
         "mdc_export": "mdc_export_value",
         "pipe": "echo",
         "cid": "Test Tool correlation id(5)"

--- a/test/src/test/testtool/ForEachChildElementPipe/common.properties
+++ b/test/src/test/testtool/ForEachChildElementPipe/common.properties
@@ -6,3 +6,6 @@ java.in.convertExceptionToMessage=true
 
 ignoreContentBetweenKeys.duration.key1="pipeline.duration": "
 ignoreContentBetweenKeys.duration.key2=",
+
+ignoreContentBetweenKeys1.key1 = mid": "
+ignoreContentBetweenKeys1.key2=",


### PR DESCRIPTION
```log
2025-04-30 15:35:28,187 DEBUG [Thread-x] {mid=123, cid=456, listener=listener of [JavaListener], adapter=CompactMessage-JavaListener3, pipe=echo} processors.TransactionAttributePipeProcessor - executing pipe with transaction definition [PROPAGATION_SUPPORTS,ISOLATION_DEFAULT] in local TX environment with timeout [0]
2025-04-30 15:35:28,187 DEBUG [Thread-x] {mid=123, cid=456, listener=listener of [JavaListener], adapter=CompactMessage-JavaListener3, pipe=echo} processors.InputOutputPipeProcessor - compacting result message
2025-04-30 15:35:28,191 WARN  [Thread-x] {mid=123, cid=456, listener=listener of [JavaListener], adapter=CompactMessage-JavaListener3, pipe=echo} processors.MonitoringPipeProcessor - message [Message[2f3ea412:String]] duration [9] ms exceeds maximum allowed threshold of [1]
2025-04-30 15:35:28,191 DEBUG [Thread-x] {mid=123, cid=456, listener=listener of [JavaListener], adapter=CompactMessage-JavaListener3} processors.CorePipeLineProcessor - Available session keys at finishing pipeline of adapter [CompactMessage-JavaListener3]:
```

This is the only PipeProcessor without the pipe in the log context, as it's also in the message.
```log
2025-04-30 15:35:27,697 DEBUG [Thread-x] {mid=123, cid=456, listener=listener of [JavaListener], adapter=CompactMessage-JavaListener} processors.LogPipeProcessor - pipeline process is about to call pipe [echo] current result [Message[3f77625b:byte[]]: [[B@72d5c144]]
```