### PR TITLE
Minor cleanups and performance improvements

### DIFF
--- a/cmis/src/test/java/org/frankframework/extensions/cmis/CmisSenderTestBase.java
+++ b/cmis/src/test/java/org/frankframework/extensions/cmis/CmisSenderTestBase.java
@@ -17,9 +17,6 @@ import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.List;
 
-import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.chemistry.opencmis.client.api.Folder;
 import org.apache.chemistry.opencmis.client.api.ItemIterable;
 import org.apache.chemistry.opencmis.client.api.ObjectFactory;
@@ -39,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import org.frankframework.core.PipeLineSession;
 import org.frankframework.senders.SenderTestBase;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.util.StreamUtil;
@@ -98,11 +94,6 @@ public class CmisSenderTestBase extends SenderTestBase<CmisSender> {
 //		GET
 		OperationContext operationContext = mock(OperationContextImpl.class);
 		doReturn(operationContext).when(cmisSession).createOperationContext();
-
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		session.put(PipeLineSession.HTTP_RESPONSE_KEY, response);
-		ServletOutputStream outputStream = mock(ServletOutputStream.class);
-		doReturn(outputStream).when(response).getOutputStream();
 
 //		CREATE
 		Folder folder = mock(FolderImpl.class);

--- a/cmis/src/test/java/org/frankframework/extensions/cmis/TestBindingTypes.java
+++ b/cmis/src/test/java/org/frankframework/extensions/cmis/TestBindingTypes.java
@@ -1,17 +1,13 @@
 package org.frankframework.extensions.cmis;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.util.stream.Stream;
-
-import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
 import org.frankframework.testutil.TestAssertions;
 
@@ -88,8 +84,6 @@ public class TestBindingTypes extends CmisSenderTestBase {
 		sender.setFilenameSessionKey("my-file");
 
 		session.put("fileContent", "dummy data");
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		session.put(PipeLineSession.HTTP_RESPONSE_KEY, response);
 
 		return sender;
 	}

--- a/core/src/main/java/org/frankframework/compression/ZipIteratorPipe.java
+++ b/core/src/main/java/org/frankframework/compression/ZipIteratorPipe.java
@@ -115,7 +115,8 @@ public class ZipIteratorPipe extends IteratingPipe<String> {
 	}
 
 	/**
-	 * If set to <code>false</code>, the inputstream is not closed after it has been used
+	 * If set to <code>false</code>, the inputstream is not closed after it has been used.
+	 * Use with caution, they may create memory leaks.
 	 *
 	 * @ff.default true
 	 */
@@ -171,14 +172,14 @@ public class ZipIteratorPipe extends IteratingPipe<String> {
 
 		@Override
 		public String next() throws SenderException {
-			log.debug("next()");
+			log.trace("next()");
 			try {
 				skipCurrent();
 				currentOpen = true;
-				log.debug("found zipEntry name [{}] size [{}] compressed size [{}]", current::getName, current::getSize, current::getCompressedSize);
+				log.debug("found zipEntry name [{}] compressed size [{}]", current::getName, current::getCompressedSize);
 				String filename = current.getName();
 				if (isStreamingContents()) {
-					MessageContext context = new MessageContext().withName(current.getName()).withSize(current.getSize());
+					MessageContext context = new MessageContext().withName(current.getName());
 					if (current.getTime() > 0L) {
 						context.withModificationTime(current.getTime());
 					}

--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -60,15 +60,16 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	public static final String MESSAGE_ID_KEY       = "mid";        // externally determined (or generated) messageId, e.g. JmsMessageID, HTTP header configured as messageId
 	public static final String CORRELATION_ID_KEY   = "cid";       // conversationId, e.g. JmsCorrelationID.
 	public static final String STORAGE_ID_KEY       = "key";
-	public static final String MANUAL_RETRY_KEY     = SYSTEM_MANAGED_RESOURCE_PREFIX + "isManualRetry";
 
 	public static final String TS_RECEIVED_KEY = "tsReceived";
 	public static final String TS_SENT_KEY = "tsSent";
+
 	public static final String SECURITY_HANDLER_KEY = SYSTEM_MANAGED_RESOURCE_PREFIX + "securityHandler";
+	public static final String MANUAL_RETRY_KEY     = SYSTEM_MANAGED_RESOURCE_PREFIX + "isManualRetry";
+	public static final String HTTP_REQUEST_KEY    = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletRequest"; // Used in one place to get the Request URI
+	public static final String HTTP_RESPONSE_KEY   = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletResponse"; // Used in one place to set a HTTP Cookie
 
 	public static final String HTTP_METHOD_KEY 	   = "HttpMethod";
-	public static final String HTTP_REQUEST_KEY    = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletRequest";
-	public static final String HTTP_RESPONSE_KEY   = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletResponse";
 
 	public static final String API_PRINCIPAL_KEY   = "apiPrincipal";
 	public static final String EXIT_STATE_CONTEXT_KEY="exitState";

--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -64,11 +64,11 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 
 	public static final String TS_RECEIVED_KEY = "tsReceived";
 	public static final String TS_SENT_KEY = "tsSent";
-	public static final String SECURITY_HANDLER_KEY ="securityHandler";
+	public static final String SECURITY_HANDLER_KEY = SYSTEM_MANAGED_RESOURCE_PREFIX + "securityHandler";
 
 	public static final String HTTP_METHOD_KEY 	   = "HttpMethod";
-	public static final String HTTP_REQUEST_KEY    = "servletRequest";
-	public static final String HTTP_RESPONSE_KEY   = "servletResponse";
+	public static final String HTTP_REQUEST_KEY    = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletRequest";
+	public static final String HTTP_RESPONSE_KEY   = SYSTEM_MANAGED_RESOURCE_PREFIX + "servletResponse";
 
 	public static final String API_PRINCIPAL_KEY   = "apiPrincipal";
 	public static final String EXIT_STATE_CONTEXT_KEY="exitState";

--- a/core/src/main/java/org/frankframework/http/RestListenerUtils.java
+++ b/core/src/main/java/org/frankframework/http/RestListenerUtils.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2016-2018, 2020 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2016-2018, 2020 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,19 +15,12 @@
  */
 package org.frankframework.http;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 import org.frankframework.core.PipeLineSession;
-import org.frankframework.util.StreamUtil;
 
 /**
- * Some utilities for working with {@link RestListener}.
+ * One utility for working with WSDL Generator Pipes.
  *
  * @author Peter Leeuwenburgh
  */
@@ -39,27 +32,5 @@ public class RestListenerUtils {
 			return request.getRequestURL().toString();
 		}
 		return null;
-	}
-
-	@Deprecated
-	public static void writeToResponseOutputStream(PipeLineSession session, InputStream input) throws IOException {
-		OutputStream output = retrieveServletOutputStream(session);
-		StreamUtil.copyStream(input, output, 30000);
-	}
-
-	private static ServletOutputStream retrieveServletOutputStream(PipeLineSession session) throws IOException {
-		HttpServletResponse response = (HttpServletResponse) session.get(PipeLineSession.HTTP_RESPONSE_KEY);
-		if (response != null) {
-			return response.getOutputStream();
-		}
-		return null;
-	}
-
-	@Deprecated
-	public static void setResponseContentType(PipeLineSession session, String contentType) {
-		HttpServletResponse response = (HttpServletResponse) session.get(PipeLineSession.HTTP_RESPONSE_KEY);
-		if (response != null) {
-			response.setContentType(contentType);
-		}
 	}
 }

--- a/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
+++ b/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018-2021 Nationale-Nederlanden, 2021-2024 WeAreFrank!
+   Copyright 2018-2021 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 	private String attachmentXmlSessionKey = null;
 	private Map<String, MessageFactory> factory = new HashMap<>();
 
-	private static final String SOAP_PROTOCOL_KEY = "soapProtocol";
+	public static final String SOAP_PROTOCOL_KEY = "soapProtocol";
 
 	protected boolean multipartBackwardsCompatibilityMode = AppConstants.getInstance().getBoolean("WebServiceListener.backwardsCompatibleMultipartNotation", false);
 

--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
@@ -59,7 +59,6 @@ import org.frankframework.documentbuilder.DocumentFormat;
 import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.parameters.IParameter;
 import org.frankframework.parameters.ParameterList;
-import org.frankframework.parameters.ParameterType;
 import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.pipes.Base64Pipe;
 import org.frankframework.pipes.Base64Pipe.Direction;
@@ -366,27 +365,6 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 			throw new SenderException("got exception sending message", t);
 		} finally {
 			closeStatementSet(queryExecutionContext);
-			ParameterList newParameterList = queryExecutionContext.getParameterList();
-			if (newParameterList != null) {
-				//noinspection deprecation
-				newParameterList.stream()
-						.filter(param -> param.getType() == ParameterType.INPUTSTREAM)
-						.forEach(param -> closeParameterInputStream(param, message, session));
-			}
-		}
-	}
-
-	private void closeParameterInputStream(IParameter param, Message message, PipeLineSession session) {
-		log.debug("Closing inputstream for parameter [{}]", param::getName);
-		try {
-			Object object = param.getValue(null, message, session, true);
-			if (object instanceof AutoCloseable closeable) {
-				closeable.close();
-			} else {
-				log.error("unable to auto-close parameter [{}]", param::getName);
-			}
-		} catch (Exception e) {
-			log.warn(new SenderException("got exception closing inputstream", e));
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
@@ -131,7 +131,6 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 	private @Getter String rowIdSessionKey=null;
 	private @Getter String packageContent = "db2";
 	private @Getter String[] columnsReturnedList=null;
-	private @Getter boolean streamResultToServlet = false; //TODO: remove stream result to servlet
 	private @Getter String sqlDialect = AppConstants.getInstance().getString("jdbc.sqlDialect", null);
 	private @Getter boolean lockRows=false;
 	private @Getter int lockWait=-1;
@@ -307,6 +306,7 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	protected SenderResult executeStatementSet(@Nonnull QueryExecutionContext queryExecutionContext, @Nonnull Message message, @Nonnull PipeLineSession session) throws SenderException, TimeoutException {
 		try {
 			PreparedStatement statement=queryExecutionContext.getStatement();
@@ -316,21 +316,12 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 					Object blobSessionVar = null;
 					Object clobSessionVar = null;
 					if (StringUtils.isNotEmpty(getBlobSessionKey())) {
-						//noinspection deprecation
 						blobSessionVar = session.getMessage(getBlobSessionKey()).asObject();
 					}
 					if (StringUtils.isNotEmpty(getClobSessionKey())) {
-						//noinspection deprecation
 						clobSessionVar = session.getMessage(getClobSessionKey()).asObject();
 					}
-					if (isStreamResultToServlet()) {
-						HttpServletResponse response = (HttpServletResponse) session.get(PipeLineSession.HTTP_RESPONSE_KEY);
-						String contentType = session.getString("contentType");
-						String contentDisposition = session.getString("contentDisposition");
-						return executeSelectQuery(statement,blobSessionVar,clobSessionVar, response, contentType, contentDisposition);
-					} else {
-						return executeSelectQuery(statement,blobSessionVar,clobSessionVar);
-					}
+					return executeSelectQuery(statement,blobSessionVar,clobSessionVar);
 				case UPDATEBLOB:
 					if (StringUtils.isNotEmpty(getBlobSessionKey())) {
 						return new SenderResult(executeUpdateBlobQuery(statement, session.getMessage(getBlobSessionKey())));
@@ -800,7 +791,7 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 			}
 			StringBuilder newMessage = new StringBuilder(message.substring(0, openingBracePosition + 1));
 			if (idx >= 0) {
-				//check if output parameter exists is expected in original message and append an ending ?(out-parameter)
+				// Check if output parameter exists is expected in original message and append an ending ?(out-parameter)
 				int parameterCount = idx + (message.contains("?") ? 1 : 0);
 				if (parameterCount > 0) {
 					newMessage.append("?");
@@ -929,15 +920,6 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 	/** If specified, the rowid of the processed row is put in the pipelinesession under the specified key (only applicable for <code>querytype=other</code>). <b>Note:</b> If multiple rows are processed a SqlException is thrown. */
 	public void setRowIdSessionKey(String string) {
 		rowIdSessionKey = string;
-	}
-
-	/**
-	 * If set, the result is streamed to the HttpServletResponse object of the RestServiceDispatcher (instead of passed as bytes or as a String)
-	 * @ff.default false
-	 */
-	@Deprecated(forRemoval = true, since = "7.6.0")
-	public void setStreamResultToServlet(boolean b) {
-		streamResultToServlet = b;
 	}
 
 	/** If set, the SQL dialect in which the queries are written and should be translated from to the actual SQL dialect */

--- a/core/src/main/java/org/frankframework/parameters/DateParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/DateParameter.java
@@ -45,7 +45,6 @@ public class DateParameter extends AbstractParameter {
 
 	private @Getter String formatString = null;
 	private DateFormatType formatType;
-	private DateFormat dateFormat;
 
 	public DateParameter() {
 		setFormatType(DateFormatType.DATE); // Defaults to Date
@@ -78,7 +77,7 @@ public class DateParameter extends AbstractParameter {
 
 		if(formatType != DateFormatType.XMLDATETIME) {
 			try {
-				dateFormat = new SimpleDateFormat(getFormatString());
+				new SimpleDateFormat(getFormatString());
 			} catch (IllegalArgumentException e) {
 				throw new ConfigurationException("invalid formatString [" + getFormatString() + "]", e);
 			}
@@ -99,8 +98,9 @@ public class DateParameter extends AbstractParameter {
 		}
 
 		log.debug("Parameter [{}] converting result [{}] to Date using formatString [{}]", this::getName, () -> request, this::getFormatString);
+		DateFormat df = new SimpleDateFormat(getFormatString());
 		try {
-			return dateFormat.parse(request.asString());
+			return df.parse(request.asString());
 		} catch (ParseException e) {
 			throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse result [" + request + "] to Date using formatString [" + getFormatString() + "]", e);
 		}

--- a/core/src/main/java/org/frankframework/parameters/DateParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/DateParameter.java
@@ -45,6 +45,7 @@ public class DateParameter extends AbstractParameter {
 
 	private @Getter String formatString = null;
 	private DateFormatType formatType;
+	private DateFormat dateFormat;
 
 	public DateParameter() {
 		setFormatType(DateFormatType.DATE); // Defaults to Date
@@ -75,6 +76,14 @@ public class DateParameter extends AbstractParameter {
 			}
 		}
 
+		if(formatType != DateFormatType.XMLDATETIME) {
+			try {
+				dateFormat = new SimpleDateFormat(getFormatString());
+			} catch (IllegalArgumentException e) {
+				throw new ConfigurationException("invalid formatString [" + getFormatString() + "]", e);
+			}
+		}
+
 		super.configure();
 	}
 
@@ -90,9 +99,8 @@ public class DateParameter extends AbstractParameter {
 		}
 
 		log.debug("Parameter [{}] converting result [{}] to Date using formatString [{}]", this::getName, () -> request, this::getFormatString);
-		DateFormat df = new SimpleDateFormat(getFormatString());
 		try {
-			return df.parse(request.asString());
+			return dateFormat.parse(request.asString());
 		} catch (ParseException e) {
 			throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse result [" + request + "] to Date using formatString [" + getFormatString() + "]", e);
 		}

--- a/core/src/main/java/org/frankframework/parameters/ParameterType.java
+++ b/core/src/main/java/org/frankframework/parameters/ParameterType.java
@@ -70,16 +70,6 @@ public enum ParameterType {
 	/** Converts the result to a Boolean */
 	BOOLEAN(BooleanParameter.class, true),
 
-	/** Only applicable as a JDBC parameter, the method setBinaryStream() is used */
-	@ConfigurationWarning("use type [BINARY] instead")
-	@Deprecated
-	INPUTSTREAM,
-
-	/** Only applicable as a JDBC parameter, the method setBytes() is used */
-	@ConfigurationWarning("use type [BINARY] instead")
-	@Deprecated
-	BYTES,
-
 	/** Forces the parameter value to be treated as binary data (e.g. when using a SQL BLOB field).
 	 * When applied as a JDBC parameter, the method setBinaryStream() or setBytes() is used */
 	BINARY,

--- a/core/src/main/java/org/frankframework/soap/SoapWrapper.java
+++ b/core/src/main/java/org/frankframework/soap/SoapWrapper.java
@@ -84,7 +84,7 @@ public class SoapWrapper {
 	private static final String EXTRACT_FAULTCODE_XPATH_SOAP12 = "/soapenv:Envelope/soapenv:Body/soapenv:Fault/soapenv:Code";
 	private static final String EXTRACT_FAULTSTRING_XPATH_SOAP11 = "/soapenv:Envelope/soapenv:Body/soapenv:Fault/faultstring";
 	private static final String EXTRACT_FAULTSTRING_XPATH_SOAP12 = "/soapenv:Envelope/soapenv:Body/soapenv:Fault/soapenv:Reason";
-	public static final String SOAP_VERSION_SESSION_KEY = "SoapWrapper.SoapVersion";
+	public static final String SOAP_VERSION_SESSION_KEY = PipeLineSession.SYSTEM_MANAGED_RESOURCE_PREFIX + "SoapWrapper.SoapVersion";
 	public static final String DEFAULT_XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
 	private static SoapWrapper self = null;

--- a/core/src/main/java/org/frankframework/util/JdbcUtil.java
+++ b/core/src/main/java/org/frankframework/util/JdbcUtil.java
@@ -567,8 +567,8 @@ public class JdbcUtil {
 		String paramName = pv.getDefinition().getName();
 		ParameterType paramType = pv.getDefinition().getType();
 		Object value = pv.getValue();
-		if (log.isDebugEnabled())
-			log.debug("jdbc parameter [{}] applying parameter [{}] type [{}] value [{}]", parameterIndex, paramName, paramType, value);
+		log.debug("jdbc parameter [{}] applying parameter [{}] type [{}] value [{}]", parameterIndex, paramName, paramType, value);
+
 		switch (paramType) {
 			case DATE:
 				if (value == null) {
@@ -615,7 +615,6 @@ public class JdbcUtil {
 				}
 				break;
 			// noinspection deprecation
-			case INPUTSTREAM:
 			case BINARY: {
 				Message message = Message.asMessage(value);
 				message.closeOnCloseOf(session);
@@ -636,14 +635,6 @@ public class JdbcUtil {
 				}
 				break;
 			}
-			// noinspection deprecation
-			case BYTES: {
-				Message message = Message.asMessage(value);
-				message.closeOnCloseOf(session);
-
-				statement.setBytes(parameterIndex, message.asByteArray());
-				break;
-			}
 			default:
 				Message message = Message.asMessage(value);
 				message.closeOnCloseOf(session);
@@ -651,7 +642,7 @@ public class JdbcUtil {
 		}
 	}
 
-	/** Set a parameter in a prepared statement. Optimised for single-parameter statements */
+	/** Set a parameter in a prepared statement. Optimized for single-parameter statements */
 	public static void setParameter(PreparedStatement statement, int parameterIndex, String value, boolean parameterTypeMatchRequired) throws SQLException {
 		setParameter(statement, parameterIndex, value, parameterTypeMatchRequired, parameterTypeMatchRequired ? statement.getParameterMetaData() : null);
 	}

--- a/core/src/test/java/org/frankframework/compression/ZipIteratorPipeTest.java
+++ b/core/src/test/java/org/frankframework/compression/ZipIteratorPipeTest.java
@@ -87,10 +87,10 @@ class ZipIteratorPipeTest extends PipeTestBase<ZipIteratorPipe> {
 		assertEquals("""
 				<results>
 				<result item="1">
-				{Metadata.Name=fileaa.txt, Metadata.Size=3, Metadata.ModificationTime=2021-04-07 15:09:20.000}
+				{Metadata.Name=fileaa.txt, Metadata.ModificationTime=2021-04-07 15:09:20.000}
 				</result>
 				<result item="2">
-				{Metadata.Name=filebb.log, Metadata.Size=3, Metadata.ModificationTime=2021-04-07 15:09:28.000}
+				{Metadata.Name=filebb.log, Metadata.ModificationTime=2021-04-07 15:09:28.000}
 				</result>
 				</results>""", prr.getResult().asString());
 	}

--- a/core/src/test/java/org/frankframework/compression/ZipIteratorPipeTest.java
+++ b/core/src/test/java/org/frankframework/compression/ZipIteratorPipeTest.java
@@ -2,21 +2,27 @@ package org.frankframework.compression;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import java.io.File;
 import java.net.URL;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
 import org.frankframework.pipes.PipeTestBase;
 import org.frankframework.senders.EchoSender;
 import org.frankframework.stream.FileMessage;
 import org.frankframework.stream.Message;
+import org.frankframework.stream.MessageContext;
 import org.frankframework.testutil.TestFileUtils;
 
 class ZipIteratorPipeTest extends PipeTestBase<ZipIteratorPipe> {
@@ -56,6 +62,37 @@ class ZipIteratorPipeTest extends PipeTestBase<ZipIteratorPipe> {
 		PipeRunResult prr = doPipe(new FileMessage(new File(zip.getFile())));
 
 		assertEquals(EXPECTED, prr.getResult().asString());
+	}
+
+	@Test
+	void testZipIteratorPipeSenderMessage() throws Exception {
+		EchoSender sender = spy(getConfiguration().createBean(EchoSender.class));
+		doAnswer(e -> {
+			Message zipEntryName = e.getArgument(0);
+			PipeLineSession localSession = e.getArgument(1);
+			Message zipEntry = localSession.getMessage(pipe.getContentsSessionKey());
+
+			assertEquals(zipEntryName.asString(), zipEntry.getContext().get(MessageContext.METADATA_NAME));
+			return new Message(StringUtils.join(zipEntry.getContext().getAll()));
+		}).when(sender).sendMessageOrThrow(any(Message.class), any(PipeLineSession.class));
+
+		pipe.setSender(sender);
+		pipe.configure();
+		pipe.start();
+
+		URL zip = TestFileUtils.getTestFileURL("/Unzip/ab.zip");
+
+		PipeRunResult prr = doPipe(new FileMessage(new File(zip.getFile())));
+
+		assertEquals("""
+				<results>
+				<result item="1">
+				{Metadata.Name=fileaa.txt, Metadata.Size=3, Metadata.ModificationTime=2021-04-07 15:09:20.000}
+				</result>
+				<result item="2">
+				{Metadata.Name=filebb.log, Metadata.Size=3, Metadata.ModificationTime=2021-04-07 15:09:28.000}
+				</result>
+				</results>""", prr.getResult().asString());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
@@ -4,6 +4,7 @@ import static org.frankframework.parameters.DateParameter.TYPE_DATE_PATTERN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
@@ -134,6 +135,16 @@ public class DateParameterTest {
 
 		assertFalse(parameter.requiresInputValueForResolution());
 		assertTrue(parameter.consumesSessionVariable("originalMessage"));
+	}
+
+	@Test
+	public void testWrongFormatString() throws Exception {
+		DateParameter p = new DateParameter();
+		p.setName("date");
+		p.setFormatType(DateFormatType.DATE);
+		p.setFormatString("abc");
+		ConfigurationException e = assertThrows(ConfigurationException.class, p::configure);
+		assertEquals("invalid formatString [abc]: (IllegalArgumentException) Illegal pattern character 'b'", e.getMessage());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/util/JdbcUtilTest.java
+++ b/core/src/test/java/org/frankframework/util/JdbcUtilTest.java
@@ -176,7 +176,7 @@ public class JdbcUtilTest {
 
 		ParameterList params = new ParameterList();
 		params.add(NumberParameterBuilder.create().withValue(1));
-		params.add(ParameterBuilder.create().withSessionKey("binaryParam").withType(ParameterType.BYTES));
+		params.add(ParameterBuilder.create().withSessionKey("binaryParam").withType(ParameterType.BINARY));
 
 		PipeLineSession session = new PipeLineSession();
 		session.put("binaryParam", new ThrowingAfterCloseInputStream(new VirtualInputStream(20_000)));

--- a/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
@@ -15,7 +15,7 @@
 					query="INSERT INTO IBISTEMP (TKEY, TVARCHAR, TTIMESTAMP, TBLOB) VALUES (SEQ_IBISTEMP.NEXTVAL, ?, CURRENT_TIMESTAMP, ?)"
 					resultQuery="SELECT SEQ_IBISTEMP.CURRVAL FROM DUAL" scalar="true">
 					<param name="TVARCHAR" sessionKey="fileName" />
-					<param name="message" sessionKey="file" type="inputstream" />
+					<param name="message" sessionKey="file" type="binary" />
 				</sender>
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -114,7 +114,7 @@
 				className="org.frankframework.pipes.SenderPipe">
 				<sender className="org.frankframework.jdbc.FixedQuerySender"
 					query="SELECT TBLOB FROM IBISTEMP WHERE TKEY=?" queryType="select"
-					scalar="true" streamResultToServlet="true"
+					scalar="true"
 					blobsCompressed="false">
 					<param name="messageKey" sessionKey="docId" />
 				</sender>


### PR DESCRIPTION
- Create formatter once during configure
- No longer store zip-streams directly in the session but use messages (with context)
- Remove inputstream and bytes parameter types ([Deprecated in version 7.7](https://github.com/frankframework/frankframework/pull/2445))
- Cleanup old CMIS tests which no longer use StreamToServlet
- Remove StreamToServlet from JDBC Query Senders

After this the PipeLineSession should no longer contain raw InputStreams or Readers.