### PR TITLE
IfPipe can lose the input message

### DIFF
--- a/core/src/main/java/org/frankframework/pipes/IfPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/IfPipe.java
@@ -280,6 +280,7 @@ public class IfPipe extends AbstractPipe {
 		} else if (StringUtils.isNotBlank(jsonPathExpression)) {
 			// Try to match the jsonPath expression on the given json string
 			try {
+				message.preserve();
 				Object jsonPathResult = JsonPath.read(message.asInputStream(), jsonPathExpression);
 
 				// if we get to this point, we have a match (and no PathNotFoundException)

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -541,7 +541,9 @@ public class Message implements Serializable, Closeable {
 			String charset = getEncodingCharset(defaultEncodingCharset);
 			if (request instanceof Reader reader) {
 				LOG.debug("returning Reader {} as InputStream", this::getObjectId);
-				return new BufferedInputStream(new ReaderInputStream(reader, charset));
+				BufferedInputStream inputStream = new BufferedInputStream(new ReaderInputStream(reader, charset));
+				this.request = inputStream;
+				return inputStream;
 			}
 			LOG.debug("returning String {} as InputStream", this::getObjectId);
 			return new ByteArrayInputStream(request.toString().getBytes(charset));

--- a/core/src/test/java/org/frankframework/pipes/IfPipeJsonPathTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IfPipeJsonPathTest.java
@@ -4,6 +4,7 @@ import static org.frankframework.pipes.IfPipeTest.PIPE_FORWARD_ELSE;
 import static org.frankframework.pipes.IfPipeTest.PIPE_FORWARD_THEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.StringReader;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -14,6 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeRunResult;
+import org.frankframework.stream.Message;
 import org.frankframework.util.CloseUtils;
 
 public class IfPipeJsonPathTest extends PipeTestBase<IfPipe> {
@@ -104,12 +106,24 @@ public class IfPipeJsonPathTest extends PipeTestBase<IfPipe> {
 
 	@ParameterizedTest
 	@MethodSource("messageSource")
-	void testExpressionsWithStreamingInput(String input, String expression, String expressionValue, String expectedValue) throws Exception {
+	void testExpressionsWithStreamingJsonInput(String input, String expression, String expressionValue, String expectedValue) throws Exception {
 		pipe.setJsonPathExpression(expression);
 		pipe.setExpressionValue(expressionValue);
 		configureAndStartPipe();
 
 		pipeRunResult = doPipe(pipe, IfPipeTest.getStreamingJsonMessage(input), session);
+		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
+		assertEquals(input, pipeRunResult.getResult().asString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("messageSource")
+	void testExpressionsWithStreamingStringInput(String input, String expression, String expressionValue, String expectedValue) throws Exception {
+		pipe.setJsonPathExpression(expression);
+		pipe.setExpressionValue(expressionValue);
+		configureAndStartPipe();
+
+		pipeRunResult = doPipe(pipe, new Message(new StringReader(input)), session);
 		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
 		assertEquals(input, pipeRunResult.getResult().asString());
 	}

--- a/core/src/test/java/org/frankframework/pipes/IfPipeJsonPathTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IfPipeJsonPathTest.java
@@ -99,5 +99,18 @@ public class IfPipeJsonPathTest extends PipeTestBase<IfPipe> {
 
 		pipeRunResult = doPipe(pipe, IfPipeTest.getJsonMessage(input), session);
 		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
+		assertEquals(input, pipeRunResult.getResult().asString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("messageSource")
+	void testExpressionsWithStreamingInput(String input, String expression, String expressionValue, String expectedValue) throws Exception {
+		pipe.setJsonPathExpression(expression);
+		pipe.setExpressionValue(expressionValue);
+		configureAndStartPipe();
+
+		pipeRunResult = doPipe(pipe, IfPipeTest.getStreamingJsonMessage(input), session);
+		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
+		assertEquals(input, pipeRunResult.getResult().asString());
 	}
 }

--- a/core/src/test/java/org/frankframework/pipes/IfPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IfPipeTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.StringReader;
 import java.util.stream.Stream;
 
 import org.hamcrest.Matchers;
@@ -132,9 +133,19 @@ public class IfPipeTest extends PipeTestBase<IfPipe> {
 
 		pipeRunResult = doPipe(pipe, "test123", session);
 		assertEquals(PIPE_FORWARD_THEN, pipeRunResult.getPipeForward().getName());
+		assertEquals("test123", pipeRunResult.getResult().asString());
 
 		pipeRunResult = doPipe(pipe, getJsonMessage("test123"), session);
 		assertEquals(PIPE_FORWARD_THEN, pipeRunResult.getPipeForward().getName());
+		assertEquals("test123", pipeRunResult.getResult().asString());
+
+		pipeRunResult = doPipe(pipe, new Message(new StringReader("test123")), session);
+		assertEquals(PIPE_FORWARD_THEN, pipeRunResult.getPipeForward().getName());
+		assertEquals("test123", pipeRunResult.getResult().asString());
+
+		pipeRunResult = doPipe(pipe, getStreamingJsonMessage("test123"), session);
+		assertEquals(PIPE_FORWARD_THEN, pipeRunResult.getPipeForward().getName());
+		assertEquals("test123", pipeRunResult.getResult().asString());
 	}
 
 	@MethodSource("messageSource")
@@ -227,6 +238,12 @@ public class IfPipeTest extends PipeTestBase<IfPipe> {
 
 	static Message getJsonMessage(String json) {
 		Message jsonMessage = new Message(json);
+		jsonMessage.getContext().withMimeType("application/json");
+		return jsonMessage;
+	}
+
+	static Message getStreamingJsonMessage(String json) {
+		Message jsonMessage = new Message(new StringReader(json));
 		jsonMessage.getContext().withMimeType("application/json");
 		return jsonMessage;
 	}

--- a/core/src/test/java/org/frankframework/pipes/IfPipeXpathTest.java
+++ b/core/src/test/java/org/frankframework/pipes/IfPipeXpathTest.java
@@ -69,6 +69,19 @@ public class IfPipeXpathTest extends PipeTestBase<IfPipe> {
 
 		pipeRunResult = doPipe(pipe, input, session);
 		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
+		assertEquals(input, pipeRunResult.getResult().asString());
+	}
+
+	@ParameterizedTest
+	@MethodSource("messageSource")
+	void testExpressionsWithStreamingInput(String input, String expression, String expressionValue, String expectedValue) throws Exception {
+		pipe.setXpathExpression(expression);
+		pipe.setExpressionValue(expressionValue);
+		configureAndStartPipe();
+
+		pipeRunResult = doPipe(pipe, input, session);
+		assertEquals(expectedValue, pipeRunResult.getPipeForward().getName());
+		assertEquals(input, pipeRunResult.getResult().asString());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
@@ -29,6 +30,8 @@ import org.frankframework.testutil.MessageTestUtils;
 import org.frankframework.testutil.TestFileUtils;
 
 public class MessageUtilsTest {
+
+	public static final String JSON_TEST_INPUT = "{\"GUID\": \"ABC\"}";
 
 	@Test
 	public void testCharset() {
@@ -204,19 +207,39 @@ public class MessageUtilsTest {
 	}
 
 	@Test
-	public void testJsonMessage() {
-		Message json = new Message("{\"GUID\": \"ABC\"}");
+	public void testJsonMessage() throws IOException {
+		Message json = new Message(JSON_TEST_INPUT);
 		MimeType mimeType = MessageUtils.computeMimeType(json);
 		assertNotNull(mimeType);
 		assertEquals("application/json", mimeType.toString());
+		assertEquals(JSON_TEST_INPUT, json.asString());
 	}
 
 	@Test
-	public void testJsonMessageWithName() {
-		Message json = new Message("{\"GUID\": \"ABC\"}", new MessageContext().withName("foo.json"));
+	public void testReaderJsonMessage() throws IOException {
+		Message json = new Message(new StringReader(JSON_TEST_INPUT));
+		MimeType mimeType = MessageUtils.computeMimeType(json);
+		assertNotNull(mimeType);
+		assertEquals("application/json", mimeType.toString());
+		assertEquals(JSON_TEST_INPUT, json.asString());
+	}
+
+	@Test
+	public void testInputStreamJsonMessage() throws IOException {
+		Message json = new Message(new ByteArrayInputStream(JSON_TEST_INPUT.getBytes()));
+		MimeType mimeType = MessageUtils.computeMimeType(json);
+		assertNotNull(mimeType);
+		assertEquals("application/json", mimeType.toString());
+		assertEquals(JSON_TEST_INPUT, json.asString());
+	}
+
+	@Test
+	public void testJsonMessageWithName() throws IOException {
+		Message json = new Message(JSON_TEST_INPUT, new MessageContext().withName("foo.json"));
 		MimeType mimeType = MessageUtils.computeMimeType(json);
 		assertNotNull(mimeType);
 		assertEquals("application/json", mimeType.toString()); //mime-type can be determined
+		assertEquals(JSON_TEST_INPUT, json.asString());
 	}
 
 	private String getMessageHeaders(Message message) {

--- a/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/MessageUtilsTest.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.frankframework.receivers.MessageWrapper;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
 import org.frankframework.stream.UrlMessage;
+import org.frankframework.testutil.LargeStructuredMockData;
 import org.frankframework.testutil.MessageTestUtils;
 import org.frankframework.testutil.TestFileUtils;
 
@@ -225,12 +227,38 @@ public class MessageUtilsTest {
 	}
 
 	@Test
+	public void testReaderHugeJsonMessage() throws IOException {
+		Message json = new Message(LargeStructuredMockData.getLargeJsonDataReader(500_000_000L));
+		MimeType mimeType = MessageUtils.computeMimeType(json);
+		assertNotNull(mimeType);
+		assertEquals("application/json", mimeType.toString());
+
+		String expectedPeek = LargeStructuredMockData.DEFAULT_JSON_OPENING_BLOCK + LargeStructuredMockData.DEFAULT_JSON_REPEATED_BLOCK;
+		String actualPeek = json.peek(expectedPeek.length());
+
+		assertEquals(expectedPeek, actualPeek);
+	}
+
+	@Test
 	public void testInputStreamJsonMessage() throws IOException {
 		Message json = new Message(new ByteArrayInputStream(JSON_TEST_INPUT.getBytes()));
 		MimeType mimeType = MessageUtils.computeMimeType(json);
 		assertNotNull(mimeType);
 		assertEquals("application/json", mimeType.toString());
 		assertEquals(JSON_TEST_INPUT, json.asString());
+	}
+
+	@Test
+	public void testInputStreamHugeJsonMessage() throws IOException {
+		Message json = new Message(LargeStructuredMockData.getLargeJsonDataInputStream(500_000_000L, StandardCharsets.UTF_8));
+		MimeType mimeType = MessageUtils.computeMimeType(json);
+		assertNotNull(mimeType);
+		assertEquals("application/json", mimeType.toString());
+
+		String expectedPeek = LargeStructuredMockData.DEFAULT_JSON_OPENING_BLOCK + LargeStructuredMockData.DEFAULT_JSON_REPEATED_BLOCK;
+		String actualPeek = json.peek(expectedPeek.length());
+
+		assertEquals(expectedPeek, actualPeek);
 	}
 
 	@Test


### PR DESCRIPTION
Closes #9012: IfPipe is supposed to pass on the input unmodified but when the input is a stream, there are various ways in which it can lose the input.
