### PR TITLE
Unix timestamp

### DIFF
--- a/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
@@ -663,7 +663,9 @@ public abstract class AbstractParameter implements IConfigurable, IWithParameter
 				case "now":
 					if ("date".equalsIgnoreCase(formatType) || "time".equalsIgnoreCase(formatType)) {
 						substitutionValue = new Date();
-					} else{
+					} else if ("number".equalsIgnoreCase(formatType)) {
+						substitutionValue = System.currentTimeMillis();
+					} else {
 						substitutionValue = formatDateToString(new Date(), formatString);
 					}
 

--- a/core/src/main/java/org/frankframework/parameters/DateParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/DateParameter.java
@@ -80,38 +80,51 @@ public class DateParameter extends AbstractParameter {
 
 	@Override
 	protected Date getValueAsType(@Nonnull Message request, boolean namespaceAware) throws ParameterException, IOException {
-		if (request.asObject() instanceof Date date) {
+		Object rawValue = request.asObject();
+		if (rawValue instanceof Date date) {
 			return date;
 		}
 
-		if(formatType == DateFormatType.XMLDATETIME) {
-			log.debug("Parameter [{}] converting result [{}] from XML dateTime to Date", this::getName, () -> request);
-			return XmlUtils.parseXmlDateTime(request.asString());
-		}
+		String value = request.asString().trim();
 
 		if (formatType == DateFormatType.UNIX) {
 			log.debug("Parameter [{}] interpreting result [{}] as UNIX timestamp", this::getName, () -> request);
-			try {
-				String value = request.asString().trim();
-				long epoch = Long.parseLong(value);
+			return parseUnixTimestamp(value);
+		}
 
-				// Heuristic: if the number is less than 10^12, treat as seconds
-				if (epoch < 1_000_000_000_000L) {
-					epoch *= 1000; // convert seconds to milliseconds
-				}
-
-				return new Date(epoch);
-			} catch (NumberFormatException e) {
-				throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse UNIX timestamp from [" + request + "]", e);
-			}
+		if (formatType == DateFormatType.XMLDATETIME) {
+			log.debug("Parameter [{}] converting result [{}] from XML dateTime to Date", this::getName, () -> request);
+			return XmlUtils.parseXmlDateTime(value);
 		}
 
 		log.debug("Parameter [{}] converting result [{}] to Date using formatString [{}]", this::getName, () -> request, this::getFormatString);
-		DateFormat df = new SimpleDateFormat(getFormatString());
 		try {
-			return df.parse(request.asString());
+			DateFormat df = new SimpleDateFormat(getFormatString());
+			return df.parse(value);
 		} catch (ParseException e) {
+			// Fallback: if value looks numeric, try to parse as unix timestamp before failing
+			if (value.matches("^[\\d.,_]+$")) {
+				log.debug("Parameter [{}] fallback: interpreting numeric result [{}] as UNIX timestamp", this::getName, () -> request);
+				log.warn("Date parameter formatType was inferred to be UNIX, but should be manually set to avoid possible parsing errors");
+				return parseUnixTimestamp(value);
+			}
 			throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse result [" + request + "] to Date using formatString [" + getFormatString() + "]", e);
+		}
+	}
+
+	private Date parseUnixTimestamp(String value) throws ParameterException {
+		try {
+			String sanitized = value.replace(".", "")
+									.replace(",", "")
+									.replace("_", "");
+			long epoch = Long.parseLong(sanitized);
+
+			if (epoch < 1_000_000_000_000L) {
+				epoch *= 1000; // convert seconds to milliseconds
+			}
+			return new Date(epoch);
+		} catch (NumberFormatException e) {
+			throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse UNIX timestamp from [" + value + "]", e);
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/parameters/DateParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/DateParameter.java
@@ -51,7 +51,7 @@ public class DateParameter extends AbstractParameter {
 	}
 
 	public enum DateFormatType {
-		DATE, DATETIME, TIMESTAMP, TIME, XMLDATETIME
+		DATE, DATETIME, TIMESTAMP, TIME, UNIX, XMLDATETIME
 	}
 
 	@Override
@@ -87,6 +87,23 @@ public class DateParameter extends AbstractParameter {
 		if(formatType == DateFormatType.XMLDATETIME) {
 			log.debug("Parameter [{}] converting result [{}] from XML dateTime to Date", this::getName, () -> request);
 			return XmlUtils.parseXmlDateTime(request.asString());
+		}
+
+		if (formatType == DateFormatType.UNIX) {
+			log.debug("Parameter [{}] interpreting result [{}] as UNIX timestamp", this::getName, () -> request);
+			try {
+				String value = request.asString().trim();
+				long epoch = Long.parseLong(value);
+
+				// Heuristic: if the number is less than 10^12, treat as seconds
+				if (epoch < 1_000_000_000_000L) {
+					epoch *= 1000; // convert seconds to milliseconds
+				}
+
+				return new Date(epoch);
+			} catch (NumberFormatException e) {
+				throw new ParameterException(getName(), "Parameter [" + getName() + "] could not parse UNIX timestamp from [" + request + "]", e);
+			}
 		}
 
 		log.debug("Parameter [{}] converting result [{}] to Date using formatString [{}]", this::getName, () -> request, this::getFormatString);

--- a/core/src/main/java/org/frankframework/parameters/ParameterType.java
+++ b/core/src/main/java/org/frankframework/parameters/ParameterType.java
@@ -56,6 +56,9 @@ public enum ParameterType {
 	/** Similar to <code>DATETIME</code>, except for the formatString that is <code>yyyy-MM-dd HH:mm:ss.SSS</code> by default */
 	TIMESTAMP(DateParameter.class, true),
 
+	/** Converts the result to a Date, formatted as a unix timestamp in ms since Jan 01 1970. (UTC).*/
+	UNIX(DateParameter.class, true),
+
 	/** Converts the result from a XML formatted dateTime to a Date.
 	 * When applied as a JDBC parameter, the method setTimestamp() is used */
 	XMLDATETIME(DateParameter.class, true),

--- a/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/DateParameterTest.java
@@ -399,6 +399,65 @@ public class DateParameterTest {
 	}
 
 	@Test
+	public void testUnixParameterConvertsToDate() throws Exception {
+		DateParameter p = new DateParameter();
+		try {
+			p.setName("date");
+			p.setValue("1747401948");
+			p.setFormatType(DateParameter.DateFormatType.UNIX);
+			p.configure();
+			PipeLineSession session = new PipeLineSession();
+
+			ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+			Message message = new Message("fakeMessage");
+
+			Object result = p.getValue(alreadyResolvedParameters, message, session, false);
+			assertInstanceOf(Date.class, result);
+		} finally {
+			System.getProperties().remove(ConfigurationUtils.STUB4TESTTOOL_CONFIGURATION_KEY);
+		}
+	}
+
+	@Test
+	public void testUnixPatternConvertsToDate() throws Exception {
+		DateParameter p = new DateParameter();
+		try {
+			p.setName("unixTimestamp");
+			p.setPattern("{now,number,#}");
+			p.setFormatType(DateFormatType.UNIX);
+			p.configure();
+			PipeLineSession session = new PipeLineSession();
+
+			ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+			Message message = new Message("fakeMessage");
+
+			Object result = p.getValue(alreadyResolvedParameters, message, session, false);
+			assertInstanceOf(Date.class, result);
+		} finally {
+			System.getProperties().remove(ConfigurationUtils.STUB4TESTTOOL_CONFIGURATION_KEY);
+		}
+	}
+
+	@Test
+	public void testUnixPatternConvertsToDateWithoutFormatType() throws Exception {
+		DateParameter p = new DateParameter();
+		try {
+			p.setName("unixTimestamp");
+			p.setPattern("{now,number}");
+			p.configure();
+			PipeLineSession session = new PipeLineSession();
+
+			ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+			Message message = new Message("fakeMessage");
+
+			Object result = p.getValue(alreadyResolvedParameters, message, session, false);
+			assertInstanceOf(Date.class, result);
+		} finally {
+			System.getProperties().remove(ConfigurationUtils.STUB4TESTTOOL_CONFIGURATION_KEY);
+		}
+	}
+
+	@Test
 	public void testParameterFromDateToDate() throws Exception {
 		Date date = new Date();
 

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -3,6 +3,7 @@ package org.frankframework.parameters;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1179,6 +1180,27 @@ public class ParameterTest {
 
 			assertEquals(expectedDate, result);
 
+		} finally {
+			System.getProperties().remove(ConfigurationUtils.STUB4TESTTOOL_CONFIGURATION_KEY);
+		}
+	}
+
+	@Test
+	public void testPatternFixedDateWithUnixTimestamp() throws Exception {
+		Parameter p = new Parameter();
+		try {
+			p.setName("unixTimestamp");
+			p.setPattern("{now,number,#}");
+			p.configure();
+			PipeLineSession session = new PipeLineSession();
+
+			ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+			Message message = new Message("fakeMessage");
+
+			Object result = p.getValue(alreadyResolvedParameters, message, session, false);
+			assertInstanceOf(String.class, result);
+
+			assertDoesNotThrow(() -> Long.parseLong(result.toString()));
 		} finally {
 			System.getProperties().remove(ConfigurationUtils.STUB4TESTTOOL_CONFIGURATION_KEY);
 		}


### PR DESCRIPTION
* Adds the option retrieve a unix timestamp when using the {now} pattern.
* Adds the option to parse a unix timestamp to a date object within a param.