### PR TITLE
Update frankdoc version to 4.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<micrometer.version>1.15.2</micrometer.version>
 		<argLine/> <!-- add empty default argLine so Surefire won't fail when JaCoCo isn't present -->
 		<!-- property [iaf.rootdir] is available to get the root of the project, because of the [directory-maven-plugin] -->
-		<frankdoc.version>4.0-SNAPSHOT</frankdoc.version>
+		<frankdoc.version>4.1-SNAPSHOT</frankdoc.version>
 		<javadoc-plugin.version>3.11.2</javadoc-plugin.version>
 
 		<!-- DB Driver Versions -->


### PR DESCRIPTION
Bump frankdoc.version from 4.0-SNAPSHOT to 4.1-SNAPSHOT in pom.xml
to use the latest snapshot version.

This will generate the new `frankdoc.json` and frontend.