### PR TITLE
Add sorting options in error store

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/datatable/datatable.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/datatable/datatable.component.ts
@@ -6,12 +6,14 @@ import { FormsModule } from '@angular/forms';
 import { DtContentDirective } from './dt-content.directive';
 import { TruncatePipe } from '../../pipes/truncate.pipe';
 import { ToDateDirective } from '../to-date.directive';
+import { SortDirection } from '../th-sortable.directive';
 
 export type TableOptions = {
   sizeOptions: number[];
   size: number;
-  serverSide: boolean;
   filter: boolean;
+  serverSide: boolean;
+  serverSort: SortDirection;
 };
 
 export type DataTableColumn<T> = {
@@ -34,7 +36,7 @@ export type DataTableEntryInfo = {
 export type DataTableServerRequestInfo = {
   size: number;
   offset: number;
-  sort: 'asc' | 'desc';
+  sort: SortDirection;
 };
 
 export type DataTableServerResponseInfo<T> = {
@@ -112,6 +114,7 @@ export class DataTableDataSource<T> extends DataSource<T> {
     size: 50,
     filter: true,
     serverSide: false,
+    serverSort: 'NONE',
   });
   private _entriesInfo = new BehaviorSubject<DataTableEntryInfo>({
     minPageEntry: 0,
@@ -124,7 +127,6 @@ export class DataTableDataSource<T> extends DataSource<T> {
   private filteredData: T[] = [];
   private _currentPage: number = 1;
   private _totalPages: number = 0;
-  private serverRequestId: number = -1;
   private serverRequestFn?: (value: DataTableServerRequestInfo) => PromiseLike<DataTableServerResponseInfo<T>>;
 
   get data(): T[] {
@@ -210,7 +212,7 @@ export class DataTableDataSource<T> extends DataSource<T> {
     Promise.resolve<DataTableServerRequestInfo>({
       size: this.options.size,
       offset: (this._currentPage - 1) * this.options.size,
-      sort: 'asc',
+      sort: this.options.serverSort,
     })
       .then(this.serverRequestFn)
       .then((response) => {

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.spec.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.spec.ts
@@ -54,9 +54,9 @@ describe('ThSortableDirective', () => {
     directiveElements[0].nativeElement.click();
     const directiveInstance = directiveElements[0].injector.get(ThSortableDirective);
 
-    expect(directiveInstance.direction).toBe('asc');
+    expect(directiveInstance.direction).toBe('ASC');
     directiveElements[0].nativeElement.click();
-    expect(directiveInstance.direction).toBe('desc');
+    expect(directiveInstance.direction).toBe('DESC');
   });
 
   it('sorts table rows', () => {
@@ -66,28 +66,28 @@ describe('ThSortableDirective', () => {
     const directive1Element = directiveElements[1].nativeElement;
 
     directive0Element.click();
-    expect(directive0Instance.direction).toBe('asc');
+    expect(directive0Instance.direction).toBe('ASC');
     expect(fixture.componentInstance.items[0]).toEqual({
       name: 'a',
       value: 2,
     });
 
     directive0Element.click();
-    expect(directive0Instance.direction).toBe('desc');
+    expect(directive0Instance.direction).toBe('DESC');
     expect(fixture.componentInstance.items[0]).toEqual({
       name: 'b',
       value: 1,
     });
 
     directive1Element.click();
-    expect(directive1Instance.direction).toBe('asc');
+    expect(directive1Instance.direction).toBe('ASC');
     expect(fixture.componentInstance.items[0]).toEqual({
       name: 'b',
       value: 1,
     });
 
     directive1Element.click();
-    expect(directive1Instance.direction).toBe('desc');
+    expect(directive1Instance.direction).toBe('DESC');
     expect(fixture.componentInstance.items[0]).toEqual({
       name: 'a',
       value: 2,

--- a/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/th-sortable.directive.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import { anyCompare, compare } from '../utils';
 
-export type SortDirection = 'asc' | 'desc' | null;
+export type SortDirection = 'ASC' | 'DESC' | 'NONE';
 export type SortEvent = {
   column: string | number;
   direction: SortDirection;
@@ -20,7 +20,7 @@ export type SortEvent = {
 export function updateSortableHeaders(headers: QueryList<ThSortableDirective>, column: string | number | symbol): void {
   for (const header of headers) {
     if (header.sortable !== column) {
-      header.updateDirection(null);
+      header.updateDirection('NONE');
     }
   }
 }
@@ -32,11 +32,11 @@ export function basicTableSort<T extends Record<string, string | number>>(
 ): T[] {
   updateSortableHeaders(headers, column);
 
-  if (direction == null || column == '') return array;
+  if (direction == 'NONE' || column == '') return array;
 
   return [...array].sort((a, b) => {
     const order = compare(a[column], b[column]);
-    return direction === 'asc' ? order : -order;
+    return direction === 'ASC' ? order : -order;
   });
 }
 
@@ -48,11 +48,11 @@ export function basicAnyValueTableSort<T>(
 ): T[] {
   updateSortableHeaders(headers, column);
 
-  if (direction == null || column == '') return array;
+  if (direction == 'NONE' || column == '') return array;
 
   return [...array].sort((a, b) => {
     const order = anyCompare(a[column as keyof T], b[column as keyof T]);
-    return direction === 'asc' ? order : -order;
+    return direction === 'ASC' ? order : -order;
   });
 }
 
@@ -61,22 +61,19 @@ export function basicAnyValueTableSort<T>(
 })
 export class ThSortableDirective implements OnInit {
   @Input() sortable: string = '';
-  @Input() direction: SortDirection = null;
+  @Input() direction: SortDirection = 'NONE';
   @Output() sorted = new EventEmitter<SortEvent>();
 
   private nextSortOption(sortOption: SortDirection): SortDirection {
     switch (sortOption) {
-      case null: {
-        return 'asc';
+      case 'NONE': {
+        return 'ASC';
       }
-      case 'asc': {
-        return 'desc';
-      }
-      case 'desc': {
-        return null;
+      case 'ASC': {
+        return 'DESC';
       }
       default: {
-        return sortOption as never;
+        return 'NONE';
       }
     }
   }
@@ -90,10 +87,10 @@ export class ThSortableDirective implements OnInit {
   updateIcon(direction: SortDirection): void {
     let updateColumnName = '';
     updateColumnName =
-      direction == null
+      direction == 'NONE'
         ? this.headerText
         : this.headerText +
-          (direction == 'asc' ? ' <i class="fa fa-arrow-up"></i>' : ' <i class="fa fa-arrow-down"></i>');
+          (direction == 'ASC' ? ' <i class="fa fa-arrow-up"></i>' : ' <i class="fa fa-arrow-down"></i>');
     this.elementRef.nativeElement.innerHTML = updateColumnName;
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
@@ -29,7 +29,7 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
 
   private promise: number = -1;
   private versions: Configuration[] = [];
-  private lastSortEvent: SortEvent = { direction: null, column: '' };
+  private lastSortEvent: SortEvent = { direction: 'NONE', column: '' };
 
   @ViewChildren(ThSortableDirective) headers!: QueryList<ThSortableDirective>;
 

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.html
@@ -45,7 +45,13 @@
                   }
                   <tr>
                     <th>&nbsp;</th>
-                    <td>&nbsp;</td>
+                    <td>
+                      <select [(ngModel)]="sortDirection" (ngModelChange)="updateSort()">
+                        @for (option of sortOptions; track option.value) {
+                          <option value="{{ option.value }}">{{ option.name }}</option>
+                        }
+                      </select>
+                    </td>
                     <td>
                       <button [ladda]="searching" (click)="searchUpdated()" class="btn btn-info btn-sm" type="button">
                         <i class="fa fa-search" aria-hidden="true"></i> Search

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
@@ -20,6 +20,7 @@ import { HasAccessToLinkDirective } from '../../../components/has-access-to-link
 import { DtContentDirective } from '../../../components/datatable/dt-content.directive';
 import { DropLastCharPipe } from '../../../pipes/drop-last-char.pipe';
 import { Subscription } from 'rxjs';
+import { SortDirection } from '../../../components/th-sortable.directive';
 
 type FieldSearchInfo = {
   fieldName: string;
@@ -76,6 +77,11 @@ export class StorageListComponent implements OnInit, AfterViewInit, OnDestroy {
   protected datasource: DataTableDataSource<MessageData> = new DataTableDataSource<MessageData>();
   protected displayedColumns: DataTableColumn<MessageData>[] = [];
   protected messageFields: SearchColumn[] = [];
+  protected sortOptions: { name: string; value: SortDirection }[] = [
+    { name: 'Ascending', value: 'ASC' },
+    { name: 'Descending', value: 'DESC' },
+  ];
+  protected sortDirection: SortDirection = 'DESC';
 
   private Session: SessionService = inject(SessionService);
   private SweetAlert: SweetalertService = inject(SweetalertService);
@@ -215,6 +221,10 @@ export class StorageListComponent implements OnInit, AfterViewInit, OnDestroy {
         displayedColumn.hidden = !column.display;
       }
     }
+  }
+
+  updateSort(): void {
+    this.datasource.options.serverSort = this.sortDirection;
   }
 
   searchUpdated(): void {

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, inject, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { MessageField, MessageStore, Note, StorageService } from '../storage.service';
 import { StorageListDtComponent } from './storage-list-dt/storage-list-dt.component';
 import { SessionService } from 'src/app/services/session.service';
@@ -51,8 +51,6 @@ type MessageData = MessageStore['messages'][number];
   ],
 })
 export class StorageListComponent implements OnInit, AfterViewInit, OnDestroy {
-  @ViewChild('storageListDt') storageListDt!: TemplateRef<StorageListDtComponent>;
-
   protected targetStates: Record<string, { name: string }> = {};
 
   protected truncated = false;
@@ -106,6 +104,7 @@ export class StorageListComponent implements OnInit, AfterViewInit, OnDestroy {
     this.datasource.options = {
       filter: false,
       serverSide: true,
+      serverSort: 'DESC',
     };
 
     this.getDisplayedColumns();


### PR DESCRIPTION
Now by default sorts descending instead of hardcoded ascending order.
Added select input in 'Display and Search Filters' options to switch sort direction