### PR TITLE
Use the new Sonatype 'deploy to central' plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1364,32 +1364,18 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.7.0</version>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
+						<version>0.7.0</version>
 						<extensions>true</extensions>
 						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+							<autoPublish>false</autoPublish><!-- Don't release the build directly after it's been published to Central (staging). -->
+							<publishingServerId>ossrh</publishingServerId>
+							<waitUntil>validated</waitUntil><!-- Wait until the deployment bundle has been uploaded and validated. -->
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
-			<distributionManagement>
-				<repository>
-					<id>ossrh</id>
-					<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-				</repository>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-				</snapshotRepository>
-				<site>
-					<id>www.ibissource.org</id>
-					<url>file:target/site-deploy</url>
-				</site>
-			</distributionManagement>
 		</profile>
 		<profile>
 			<id>ibissource</id>


### PR DESCRIPTION
It should be as simple as this, maven config files etc have already been changed on the build/deployment servers.