### PR TITLE
Remove tip about files in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -91,10 +91,6 @@ body:
   - type: textarea
     attributes:
       label: Anything else?
-      description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
-
-        > [!TIP]
-        > You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      description: Links? References? Anything that will give us more context about the issue you are encountering!
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -36,10 +36,6 @@ body:
   - type: textarea 
     attributes:
       label: Anything else?
-      description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
-
-        > [!TIP]
-        > You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      description: Links? References? Anything that will give us more context about the issue you are encountering!
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/3-epic.yml
+++ b/.github/ISSUE_TEMPLATE/3-epic.yml
@@ -33,10 +33,6 @@ body:
   - type: textarea
     attributes:
       label: Anything else?
-      description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
-
-        > [!TIP]
-        > You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      description: Links? References? Anything that will give us more context about the issue you are encountering!
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/4-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation.yml
@@ -24,10 +24,6 @@ body:
   - type: textarea
     attributes:
       label: What would you like to change?
-      description: |
-        Please give a clear and concise description of the requested change. Please give an example if possible.
-
-        > [!TIP]
-        > You can attach images or text files by clicking this area to highlight it and then dragging files in.
+      description: Please give a clear and concise description of the requested change. Please give an example if possible.
     validations:
       required: true


### PR DESCRIPTION
Since GitHub now gives the same message, it is double. It also didn't render nicely. So now it is gone.