### PR TITLE
Fix the name of the default DirectoryClassLoader in the AppConstants.properties

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -72,7 +72,7 @@ configurations.directory.autoLoad=false
 
 ## When loading Directories using the `configurations.directory.autoLoad` this allows users to change the default.
 ## Must be a subclass of the DirectoryClassloader, such as the ScanningDirectoryClassLoader.
-configurations.directory.classLoaderType=DirectoryClassloader
+configurations.directory.classLoaderType=DirectoryClassLoader
 
 ## Temporary directory in which the Frank!Framework can write temporary files such as J2V8, the flow diagrams, etc.
 ibis.tmpdir=${java.io.tmpdir}/${instance.name}


### PR DESCRIPTION
This is the exception / test failure I got, both in Maven and when running unit-tests from IntelliJ:

```
java.lang.NoClassDefFoundError: org/frankframework/configuration/classloaders/DirectoryClassloader (wrong name: org/frankframework/configuration/classloaders/DirectoryClassLoader)

	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1026)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:528)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:462)
	at java.base/java.lang.Class.forName(Class.java:453)
	at org.frankframework.configuration.ConfigurationUtils.getDefaultDirectoryClassLoaderType(ConfigurationUtils.java:535)
	at org.frankframework.configuration.ConfigurationUtils.retrieveAllConfigNames(ConfigurationUtils.java:496)
	at org.frankframework.configuration.ConfigurationUtilsTest.retrieveAllConfigNamesTestWithFS(ConfigurationUtilsTest.java:261)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```
