### PR TITLE
Revert "Bump org.springframework.security:spring-security-bom from 6.4.5 to 6.5.0 (#9011)"

### DIFF
--- a/core/src/test/resources/testBusApplicationContext.xml
+++ b/core/src/test/resources/testBusApplicationContext.xml
@@ -9,7 +9,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-5.2.xsd
-		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-6.5.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-6.4.xsd
 		"
 	>
 <!-- 	<integration:control-bus dispatcher-pool-size="25" auto-create-channels="true"/> -->

--- a/messaging/src/test/resources/testBusApplicationContext.xml
+++ b/messaging/src/test/resources/testBusApplicationContext.xml
@@ -9,7 +9,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-5.2.xsd
-		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-6.5.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-6.4.xsd
 		"
 	>
 <!-- 	<integration:control-bus dispatcher-pool-size="25" auto-create-channels="true"/> -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 		<jackson.version>2.19.0</jackson.version>
 		<cxf.version>4.1.1</cxf.version>
 		<spring.version>6.2.7</spring.version>
-		<spring-security.version>6.5.0</spring-security.version>
-		<spring-integration.version>6.5.0</spring-integration.version>
+		<spring-security.version>6.4.5</spring-security.version>
+		<spring-integration.version>6.4.4</spring-integration.version>
 		<spring.boot.version>3.4.5</spring.boot.version>
 		<tomcat.version>10.1.41</tomcat.version>
 		<bouncycastle.version>1.80</bouncycastle.version>


### PR DESCRIPTION
The Spring Security 6.4.5 update breaks the current version of LadyBug (v0.1.0-20250407.114528), so reverting it.

We should have a test that verifies that LadyBug does at the very least nog give a status 500 return -- not sure yet where to make such a test. Add to Cypress tests? Is there an endpoint we could check in another test in the `test` project which already starts all systems via IafTestInitializer?