### PR TITLE
Fix time-dependent tests

### DIFF
--- a/commons/src/main/java/org/frankframework/util/TimeProvider.java
+++ b/commons/src/main/java/org/frankframework/util/TimeProvider.java
@@ -1,0 +1,40 @@
+/*
+   Copyright 2025 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.util;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * This class provides a way to get current time, but also control time in unit tests.
+ */
+public class TimeProvider {
+
+	public static Clock clock = Clock.systemUTC();
+
+	private TimeProvider() {
+		// Private constructor to prevent creating instances of static utility classes
+	}
+
+	public static Instant now() {
+		return clock.instant();
+	}
+
+	public static Date nowAsDate() {
+		return Date.from(now());
+	}
+}

--- a/core/src/main/java/org/frankframework/encryption/PkiUtil.java
+++ b/core/src/main/java/org/frankframework/encryption/PkiUtil.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020, 2021 WeAreFrank!
+   Copyright 2020, 2021, 2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.frankframework.encryption;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.security.KeyFactory;
 import java.security.KeyStore;
@@ -52,15 +51,16 @@ import jakarta.annotation.Nonnull;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
+
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.util.ClassLoaderUtils;
 import org.frankframework.util.CredentialFactory;
-import org.frankframework.util.LogUtil;
 import org.frankframework.util.StreamUtil;
+import org.frankframework.util.TimeProvider;
 
+@Log4j2
 public class PkiUtil {
-	private static final Logger log = LogUtil.getLogger(MethodHandles.lookup().lookupClass());
 
 	public static HasTruststore keyStoreAsTrustStore(HasKeystore keystoreOwner) {
 		return new HasTruststore() {
@@ -298,7 +298,7 @@ public class PkiUtil {
 	@Nonnull
 	public static List<String> getExpiringCertificates(KeyStore keystore, TemporalAmount duration) throws EncryptionException {
 		List<String> certificates = new ArrayList<>();
-		Instant dateAfterWhichCertsAreExpired = Instant.now().minus(duration);
+		Instant dateAfterWhichCertsAreExpired = TimeProvider.now().minus(duration);
 		try {
 			for (String certAlias : Collections.list(keystore.aliases())) {
 				Certificate cert = keystore.getCertificate(certAlias);

--- a/core/src/test/java/org/frankframework/encryption/PkiUtilTest.java
+++ b/core/src/test/java/org/frankframework/encryption/PkiUtilTest.java
@@ -6,13 +6,31 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import org.frankframework.util.TimeProvider;
 
 public class PkiUtilTest {
 	private final String MULTI_KEY_KEYSTORE = "Encryption/MultiKeyKeystore.jks";
+
+	@BeforeEach
+	public void setup() {
+		ZonedDateTime testTime = ZonedDateTime.of(2025, 6, 15, 10, 0, 0, 0, ZoneId.systemDefault());
+		TimeProvider.clock = Clock.fixed(testTime.toInstant(), ZoneId.systemDefault());
+	}
+
+	@AfterEach
+	public void tearDown() {
+		TimeProvider.clock = Clock.systemUTC();
+	}
 
 	@Test
 	public void testGetPrivateKeyMultiKeyKeyStoreAlias1() throws EncryptionException {

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestSecurityItems.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestSecurityItems.java
@@ -2,10 +2,14 @@ package org.frankframework.management.bus.endpoints;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -28,6 +32,7 @@ import org.frankframework.testutil.MatchUtils;
 import org.frankframework.testutil.SpringRootInitializer;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.util.SpringUtils;
+import org.frankframework.util.TimeProvider;
 
 @SpringJUnitConfig(initializers = {SpringRootInitializer.class})
 public class TestSecurityItems extends BusTestBase {
@@ -36,6 +41,9 @@ public class TestSecurityItems extends BusTestBase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+		ZonedDateTime testTime = ZonedDateTime.of(2025, 6, 15, 10, 0, 0, 0, ZoneId.systemDefault());
+		TimeProvider.clock = Clock.fixed(testTime.toInstant(), ZoneId.systemDefault());
+
 		JmsRealmFactory.getInstance().clear();
 		JmsRealm jdbcRealm = new JmsRealm();
 		jdbcRealm.setRealmName("dummyJmsRealm1");
@@ -65,6 +73,11 @@ public class TestSecurityItems extends BusTestBase {
 		pipeline.addPipe(pipe);
 		adapter.setPipeLine(pipeline);
 		getConfiguration().addAdapter(adapter);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		TimeProvider.clock = Clock.systemUTC();
 	}
 
 	@Test


### PR DESCRIPTION
There are many more places where `Instant.now()` could be replaced with call to TimeProvider, and same for `Date.now()` which isn't used yet.

For now however this fixes some broken tests.

The name "TimeProvider" was the best I could come up with for now but I'm open to better suggestions!