### PR TITLE
Set standalone console servlet authenticator to NONE

### DIFF
--- a/console/war/src/main/resources/application.properties
+++ b/console/war/src/main/resources/application.properties
@@ -36,6 +36,9 @@ spring.profiles.default=ladybug.file
 management.gateway.outbound.class=org.frankframework.management.gateway.HazelcastOutboundGateway
 management.gateway.http.outbound.endpoint=http://localhost/iaf-test/iaf/management
 
+# Set application servlet authenticator to NONE instead of the default
+application.security.console.authentication.type=NONE
+
 ## list the console on the server root.
 servlet.IAF-GUI.urlMapping=/*
 


### PR DESCRIPTION
The default for the standalone console shouldn't be set to have the SealedAuthenticator by default return http 401 on every endpoint, this pr the servlet authenticator to NoOpAuthenticator

Found while helping @MatthijsSmets with running the standalone console for testing his own outboundgateway