### PR TITLE
Test that verifies IdinSender auth-aliases work to resolve passwords for keystore / certificate stores.

### DIFF
--- a/idin/src/test/java/org/frankframework/extensions/idin/IdinSenderTest.java
+++ b/idin/src/test/java/org/frankframework/extensions/idin/IdinSenderTest.java
@@ -114,6 +114,18 @@ public class IdinSenderTest {
 	}
 
 	@Test
+	public void testCredentialsAliasesToPasswordMappings() {
+			sender.setKeyStoreAuthAlias("alias1");
+			assertEquals("password1", sender.getKeyStorePassword());
+
+			sender.setMerchantCertificateAuthAlias("alias1");
+			assertEquals("password1", sender.getMerchantCertificatePassword());
+
+			sender.setSAMLCertificateAuthAlias("alias1");
+			assertEquals("password1", sender.getSAMLCertificatePassword());
+	}
+
+	@Test
 	public void testXmlConfigurationFile() throws Exception {
 		String message = "<idin><transactionID>1111111111111111</transactionID></idin>";
 

--- a/idin/src/test/resources/credentialprovider.properties
+++ b/idin/src/test/resources/credentialprovider.properties
@@ -1,0 +1,1 @@
+credentialFactory.class=org.frankframework.credentialprovider.PropertyFileCredentialFactory

--- a/idin/src/test/resources/credentials.properties
+++ b/idin/src/test/resources/credentials.properties
@@ -1,0 +1,2 @@
+alias1/username=username1
+alias1/password=password1


### PR DESCRIPTION
Erik, kan je verifieren dat deze test ook in jouw PR #8909 branch werkt? 