### PR TITLE
Console use Signals for state management

### DIFF
--- a/console/frontend/src/main/frontend/.eslintrc.js
+++ b/console/frontend/src/main/frontend/.eslintrc.js
@@ -26,7 +26,12 @@ module.exports = {
         'unicorn/prefer-ternary': 'warn',
         'unicorn/no-null': 'off',
         'unicorn/prefer-dom-node-text-content': 'warn',
-        'unicorn/consistent-function-scoping': 'off',
+        'unicorn/consistent-function-scoping': [
+          'error',
+          {
+            checkArrowFunctions: 'false',
+          },
+        ],
       },
     },
     {

--- a/console/frontend/src/main/frontend/.eslintrc.js
+++ b/console/frontend/src/main/frontend/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
         'unicorn/prefer-ternary': 'warn',
         'unicorn/no-null': 'off',
         'unicorn/prefer-dom-node-text-content': 'warn',
+        'unicorn/consistent-function-scoping': 'off',
       },
     },
     {

--- a/console/frontend/src/main/frontend/src/app/app.component.html
+++ b/console/frontend/src/main/frontend/src/app/app.component.html
@@ -16,10 +16,10 @@
         [userName]="userName"
       ></app-pages-topnavbar>
       <app-pages-topinfobar class="topinfobar"></app-pages-topinfobar>
-      @if (startupError) {
+      @if (startupError()) {
         <div class="m-sm alert alert-danger pointer" role="alert" type="danger" routerLink="/error">
           <h4>Startup error:</h4>
-          <span [innerHtml]="startupError"></span>
+          <span [innerHtml]="startupError()"></span>
         </div>
       }
       <!-- Main view  -->

--- a/console/frontend/src/main/frontend/src/app/app.component.ts
+++ b/console/frontend/src/main/frontend/src/app/app.component.ts
@@ -307,7 +307,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
     this.appService.getEnvironmentVariables().subscribe((data) => {
       if (data['Application Constants']) {
-        const appConstants = Object.assign(this.appService.appConstants(), data['Application Constants']['Global']); //make FF!Application Constants default
+        const appConstants = { ...this.appService.appConstants(), ...data['Application Constants']['Global'] }; //make FF!Application Constants default
 
         const idleTime =
           Number.parseInt(appConstants['console.idle.time'] as string) > 0

--- a/console/frontend/src/main/frontend/src/app/app.component.ts
+++ b/console/frontend/src/main/frontend/src/app/app.component.ts
@@ -3,8 +3,6 @@ import { Idle } from '@ng-idle/core';
 import { filter, first, Subscription } from 'rxjs';
 import {
   Adapter,
-  AdapterMessage,
-  AppConstants,
   AppInitState,
   appInitState,
   AppService,
@@ -67,7 +65,6 @@ export class AppComponent implements OnInit, OnDestroy {
   protected loading = true;
   protected dtapStage = '';
   protected dtapSide = '';
-  protected startupError: Signal<string | null> = this.appService.startupError;
   protected userName?: string;
   protected routeData: Data = {};
   protected routeQueryParams: ParamMap = convertToParamMap({});
@@ -98,12 +95,13 @@ export class AppComponent implements OnInit, OnDestroy {
   private debugService: DebugService = inject(DebugService);
   private sweetAlertService: SweetalertService = inject(SweetalertService);
   private toastService: ToastService = inject(ToastService);
-  private appService: AppService = inject(AppService);
   private idle: Idle = inject(Idle);
   private modalService: NgbModal = inject(NgbModal);
   private serverInfoService: ServerInfoService = inject(ServerInfoService);
   private websocketService: WebsocketService = inject(WebsocketService);
   private serverTimeService: ServerTimeService = inject(ServerTimeService);
+  private appService: AppService = inject(AppService);
+  protected startupError: Signal<string | null> = this.appService.startupError;
 
   constructor() {
     Pace.start({
@@ -389,10 +387,10 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   initializeWarnings(): void {
-    const startupErrorSubscription = this.appService.startupError$.subscribe(() => {
+    /*const startupErrorSubscription = this.appService.startupError$.subscribe(() => {
       this.startupError = this.appService.startupError();
     });
-    this._subscriptionsReloadable.add(startupErrorSubscription);
+    this._subscriptionsReloadable.add(startupErrorSubscription);*/
 
     this.http
       .get<Record<string, MessageLog>>(`${this.appService.absoluteApiPath}server/warnings`)

--- a/console/frontend/src/main/frontend/src/app/components/conditional-on-property.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/conditional-on-property.directive.ts
@@ -1,23 +1,30 @@
-import { Directive, ElementRef, inject, Input, OnInit } from '@angular/core';
+import { Directive, ElementRef, inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { AppService } from '../app.service';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
 
 @Directive({
   selector: '[appConditionalOnProperty]',
 })
-export class ConditionalOnPropertyDirective implements OnInit {
+export class ConditionalOnPropertyDirective implements OnInit, OnDestroy {
   @Input({ required: true }) appConditionalOnProperty!: string;
   @Input() onFalseConditionClassName: string = 'disabled';
 
   private readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly appService: AppService = inject(AppService);
+  private subscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.appService.appConstants$.subscribe(() => this.checkCondition());
+    this.subscription = toObservable(this.appService.appConstants).subscribe(() => this.checkCondition());
     this.checkCondition();
   }
 
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
   checkCondition(): void {
-    if (this.appService.APP_CONSTANTS[this.appConditionalOnProperty] === 'true') {
+    if (this.appService.appConstants()[this.appConditionalOnProperty] === 'true') {
       this.elementRef.nativeElement.classList.remove(this.onFalseConditionClassName);
       this.elementRef.nativeElement.style.removeProperty('pointer-events');
       return;

--- a/console/frontend/src/main/frontend/src/app/components/conditional-on-property.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/conditional-on-property.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, inject, Input, OnDestroy, OnInit } from '@angular/core';
-import { AppService } from '../app.service';
+import { AppConstants, AppService } from '../app.service';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Subscription } from 'rxjs';
 
@@ -12,19 +12,19 @@ export class ConditionalOnPropertyDirective implements OnInit, OnDestroy {
 
   private readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
   private readonly appService: AppService = inject(AppService);
+  private appConstants$ = toObservable(this.appService.appConstants);
   private subscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.subscription = toObservable(this.appService.appConstants).subscribe(() => this.checkCondition());
-    this.checkCondition();
+    this.subscription = this.appConstants$.subscribe((appConstants) => this.checkCondition(appConstants));
   }
 
   ngOnDestroy(): void {
     this.subscription?.unsubscribe();
   }
 
-  checkCondition(): void {
-    if (this.appService.appConstants()[this.appConditionalOnProperty] === 'true') {
+  checkCondition(appConstants: AppConstants): void {
+    if (appConstants[this.appConditionalOnProperty] === 'true') {
       this.elementRef.nativeElement.classList.remove(this.onFalseConditionClassName);
       this.elementRef.nativeElement.style.removeProperty('pointer-events');
       return;

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -19,10 +19,11 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
   }[] = [];
 
   private appService: AppService = inject(AppService);
+  private appConstants$ = toObservable(this.appService.appConstants);
   private subscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.subscription = toObservable(this.appService.appConstants).subscribe(() => this.updateCustomViews());
+    this.subscription = this.appConstants$.subscribe(() => this.updateCustomViews());
     this.updateCustomViews();
   }
 

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AppConstants, AppService } from 'src/app/app.service';
 import { RouterModule } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-custom-views',
@@ -17,30 +18,29 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
     url: string;
   }[] = [];
 
-  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
-  private _subscriptions = new Subscription();
-
-  constructor(private appService: AppService) {}
+  private appService: AppService = inject(AppService);
+  private subscription: Subscription | null = null;
 
   ngOnInit(): void {
-    const appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.appConstants = this.appService.APP_CONSTANTS;
-      this.updateCustomViews();
-    });
-    this._subscriptions.add(appConstantsSubscription);
+    this.subscription = toObservable(this.appService.appConstants).subscribe(() => this.updateCustomViews());
     this.updateCustomViews();
   }
 
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
   updateCustomViews(): void {
-    const customViews = this.appConstants['customViews.names'] as string;
+    const appConstants: AppConstants = this.appService.appConstants();
+    const customViews = appConstants['customViews.names'] as string | undefined;
     if (typeof customViews !== 'string') return;
 
     if (customViews.length > 0) {
       const views = customViews.split(',');
       for (const index in views) {
         const viewId = views[index];
-        const name = this.appConstants[`customViews.${viewId}.name`] as string;
-        const url = this.appConstants[`customViews.${viewId}.url`] as string;
+        const name = appConstants[`customViews.${viewId}.name`] as string;
+        const url = appConstants[`customViews.${viewId}.url`] as string;
         if (name && url)
           this.customViews.push({
             view: viewId,
@@ -49,9 +49,5 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
           });
       }
     }
-  }
-
-  ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/file-viewer/file-viewer.component.ts
@@ -6,7 +6,7 @@ import {
   HttpEventType,
   HttpResponse,
 } from '@angular/common/http';
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, inject, Input, OnInit } from '@angular/core';
 import { debounceTime, filter } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 import { MiscService } from 'src/app/services/misc.service';
@@ -27,11 +27,9 @@ export class FileViewerComponent implements OnInit {
   protected loading = true;
   protected error = false;
 
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-    private miscService: MiscService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
+  private readonly miscService: MiscService = inject(MiscService);
 
   ngOnInit(): void {
     const requestOptions = {

--- a/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.html
@@ -29,9 +29,9 @@
         Up since:
         <strong><span appToDate [time]="uptime"></span></strong> (<span appTimeSince [time]="uptime"></span>), timezone:
         <strong>{{ serverTimeService.timezone }}</strong>
-        @if (consoleVersion !== framework.version) {
+        @if (consoleVersion() !== framework.version) {
           <br />
-          Console version: <strong>{{ consoleVersion }}</strong>
+          Console version: <strong>{{ consoleVersion() }}</strong>
         }
       </p>
     } @else {

--- a/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
@@ -50,7 +50,6 @@ export class InformationModalComponent implements OnInit, OnDestroy {
     totalSpace: -1,
   };
   protected uptime: number = 0;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected consoleVersion = computed(() => this.serverInfoService.consoleInfo().version ?? 'null');
 
   private activeModal: NgbActiveModal = inject(NgbActiveModal);

--- a/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { copyToClipboard } from '../../../utils';
 import { ToastService } from '../../../services/toast.service';
@@ -9,6 +9,7 @@ import { HumanFileSizePipe } from '../../../pipes/human-file-size.pipe';
 import { ServerInfoService } from '../../../services/server-info.service';
 import { Subscription } from 'rxjs';
 import { ServerTimeService } from '../../../services/server-time.service';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-information-modal',
@@ -49,7 +50,8 @@ export class InformationModalComponent implements OnInit, OnDestroy {
     totalSpace: -1,
   };
   protected uptime: number = 0;
-  protected consoleVersion = 'null';
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected consoleVersion = computed(() => this.serverInfoService.consoleInfo().version ?? 'null');
 
   private activeModal: NgbActiveModal = inject(NgbActiveModal);
   private toastService: ToastService = inject(ToastService);
@@ -66,8 +68,10 @@ export class InformationModalComponent implements OnInit, OnDestroy {
   }
 
   subscribeToServerInfo(): void {
-    this.subscriptions = this.serverInfoService.serverInfo$.subscribe({
+    this.subscriptions = toObservable(this.serverInfoService.serverInfo).subscribe({
       next: (data) => {
+        if (data === null) return;
+
         this.applicationServer = data.applicationServer;
         this.fileSystem = data.fileSystem;
         this.framework = data.framework;
@@ -79,13 +83,6 @@ export class InformationModalComponent implements OnInit, OnDestroy {
         this.initialized = true;
       },
     });
-    this.subscriptions.add(
-      this.serverInfoService.consoleVersion$.subscribe({
-        next: (data) => {
-          this.consoleVersion = data.version ?? 'null';
-        },
-      }),
-    );
   }
 
   close(): void {

--- a/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/information-modal/information-modal.component.ts
@@ -56,6 +56,7 @@ export class InformationModalComponent implements OnInit, OnDestroy {
   private activeModal: NgbActiveModal = inject(NgbActiveModal);
   private toastService: ToastService = inject(ToastService);
   private serverInfoService: ServerInfoService = inject(ServerInfoService);
+  private serverInfo$ = toObservable(this.serverInfoService.serverInfo);
   private subscriptions?: Subscription;
 
   ngOnInit(): void {
@@ -68,7 +69,7 @@ export class InformationModalComponent implements OnInit, OnDestroy {
   }
 
   subscribeToServerInfo(): void {
-    this.subscriptions = toObservable(this.serverInfoService.serverInfo).subscribe({
+    this.subscriptions = this.serverInfo$.subscribe({
       next: (data) => {
         if (data === null) return;
 

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.html
@@ -1,6 +1,6 @@
 <div class="footer">
   <div>
-    <strong>FF!</strong>&nbsp;<strong>Console</strong> {{ consoleVersion }} | powered by:
+    <strong>FF!</strong>&nbsp;<strong>Console</strong> {{ consoleVersion() }} | powered by:
     <a href="//frankframework.org" target="_blank"> <i class="fa fa-globe"></i> frankframework.org </a>
     |
     <a href="//github.com/frankframework/frankframework" target="_blank">

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.ts
@@ -6,7 +6,6 @@ import { ServerInfoService } from '../../../services/server-info.service';
   templateUrl: './pages-footer.component.html',
 })
 export class PagesFooterComponent {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected consoleVersion = computed(() => this.serverInfoService.consoleInfo().version ?? '');
 
   private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-footer/pages-footer.component.ts
@@ -1,28 +1,13 @@
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { ServerInfoService } from '../../../services/server-info.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-pages-footer',
   templateUrl: './pages-footer.component.html',
 })
-export class PagesFooterComponent implements OnInit, OnDestroy {
-  protected consoleVersion = '';
+export class PagesFooterComponent {
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected consoleVersion = computed(() => this.serverInfoService.consoleInfo().version ?? '');
 
   private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);
-  private subscriptions: Subscription = new Subscription();
-
-  ngOnInit(): void {
-    this.subscriptions.add(
-      this.serverInfoService.consoleVersion$.subscribe({
-        next: (data) => {
-          this.consoleVersion = data.version ?? 'null';
-        },
-      }),
-    );
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
 }

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.html
@@ -101,7 +101,7 @@
             <li data-cy-nav="testingLarva" routerLinkActive="active" appConditionalOnProperty="larva.enabled">
               <a routerLink="/testing/larva">Larva</a>
             </li>
-            @if (showOldLadybug) {
+            @if (showOldLadybug()) {
               <li data-cy-nav="testingLadybugLegacy" routerLinkActive="active">
                 <a routerLink="/testing/ladybug-legacy">Ladybug (legacy)</a>
               </li>

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.html
@@ -260,7 +260,7 @@
             target="_blank"
             title="Report a Bug"
             href="https://github.com/frankframework/frankframework/issues/new?template=1-bug.yml&environment={{
-              encodedServerInfo
+              encodedServerInfo()
             }}"
           >
             <i class="fa fa-flag"></i>

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   Input,
   OnChanges,
-  OnInit,
   Output,
   Signal,
 } from '@angular/core';
@@ -43,7 +42,7 @@ type ExpandedItem = {
     ConditionalOnPropertyDirective,
   ],
 })
-export class PagesNavigationComponent implements OnChanges, OnInit, AfterViewInit {
+export class PagesNavigationComponent implements OnChanges, AfterViewInit {
   @Input() queryParams = convertToParamMap({});
   @Output() shouldOpenInfo = new EventEmitter<void>();
 
@@ -53,7 +52,11 @@ export class PagesNavigationComponent implements OnChanges, OnInit, AfterViewIni
     // eslint-disable-next-line unicorn/consistent-function-scoping
     () => this.appService.appConstants()['testtool.echo2.enabled'] === 'true',
   );
-  protected encodedServerInfo: string = '';
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected encodedServerInfo: Signal<string> = computed(() => {
+    if (!this.serverInfoService.serverInfo()) return '';
+    return encodeURIComponent(this.serverInfoService.getMarkdownFormatedServerInfo());
+  });
 
   private readonly router: Router = inject(Router);
   private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);
@@ -62,13 +65,6 @@ export class PagesNavigationComponent implements OnChanges, OnInit, AfterViewIni
   private readonly ANIMATION_SPEED = 250;
   private expandedItem: ExpandedItem | null = null;
   private initializing: boolean = true;
-
-  ngOnInit(): void {
-    this.updateServerInfo();
-    this.serverInfoService.serverInfo$.subscribe(() => {
-      this.updateServerInfo();
-    });
-  }
 
   ngOnChanges(): void {
     const uwuEnabledString = localStorage.getItem('uwu') ? 'uwu-' : '';
@@ -100,10 +96,6 @@ export class PagesNavigationComponent implements OnChanges, OnInit, AfterViewIni
       this.expandedItem = templateInfo;
     }
     return expanded;
-  }
-
-  getConfigurationsQueryParam(): string | null {
-    return this.queryParams.get('configuration');
   }
 
   collapseItem(element: HTMLElement, accordionItem: CdkAccordionItem): void {
@@ -145,9 +137,5 @@ export class PagesNavigationComponent implements OnChanges, OnInit, AfterViewIni
       this.collapseItem(this.expandedItem.element, this.expandedItem.accordionItem);
       this.expandedItem = null;
     }
-  }
-
-  private updateServerInfo(): void {
-    this.encodedServerInfo = encodeURIComponent(this.serverInfoService.getMarkdownFormatedServerInfo());
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.ts
@@ -49,10 +49,8 @@ export class PagesNavigationComponent implements OnChanges, AfterViewInit {
   protected frankframeworkLogoPath: string = 'assets/images/ff-kawaii.svg';
   protected frankExclamationPath: string = 'assets/images/frank-exclemation.svg';
   protected showOldLadybug: Signal<boolean> = computed(
-    // eslint-disable-next-line unicorn/consistent-function-scoping
     () => this.appService.appConstants()['testtool.echo2.enabled'] === 'true',
   );
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected encodedServerInfo: Signal<string> = computed(() => {
     if (!this.serverInfoService.serverInfo()) return '';
     return encodeURIComponent(this.serverInfoService.getMarkdownFormatedServerInfo());

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/sidebar.directive.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/sidebar.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, AfterViewInit, OnDestroy, inject } from '@angular/core';
 import { AppService } from '../../../app.service';
 import { Subscription } from 'rxjs';
 
@@ -7,14 +7,11 @@ import { Subscription } from 'rxjs';
   standalone: true,
 })
 export class SidebarDirective implements AfterViewInit, OnDestroy {
-  private bodyElement = document.querySelector<HTMLElement>('body')!;
+  private readonly appService: AppService = inject(AppService);
+  private readonly sideMenuElementReference: ElementRef<HTMLElement> = inject(ElementRef);
   private sideMenuElement = this.sideMenuElementReference.nativeElement;
+  private bodyElement = document.querySelector<HTMLElement>('body')!;
   private subscription = new Subscription();
-
-  constructor(
-    private sideMenuElementReference: ElementRef<HTMLElement>,
-    private appService: AppService,
-  ) {}
 
   ngAfterViewInit(): void {
     const sidebarSubscription = this.appService.toggleSidebar$.subscribe(() => {

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.html
@@ -15,7 +15,7 @@
     </ol>
   </div>
   <div class="col-sm-4">
-    @if (loading) {
+    @if (loading()) {
       <div class="sk-spinner sk-spinner-wave pull-right text-right loading-indicator">
         <div class="sk-rect1"></div>
         <div class="sk-rect2"></div>

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.html
@@ -4,7 +4,7 @@
       <li class="active">
         <strong>{{ breadcrumbs }}</strong>
       </li>
-      @if (popoutUrl) {
+      @if (popoutUrl()) {
         <li>
           <button (click)="navigateToUrl()" class="btn btn-xs pull-right">
             <i class="fa fa-arrow-circle-right"></i>

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject, Signal } from '@angular/core';
 import { ActivatedRoute, ActivationEnd, NavigationEnd, Router } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AppService } from 'src/app/app.service';
@@ -10,39 +10,36 @@ import { AppService } from 'src/app/app.service';
   imports: [],
 })
 export class PagesTopinfobarComponent implements OnInit, OnDestroy {
-  loading: boolean = true;
-  breadcrumbs: string = 'Loading';
-  popoutUrl: string | null = null;
+  protected breadcrumbs: string = 'Loading';
 
-  private _subscriptions = new Subscription();
-
-  constructor(
-    private router: Router,
-    private route: ActivatedRoute,
-    private appService: AppService,
-  ) {}
+  private _subscriptions: Subscription = new Subscription();
+  private readonly router: Router = inject(Router);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly appService: AppService = inject(AppService);
+  protected loading: Signal<boolean> = this.appService.loading;
+  protected popoutUrl: Signal<string | null> = this.appService.iframePopoutUrl;
 
   ngOnInit(): void {
-    this.router.events.pipe(filter((event) => event instanceof ActivationEnd)).subscribe(() => {
-      this.popoutUrl = null;
-    });
-    this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
-      const childRoute = this.route.children.pop()!;
-      if (!childRoute.snapshot.data['breadcrumbIsCustom']) {
-        this.breadcrumbs = childRoute.snapshot.data['breadcrumbs'] ?? 'Error';
-      }
-    });
-
-    const loadingSubscription = this.appService.loading$.subscribe((loading) => (this.loading = loading));
-    this._subscriptions.add(loadingSubscription);
-
+    const navigationActivationSubscription = this.router.events
+      .pipe(filter((event) => event instanceof ActivationEnd))
+      .subscribe(() => {
+        this.appService.iframePopoutUrl.set(null);
+      });
+    const navigationEndSubscription = this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const childRoute = this.route.children.pop()!;
+        if (!childRoute.snapshot.data['breadcrumbIsCustom']) {
+          this.breadcrumbs = childRoute.snapshot.data['breadcrumbs'] ?? 'Error';
+        }
+      });
     const customBreadcrumbsSubscription = this.appService.customBreadcrumbs$.subscribe(
       (breadcrumbs) => (this.breadcrumbs = breadcrumbs),
     );
-    this._subscriptions.add(customBreadcrumbsSubscription);
 
-    const iframePopoutUrlSubscription = this.appService.iframePopoutUrl$.subscribe((url) => (this.popoutUrl = url));
-    this._subscriptions.add(iframePopoutUrlSubscription);
+    this._subscriptions.add(navigationActivationSubscription);
+    this._subscriptions.add(navigationEndSubscription);
+    this._subscriptions.add(customBreadcrumbsSubscription);
   }
 
   ngOnDestroy(): void {
@@ -50,6 +47,7 @@ export class PagesTopinfobarComponent implements OnInit, OnDestroy {
   }
 
   navigateToUrl(): void {
-    if (this.popoutUrl) window.open(this.popoutUrl, '_blank');
+    const popoutUrl = this.popoutUrl();
+    if (popoutUrl) window.open(popoutUrl, '_blank');
   }
 }

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topinfobar/pages-topinfobar.component.ts
@@ -36,7 +36,7 @@ export class PagesTopinfobarComponent implements OnInit, OnDestroy {
     const loadingSubscription = this.appService.loading$.subscribe((loading) => (this.loading = loading));
     this._subscriptions.add(loadingSubscription);
 
-    const customBreadcrumbsSubscription = this.appService.customBreadscrumb$.subscribe(
+    const customBreadcrumbsSubscription = this.appService.customBreadcrumbs$.subscribe(
       (breadcrumbs) => (this.breadcrumbs = breadcrumbs),
     );
     this._subscriptions.add(customBreadcrumbsSubscription);

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/hamburger.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/hamburger.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { AppService } from '../../../app.service';
 
 @Component({
@@ -7,7 +7,7 @@ import { AppService } from '../../../app.service';
   standalone: true,
 })
 export class HamburgerComponent {
-  constructor(private appService: AppService) {}
+  private readonly appService: AppService = inject(AppService);
 
   toggle(): void {
     this.appService.toggleSidebar();

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
@@ -32,12 +32,13 @@
       <li ngbDropdown (click)="resetNotificationCount()">
         <a class="count-info" ngbDropdownToggle>
           <i class="fa fa-bell"></i>
-          @if (notificationCount > 0) {
-            <span class="label label-primary">{{ notificationCount > 5 ? '5+' : notificationCount }}</span>
+          @let count = notificationCount();
+          @if (count > 0) {
+            <span class="label label-primary">{{ count > 5 ? '5+' : count }}</span>
           }
         </a>
         <ul class="dropdown-alerts" ngbDropdownMenu>
-          @for (message of notificationList; track message.id; let last = $last) {
+          @for (message of notificationList(); track message.id; let last = $last) {
             <li ngbDropdownItem>
               <a routerLink="/notifications" [queryParams]="{ id: message.id }">
                 <div>
@@ -50,30 +51,13 @@
             @if (!last) {
               <li class="divider"></li>
             }
-          }
-          @if (notificationList.length <= 0) {
+          } @empty {
             <li class="text-center">No notifications</li>
           }
         </ul>
       </li>
       @if (clusterMembers.length > 0) {
         <li>
-          <!-- <span>
-              <select
-                class="cluster-member-selector"
-                name="selectedClusterMember"
-                [(ngModel)]="selectedClusterMember"
-                (ngModelChange)="selectClusterMember()">
-                <option
-                  *ngFor="let member of clusterMembers"
-                  [ngValue]="member"
-                  title="{{ member.name }}&#013;{{ member.id }}"
-                  >
-                  {{ member.address }}
-                </option>
-              </select>
-              <i class="fa fa-chevron-down" aria-hidden="true"></i>
-            </span> -->
           <select
             class="cluster-member-selector"
             name="selectedClusterMember"

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
@@ -23,14 +23,12 @@ export class PagesTopnavbarComponent implements OnChanges {
   @Input() userName?: string;
 
   protected readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected notificationList: Signal<Notification[]> = computed(() => this.Notification.getLatest(5));
   protected loggedIn: boolean = false;
 
   private readonly appService: AppService = inject(AppService);
   private readonly authService: AuthService = inject(AuthService);
   private readonly Notification: NotificationService = inject(NotificationService);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected notificationCount: Signal<number> = this.Notification.count;
 
   ngOnChanges(): void {

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
@@ -1,5 +1,4 @@
-import { Component, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component, computed, inject, Input, OnChanges, Signal } from '@angular/core';
 import { NotificationService, Notification } from 'src/app/services/notification.service';
 import { HamburgerComponent } from './hamburger.component';
 import { TimeSinceDirective } from '../../time-since.directive';
@@ -16,7 +15,7 @@ import { ServerTimeService } from '../../../services/server-time.service';
   styleUrls: ['./pages-topnavbar.component.scss'],
   imports: [FormsModule, HamburgerComponent, RouterModule, TimeSinceDirective, NgbDropdownModule],
 })
-export class PagesTopnavbarComponent implements OnInit, OnChanges, OnDestroy {
+export class PagesTopnavbarComponent implements OnChanges {
   @Input() dtapSide: string = '';
   @Input() dtapStage: string = '';
   @Input() clusterMembers: ClusterMember[] = [];
@@ -24,28 +23,18 @@ export class PagesTopnavbarComponent implements OnInit, OnChanges, OnDestroy {
   @Input() userName?: string;
 
   protected readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
-  protected notificationCount: number = 0;
-  protected notificationList: Notification[] = [];
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected notificationList: Signal<Notification[]> = computed(() => this.Notification.getLatest(5));
   protected loggedIn: boolean = false;
 
   private readonly appService: AppService = inject(AppService);
   private readonly authService: AuthService = inject(AuthService);
   private readonly Notification: NotificationService = inject(NotificationService);
-  private notificationCountSubscription: Subscription | null = null;
-
-  ngOnInit(): void {
-    this.notificationCountSubscription = this.Notification.onCountUpdate$.subscribe(() => {
-      this.notificationCount = this.Notification.getCount();
-      this.notificationList = this.Notification.getLatest(5);
-    });
-  }
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected notificationCount: Signal<number> = this.Notification.count;
 
   ngOnChanges(): void {
     this.loggedIn = this.authService.isLoggedIn();
-  }
-
-  ngOnDestroy(): void {
-    this.notificationCountSubscription?.unsubscribe();
   }
 
   resetNotificationCount(): void {

--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { NotificationService } from 'src/app/services/notification.service';
+import { NotificationService, Notification } from 'src/app/services/notification.service';
 import { HamburgerComponent } from './hamburger.component';
 import { TimeSinceDirective } from '../../time-since.directive';
 import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
@@ -23,23 +23,21 @@ export class PagesTopnavbarComponent implements OnInit, OnChanges, OnDestroy {
   @Input() selectedClusterMember: ClusterMember | null = null;
   @Input() userName?: string;
 
-  private Notification: NotificationService = inject(NotificationService);
-
-  protected serverTimeService: ServerTimeService = inject(ServerTimeService);
-  protected notificationCount: number = this.Notification.getCount();
-  protected notificationList: NotificationService['list'] = [];
+  protected readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
+  protected notificationCount: number = 0;
+  protected notificationList: Notification[] = [];
   protected loggedIn: boolean = false;
 
-  private appService: AppService = inject(AppService);
-  private authService: AuthService = inject(AuthService);
-  private _subscriptions = new Subscription();
+  private readonly appService: AppService = inject(AppService);
+  private readonly authService: AuthService = inject(AuthService);
+  private readonly Notification: NotificationService = inject(NotificationService);
+  private notificationCountSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    const notifCountSub = this.Notification.onCountUpdate$.subscribe(() => {
+    this.notificationCountSubscription = this.Notification.onCountUpdate$.subscribe(() => {
       this.notificationCount = this.Notification.getCount();
       this.notificationList = this.Notification.getLatest(5);
     });
-    this._subscriptions.add(notifCountSub);
   }
 
   ngOnChanges(): void {
@@ -47,7 +45,7 @@ export class PagesTopnavbarComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
+    this.notificationCountSubscription?.unsubscribe();
   }
 
   resetNotificationCount(): void {

--- a/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
@@ -20,7 +20,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
   private readonly router: Router = inject(Router);
   private readonly appService: AppService = inject(AppService);
-  private readonly subscriptions: Subscription = new Subscription();
+  private adaptersSubscription: Subscription | null = null;
   private configurationsList: string[] = [];
 
   @Input({ required: true })
@@ -31,10 +31,9 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   }
 
   ngOnInit(): void {
-    const adaptersSubscription = toObservable(this.appService.adapters).subscribe((adapters) =>
+    this.adaptersSubscription = toObservable(this.appService.adapters).subscribe((adapters) =>
       this.processTabList(adapters),
     );
-    this.subscriptions.add(adaptersSubscription);
 
     this.route.queryParamMap.subscribe((parameters) => {
       const tab = parameters.get(this.queryParamName);
@@ -59,7 +58,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
+    this.adaptersSubscription?.unsubscribe();
   }
 
   protected override changeTab(tab: string): void {

--- a/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
@@ -20,6 +20,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
   private readonly router: Router = inject(Router);
   private readonly appService: AppService = inject(AppService);
+  private adapters$ = toObservable(this.appService.adapters);
   private adaptersSubscription: Subscription | null = null;
   private configurationsList: string[] = [];
 
@@ -31,9 +32,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   }
 
   ngOnInit(): void {
-    this.adaptersSubscription = toObservable(this.appService.adapters).subscribe((adapters) =>
-      this.processTabList(adapters),
-    );
+    this.adaptersSubscription = this.adapters$.subscribe((adapters) => this.processTabList(adapters));
 
     this.route.queryParamMap.subscribe((parameters) => {
       const tab = parameters.get(this.queryParamName);

--- a/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/tab-list/configuration-tab-list.component.ts
@@ -1,9 +1,10 @@
 import { Component, inject, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { TabListComponent } from './tab-list.component';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AppService, Configuration } from '../../app.service';
+import { Adapter, AppService, Configuration } from '../../app.service';
 import { NgClass } from '@angular/common';
-import { first, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-configuration-tab-list',
@@ -30,9 +31,9 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   }
 
   ngOnInit(): void {
-    const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.processTabList();
-    });
+    const adaptersSubscription = toObservable(this.appService.adapters).subscribe((adapters) =>
+      this.processTabList(adapters),
+    );
     this.subscriptions.add(adaptersSubscription);
 
     this.route.queryParamMap.subscribe((parameters) => {
@@ -41,20 +42,20 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
         return;
       } else if (tab) {
         this.setSelectedTab(tab);
-        this.appService.updateSelectedConfigurationTab(tab);
+        this.appService.selectedConfigurationTab.set(tab);
       } else if (this.showAllTab) {
         this.setSelectedTab(this._allTabName);
       } else if (this.tabsList.length > 0) {
         this.setSelectedTab(this.tabsList[0]);
       }
     });
-    this.appService.selectedConfigurationTab$.pipe(first()).subscribe((tab) => {
-      if (tab !== null) this.changeTab(tab);
-    });
+
+    const tab = this.appService.selectedConfigurationTab();
+    if (tab !== null) this.changeTab(tab);
   }
 
   ngOnChanges(): void {
-    this.processTabList();
+    this.processTabList(this.appService.adapters());
   }
 
   ngOnDestroy(): void {
@@ -62,7 +63,7 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
   }
 
   protected override changeTab(tab: string): void {
-    this.appService.updateSelectedConfigurationTab(tab);
+    this.appService.selectedConfigurationTab.set(tab);
     const queryParameters = tab === this._allTabName ? { [this.queryParamName]: null } : { [this.queryParamName]: tab };
     this.router.navigate([], {
       relativeTo: this.route,
@@ -77,12 +78,23 @@ export class ConfigurationTabListComponent extends TabListComponent implements O
     this.selectedTabChange.emit(tab);
   }
 
-  private processTabList(): void {
+  private processTabList(adapters: Record<string, Adapter>): void {
     if (!this.showAll) {
+      const configurationLengths = this.calculateConfigurationLengths(adapters);
       this.tabs = this.configurationsList.filter((configuration) => {
         if (configuration === 'IAF_Util' && this.filterIAF_Util) return false;
-        return this.appService.configurationLengths[configuration] > 0;
+        return configurationLengths[configuration] > 0;
       });
     }
+  }
+
+  private calculateConfigurationLengths(adapters: Record<string, Adapter>): Record<string, number> {
+    const configurationLengths: Record<string, number> = {};
+    for (const adapter of Object.values(adapters)) {
+      const configuration = adapter.configuration;
+      configurationLengths[configuration] ??= 0;
+      configurationLengths[configuration]++;
+    }
+    return configurationLengths;
   }
 }

--- a/console/frontend/src/main/frontend/src/app/guards/conditional-on-property.guard.ts
+++ b/console/frontend/src/main/frontend/src/app/guards/conditional-on-property.guard.ts
@@ -4,7 +4,6 @@ import { AppService } from '../app.service';
 
 export const conditionalOnPropertyGuard: CanActivateFn = (route) => {
   const appService = inject(AppService);
-  const appConstants = appService.APP_CONSTANTS;
   const propertyName: string = route.routeConfig?.data?.['onProperty'];
-  return appConstants[propertyName] === 'true';
+  return appService.appConstants()[propertyName] === 'true';
 };

--- a/console/frontend/src/main/frontend/src/app/http-interceptors/auth-interceptor.ts
+++ b/console/frontend/src/main/frontend/src/app/http-interceptors/auth-interceptor.ts
@@ -1,15 +1,11 @@
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AuthService } from '../services/auth.service';
 import { Injectable } from '@angular/core';
-import { AppService } from '../app.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  constructor(
-    private authService: AuthService,
-    private appService: AppService,
-  ) {}
+  // private authService: AuthService = inject(AuthService);
+  // private appService: AppService = inject(AppService);
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     /* const authToken = this.authService.getAuthToken();

--- a/console/frontend/src/main/frontend/src/app/http-interceptors/auth-interceptor.ts
+++ b/console/frontend/src/main/frontend/src/app/http-interceptors/auth-interceptor.ts
@@ -4,9 +4,6 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  // private authService: AuthService = inject(AuthService);
-  // private appService: AppService = inject(AppService);
-
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     /* const authToken = this.authService.getAuthToken();
 

--- a/console/frontend/src/main/frontend/src/app/http-interceptors/connection-interceptor.ts
+++ b/console/frontend/src/main/frontend/src/app/http-interceptors/connection-interceptor.ts
@@ -7,11 +7,10 @@ import { ToastService } from '../services/toast.service';
 
 @Injectable()
 export class ConnectionInterceptor implements HttpInterceptor {
+  private readonly router: Router = inject(Router);
+  private readonly appService: AppService = inject(AppService);
+  private readonly toastsService: ToastService = inject(ToastService);
   private errorCount = 0;
-
-  private router: Router = inject(Router);
-  private appService: AppService = inject(AppService);
-  private toastsService: ToastService = inject(ToastService);
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
@@ -20,39 +19,7 @@ export class ConnectionInterceptor implements HttpInterceptor {
           if (error.url && !error.url.includes(this.appService.absoluteApiPath)) return;
           switch (error.status) {
             case 0: {
-              if (error.url) {
-                fetch(error.url, { redirect: 'manual' }).then((res) => {
-                  if (res.type === 'opaqueredirect') {
-                    // if the request ended in a redirect that failed, then login
-                    const login_url = `${this.appService.getServerPath()}iaf/`;
-                    this.router.navigate([login_url]);
-                  }
-                });
-              }
-
-              if (this.appService.APP_CONSTANTS['init'] == 1) {
-                if (error.headers.get('Authorization') == undefined) {
-                  this.toastsService.error('Failed to connect to backend!');
-                } else {
-                  console.warn('Authorization error');
-                }
-              } else if (this.appService.APP_CONSTANTS['init'] == 2 /*  && rejection.config.poller */) {
-                console.warn('Connection to the server was lost!');
-                this.errorCount++;
-                if (this.errorCount > 2) {
-                  this.toastsService.error(
-                    'Server Error',
-                    'Connection to the server was lost! Click to refresh the page.',
-                    {
-                      timeout: 0,
-                      clickHandler: () => {
-                        window.location.reload();
-                        return true;
-                      },
-                    },
-                  );
-                }
-              }
+              this.lostConnection(error);
               break;
             }
             case 400: {
@@ -78,5 +45,39 @@ export class ConnectionInterceptor implements HttpInterceptor {
         },
       }),
     );
+  }
+
+  private lostConnection(error: HttpErrorResponse): void {
+    const appConstants = this.appService.appConstants();
+    if (error.url) {
+      fetch(error.url, { redirect: 'manual' }).then((response) => {
+        if (response.type === 'opaqueredirect') {
+          // if the request ended in a redirect that failed, then login
+          const login_url = `${this.appService.getServerPath()}iaf/`;
+          this.router.navigate([login_url]);
+        }
+      });
+      return;
+    }
+
+    if (appConstants['init'] == 1) {
+      if (error.headers.get('Authorization') == undefined) {
+        this.toastsService.error('Failed to connect to backend!');
+      } else {
+        console.warn('Authorization error');
+      }
+    } else if (appConstants['init'] == 2) {
+      console.warn('Connection to the server was lost!');
+      this.errorCount++;
+      if (this.errorCount > 2) {
+        this.toastsService.error('Server Error', 'Connection to the server was lost! Click to refresh the page.', {
+          timeout: 0,
+          clickHandler: () => {
+            window.location.reload();
+            return true;
+          },
+        });
+      }
+    }
   }
 }

--- a/console/frontend/src/main/frontend/src/app/pages-title-strategy.ts
+++ b/console/frontend/src/main/frontend/src/app/pages-title-strategy.ts
@@ -7,7 +7,7 @@ import { AppService } from './app.service';
 export class PagesTitleStrategy extends TitleStrategy {
   constructor(
     private readonly title: Title,
-    private appService: AppService,
+    private readonly appService: AppService,
   ) {
     super();
   }
@@ -15,8 +15,8 @@ export class PagesTitleStrategy extends TitleStrategy {
   override updateTitle(routerState: RouterStateSnapshot): void {
     const title = this.buildTitle(routerState);
     if (title !== undefined) {
-      const dtapStage = this.appService.dtapStage;
-      const instanceName = this.appService.instanceName;
+      const dtapStage = this.appService.dtapStage();
+      const instanceName = this.appService.instanceName();
       this.title.setTitle(`${dtapStage}-${instanceName} | ${title}`);
     }
   }

--- a/console/frontend/src/main/frontend/src/app/services/alert.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/alert.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { SessionService } from './session.service';
 
 export type Alert = {
@@ -12,10 +12,10 @@ export type Alert = {
   providedIn: 'root',
 })
 export class AlertService {
-  constructor(private Session: SessionService) {}
+  private readonly Session: SessionService = inject(SessionService);
 
   add(level: string | number, message: string, non_repeditive: boolean): void {
-    if (non_repeditive === true && this.checkIfExists(message)) return;
+    if (non_repeditive && this.checkIfExists(message)) return;
 
     let type;
     switch (level) {
@@ -54,7 +54,7 @@ export class AlertService {
   get(preserveList?: boolean): Alert[] {
     //var list = JSON.parse(sessionStorage.getItem("Alert"));
     const list = this.Session.get('Alert');
-    if (preserveList == undefined) this.Session.set('Alert', []); //sessionStorage.setItem("Alert", JSON.stringify([])); //Clear after retreival
+    if (!preserveList) this.Session.set('Alert', []); //sessionStorage.setItem("Alert", JSON.stringify([])); //Clear after retreival
     return list == null ? [] : (list as Alert[]);
   }
 

--- a/console/frontend/src/main/frontend/src/app/services/base64.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/base64.service.ts
@@ -4,8 +4,6 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class Base64Service {
-  constructor() {}
-
   encode(input: string): string {
     return btoa(input);
   }

--- a/console/frontend/src/main/frontend/src/app/services/misc.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/misc.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Base64Service } from './base64.service';
 import { ServerInfo } from './server-info.service';
 
@@ -6,22 +6,22 @@ import { ServerInfo } from './server-info.service';
   providedIn: 'root',
 })
 export class MiscService {
-  constructor(private Base64: Base64Service) {}
+  private readonly Base64: Base64Service = inject(Base64Service);
 
   escapeURL(uri: string | number | boolean): string {
     return encodeURIComponent(uri);
   }
 
   isMobile(): boolean {
-    return /android/i.test(navigator.userAgent) ||
+    return (
+      /android/i.test(navigator.userAgent) ||
       /webos/i.test(navigator.userAgent) ||
       /iphone/i.test(navigator.userAgent) ||
       /ipad/i.test(navigator.userAgent) ||
       /ipod/i.test(navigator.userAgent) ||
       /blackberry/i.test(navigator.userAgent) ||
       /windows phone/i.test(navigator.userAgent)
-      ? true
-      : false;
+    );
   }
 
   getUID(serverInfo: ServerInfo): string {

--- a/console/frontend/src/main/frontend/src/app/services/notification.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/notification.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Injectable, signal, Signal, WritableSignal } from '@angular/core';
 import Tinycon from 'tinycon';
 
 export type Notification = {
@@ -15,10 +14,16 @@ export type Notification = {
   providedIn: 'root',
 })
 export class NotificationService {
-  list: Notification[] = [];
-  count: number = 0;
-  private onCountUpdateSource = new Subject<void>();
-  onCountUpdate$ = this.onCountUpdateSource.asObservable();
+  private _list: WritableSignal<Notification[]> = signal([]);
+  private _count: WritableSignal<number> = signal(0);
+
+  get list(): Signal<Notification[]> {
+    return this._list.asReadonly();
+  }
+
+  get count(): Signal<number> {
+    return this._count.asReadonly();
+  }
 
   constructor() {
     Tinycon.setOptions({
@@ -27,24 +32,23 @@ export class NotificationService {
   }
 
   add(icon: string, title: string, message?: string | boolean, function_?: (notification: Notification) => void): void {
-    const object: Notification = {
+    const newNotification: Notification = {
       icon: icon,
       title: title,
       message: message ?? false,
       fn: function_ ?? false,
       time: Date.now(),
     };
-    this.list.unshift(object);
-    object.id = this.list.length;
-    this.count++;
-    this.onCountUpdateSource.next();
+    this._list.set([newNotification, ...this.list()]);
+    newNotification.id = this.list.length;
+    this._count.set(this.count() + 1);
 
-    Tinycon.setBubble(this.count);
+    Tinycon.setBubble(this.count());
   }
 
   get(id: number): Notification | null {
-    for (let index = 0; index < this.list.length; index++) {
-      const notification = this.list[index];
+    for (let index = 0; index < this.list().length; index++) {
+      const notification = this.list()[index];
       if (notification.id == id) {
         if (notification.fn) {
           window.setTimeout(() => {
@@ -60,16 +64,11 @@ export class NotificationService {
 
   resetCount(): void {
     Tinycon.setBubble(0);
-    this.count = 0;
-    this.onCountUpdateSource.next();
-  }
-
-  getCount(): number {
-    return this.count;
+    this._count.set(0);
   }
 
   getLatest(amount: number): Notification[] {
     if (amount < 1) amount = 1;
-    return this.list.slice(0, amount);
+    return this.list().slice(0, amount);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
@@ -44,22 +44,18 @@ export type ConsoleInfo = {
   providedIn: 'root',
 })
 export class ServerInfoService {
-  private readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
   private serverInfoSubject = new ReplaySubject<ServerInfo>(1);
+  public serverInfo$ = this.serverInfoSubject.asObservable();
   private consoleInfoSubject = new BehaviorSubject<ConsoleInfo>({
     version: null,
   });
+  public consoleVersion$ = this.consoleInfoSubject.asObservable();
 
-  serverInfo$ = this.serverInfoSubject.asObservable();
-  consoleVersion$ = this.consoleInfoSubject.asObservable();
-
+  private readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
+  private readonly appService: AppService = inject(AppService);
+  private readonly http: HttpClient = inject(HttpClient);
   private serverInfo?: ServerInfo;
   private consoleInfo?: ConsoleInfo;
-
-  constructor(
-    private appService: AppService,
-    private http: HttpClient,
-  ) {}
 
   fetchServerInfo(): Observable<ServerInfo> {
     return this.http.get<ServerInfo>(`${this.appService.absoluteApiPath}server/info`);

--- a/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/server-info.service.ts
@@ -1,5 +1,5 @@
-import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, ReplaySubject, tap } from 'rxjs';
+import { inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { Observable, tap } from 'rxjs';
 import { AppService } from '../app.service';
 import { HttpClient } from '@angular/common/http';
 import { HumanFileSizePipe } from '../pipes/human-file-size.pipe';
@@ -44,18 +44,22 @@ export type ConsoleInfo = {
   providedIn: 'root',
 })
 export class ServerInfoService {
-  private serverInfoSubject = new ReplaySubject<ServerInfo>(1);
-  public serverInfo$ = this.serverInfoSubject.asObservable();
-  private consoleInfoSubject = new BehaviorSubject<ConsoleInfo>({
+  private _serverInfo: WritableSignal<ServerInfo | null> = signal(null);
+  private _consoleInfo: WritableSignal<ConsoleInfo> = signal({
     version: null,
   });
-  public consoleVersion$ = this.consoleInfoSubject.asObservable();
 
   private readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
   private readonly appService: AppService = inject(AppService);
   private readonly http: HttpClient = inject(HttpClient);
-  private serverInfo?: ServerInfo;
-  private consoleInfo?: ConsoleInfo;
+
+  get consoleInfo(): Signal<ConsoleInfo> {
+    return this._consoleInfo.asReadonly();
+  }
+
+  get serverInfo(): Signal<ServerInfo | null> {
+    return this._serverInfo.asReadonly();
+  }
 
   fetchServerInfo(): Observable<ServerInfo> {
     return this.http.get<ServerInfo>(`${this.appService.absoluteApiPath}server/info`);
@@ -66,32 +70,22 @@ export class ServerInfoService {
   }
 
   refresh(): Observable<ServerInfo> {
-    this.fetchConsoleVersion().subscribe({
-      next: (info) => {
-        this.consoleInfo = info;
-        this.consoleInfoSubject.next(info);
-      },
-    });
-    return this.fetchServerInfo().pipe(
-      tap({
-        next: (data) => {
-          this.serverInfo = data;
-          this.serverInfoSubject.next(data);
-        },
-      }),
-    );
+    this.fetchConsoleVersion().subscribe((info) => this._consoleInfo.set(info));
+    return this.fetchServerInfo().pipe(tap((data) => this._serverInfo.set(data)));
   }
 
   getMarkdownFormatedServerInfo(): string {
     if (!this.serverInfo) return '**Server info not available**';
     const humanFileSize = new HumanFileSizePipe();
-    return `**${this.serverInfo?.framework.name}${this.serverInfo?.framework.version ? ` ${this.serverInfo?.framework.version}` : ''}**: ${this.serverInfo?.instance.name} ${this.serverInfo?.instance.version}
-Running on **${this.serverInfo?.machineName}** using **${this.serverInfo?.applicationServer}**
-Java Version: **${this.serverInfo?.javaVersion}**
-Heap size: **${humanFileSize.transform(this.serverInfo?.processMetrics.heapSize ?? 0)}**, total JVM memory: **${humanFileSize.transform(this.serverInfo?.processMetrics?.totalMemory ?? 0)}**
-Free memory: **${humanFileSize.transform(this.serverInfo?.processMetrics.freeMemory ?? 0)}**, max memory: **${humanFileSize.transform(this.serverInfo?.processMetrics.maxMemory ?? 0)}**
-Free disk space: **${humanFileSize.transform(this.serverInfo?.fileSystem.freeSpace ?? 0)}**, total disk space: **${humanFileSize.transform(this.serverInfo?.fileSystem.totalSpace ?? 0)}**
-Up since: **${this.serverTimeService.getIntialTime()}**, timezone: **${this.serverInfo?.serverTimezone}**
-${this.consoleInfo?.version === this.serverInfo.framework.version ? '' : `Console version: **${this.consoleInfo?.version ?? 'null'}**`}`;
+    const serverInfo = this.serverInfo();
+    const consoleVersion = this.consoleInfo().version ?? 'null';
+    return `**${serverInfo?.framework.name}${serverInfo?.framework.version ? ` ${serverInfo?.framework.version}` : ''}**: ${serverInfo?.instance.name} ${serverInfo?.instance.version}
+Running on **${serverInfo?.machineName}** using **${serverInfo?.applicationServer}**
+Java Version: **${serverInfo?.javaVersion}**
+Heap size: **${humanFileSize.transform(serverInfo?.processMetrics.heapSize ?? 0)}**, total JVM memory: **${humanFileSize.transform(serverInfo?.processMetrics?.totalMemory ?? 0)}**
+Free memory: **${humanFileSize.transform(serverInfo?.processMetrics.freeMemory ?? 0)}**, max memory: **${humanFileSize.transform(serverInfo?.processMetrics.maxMemory ?? 0)}**
+Free disk space: **${humanFileSize.transform(serverInfo?.fileSystem.freeSpace ?? 0)}**, total disk space: **${humanFileSize.transform(serverInfo?.fileSystem.totalSpace ?? 0)}**
+Up since: **${this.serverTimeService.getIntialTime()}**, timezone: **${serverInfo?.serverTimezone}**
+${consoleVersion === serverInfo?.framework.version ? '' : `Console version: **${consoleVersion}**`}`;
   }
 }

--- a/console/frontend/src/main/frontend/src/app/services/session.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/session.service.ts
@@ -4,8 +4,6 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class SessionService {
-  constructor() {}
-
   get<T>(key: string): T | null {
     try {
       return JSON.parse(sessionStorage.getItem(key)!);

--- a/console/frontend/src/main/frontend/src/app/services/sweetalert.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/sweetalert.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import Swal, { SweetAlertOptions, SweetAlertResult } from 'sweetalert2';
 import { DebugService } from './debug.service';
 
@@ -6,11 +6,11 @@ import { DebugService } from './debug.service';
   providedIn: 'root',
 })
 export class SweetalertService {
-  defaultSettings: SweetAlertOptions = {
+  private defaultSettings: SweetAlertOptions = {
     //			confirmButtonColor: "#449d44"
   };
 
-  constructor(private Debug: DebugService) {}
+  private readonly Debug: DebugService = inject(DebugService);
 
   defaults(title: string | SweetAlertOptions, text?: string): SweetAlertOptions {
     // let args = arguments || [];

--- a/console/frontend/src/main/frontend/src/app/services/toast.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/toast.service.ts
@@ -22,10 +22,8 @@ export type DuplicateToast = ToastBody & { count: number };
   providedIn: 'root',
 })
 export class ToastService {
-  toasts: Toast[] = [];
+  public toasts: Toast[] = [];
   private duplicates: DuplicateToast[] = [];
-
-  constructor() {}
 
   error = (title: string, body?: string, options?: ToastOptions): void => this.show('error', title, body, options);
   success = (title: string, body?: string, options?: ToastOptions): void => this.show('success', title, body, options);

--- a/console/frontend/src/main/frontend/src/app/services/websocket.service.ts
+++ b/console/frontend/src/main/frontend/src/app/services/websocket.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, isDevMode } from '@angular/core';
+import { inject, Injectable, isDevMode } from '@angular/core';
 import { Client, IFrame, IMessage, IStompSocket, StompSubscription } from '@stomp/stompjs';
 import { AppService, ClusterMember } from '../app.service';
 import { Subject } from 'rxjs';
@@ -35,6 +35,9 @@ export class WebsocketService {
   onWebSocketError$ = this.onWebSocketErrorSubject.asObservable();
   onMessage$ = this.onMessageSubject.asObservable();
 
+  private readonly appService: AppService = inject(AppService);
+  private readonly sweetalertService: SweetalertService = inject(SweetalertService);
+  private readonly toastsService: ToastService = inject(ToastService);
   private baseUrl: string = `${window.location.host}${this.appService.absoluteApiPath}`;
   private errorCount: number = 0;
   private httpProtocol: string = window.location.protocol == 'https:' ? 'https:' : 'http:';
@@ -66,12 +69,6 @@ export class WebsocketService {
     },
   });
   private stompSubscriptions: Map<string, StompSubscription> = new Map<string, StompSubscription>();
-
-  constructor(
-    private appService: AppService,
-    private sweetalertService: SweetalertService,
-    private toastsService: ToastService,
-  ) {}
 
   activate(): void {
     if (!this.client.connected) {

--- a/console/frontend/src/main/frontend/src/app/views/adapterstatistics/adapterstatistics.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/adapterstatistics/adapterstatistics.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import type { ChartData, ChartDataset, ChartOptions } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 import { Subscription } from 'rxjs';
-import { AppService } from 'src/app/app.service';
+import { AppConstants, AppService } from 'src/app/app.service';
 import { DebugService } from 'src/app/services/debug.service';
 import { SweetalertService } from 'src/app/services/sweetalert.service';
 import { AdapterstatisticsService, Statistics, StatisticsKeeper } from './adapterstatistics.service';
@@ -90,6 +90,7 @@ export class AdapterstatisticsComponent implements OnInit, OnDestroy {
   private readonly SweetAlert: SweetalertService = inject(SweetalertService);
   private readonly Debug: DebugService = inject(DebugService);
   private readonly serverTimeService: ServerTimeService = inject(ServerTimeService);
+  private appConstants$ = toObservable(this.appService.appConstants);
   private appConstantsSubscription: Subscription | null = null;
   private dataset: Partial<ChartDataset<'line', number[]>> = {
     fill: false,
@@ -111,10 +112,9 @@ export class AdapterstatisticsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe(() =>
-      this.populateBoundaries(),
+    this.appConstantsSubscription = this.appConstants$.subscribe((appConstants) =>
+      this.populateBoundaries(appConstants),
     );
-    this.populateBoundaries();
 
     window.setTimeout(() => {
       this.refresh();
@@ -161,8 +161,7 @@ export class AdapterstatisticsComponent implements OnInit, OnDestroy {
     return receiver.processing.sort((a: StatisticsKeeper, b: StatisticsKeeper) => a.name.localeCompare(b.name));
   }
 
-  private populateBoundaries(): void {
-    const appConstants = this.appService.appConstants();
+  private populateBoundaries(appConstants: AppConstants): void {
     if (!appConstants['Statistics.boundaries']) return;
 
     const timeBoundaries: string[] = (appConstants['Statistics.boundaries'] as string).split(',');

--- a/console/frontend/src/main/frontend/src/app/views/adapterstatistics/adapterstatistics.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/adapterstatistics/adapterstatistics.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 import { MiscService } from 'src/app/services/misc.service';
@@ -59,11 +59,9 @@ export type Statistics = {
   providedIn: 'root',
 })
 export class AdapterstatisticsService {
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-    private Misc: MiscService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
+  private readonly Misc: MiscService = inject(MiscService);
 
   getStatistics(configurationName: string, adapterName: string): Observable<Statistics> {
     return this.http.get<Statistics>(

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage-details/configurations-manage-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AppService, Configuration } from 'src/app/app.service';
 import { SweetalertService } from 'src/app/services/sweetalert.service';
@@ -16,6 +16,10 @@ import { FormsModule } from '@angular/forms';
   styleUrls: ['./configurations-manage-details.component.scss'],
 })
 export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
+  @ViewChildren(ThSortableDirective) headers!: QueryList<ThSortableDirective>;
+
+  protected versionsSorted: Configuration[] = [];
+  protected search: string = '';
   protected configuration: Configuration = {
     name: '',
     stubbed: false,
@@ -24,23 +28,18 @@ export class ConfigurationsManageDetailsComponent implements OnInit, OnDestroy {
     jdbcMigrator: false,
     version: '',
   };
-  protected versionsSorted: Configuration[] = [];
-  protected search: string = '';
 
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly router: Router = inject(Router);
+  private readonly appService: AppService = inject(AppService);
+  private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
+  private readonly sweetalertService: SweetalertService = inject(SweetalertService);
+  private readonly toastService: ToastService = inject(ToastService);
   private promise: number = -1;
   private versions: Configuration[] = [];
   private lastSortEvent: SortEvent = { direction: 'NONE', column: '' };
 
-  @ViewChildren(ThSortableDirective) headers!: QueryList<ThSortableDirective>;
-
-  constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-    private appService: AppService,
-    private configurationsService: ConfigurationsService,
-    private sweetalertService: SweetalertService,
-    private toastService: ToastService,
-  ) {
+  constructor() {
     const routeState = this.router.getCurrentNavigation()?.extras.state ?? {};
     if (!routeState['configuration']) {
       this.router.navigate(['..'], { relativeTo: this.route });

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.html
@@ -37,7 +37,7 @@
               </tr>
             </thead>
             <tbody>
-              @for (configuration of configurations; track configuration.name) {
+              @for (configuration of configurations(); track configuration.name) {
                 <tr [ngClass]="{ 'text-danger': configuration.exception }" [title]="configuration.exception ?? ''">
                   @if (configuration.type === 'DatabaseClassLoader') {
                     <td>

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-manage/configurations-manage.component.ts
@@ -1,7 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnInit, Signal } from '@angular/core';
 import { AppService, Configuration } from 'src/app/app.service';
 import { ConfigurationsService } from '../configurations.service';
-import { Subscription } from 'rxjs';
 import { NgClass } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { HasAccessToLinkDirective } from '../../../components/has-access-to-link.directive';
@@ -12,30 +11,13 @@ import { HasAccessToLinkDirective } from '../../../components/has-access-to-link
   templateUrl: './configurations-manage.component.html',
   styleUrls: ['./configurations-manage.component.scss'],
 })
-export class ConfigurationsManageComponent implements OnInit, OnDestroy {
-  protected configurations: Configuration[] = [];
-
-  private subscriptions = new Subscription();
-
-  constructor(
-    private configurationsService: ConfigurationsService,
-    private appService: AppService,
-  ) {}
+export class ConfigurationsManageComponent implements OnInit {
+  private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
+  private readonly appService: AppService = inject(AppService);
+  protected configurations: Signal<Configuration[]> = this.appService.configurations;
 
   ngOnInit(): void {
-    this.configurations = this.appService.configurations;
-    const appConfigurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-    });
-    this.subscriptions.add(appConfigurationsSubscription);
-
-    this.configurationsService.getConfigurations().subscribe((data) => {
-      this.appService.updateConfigurations(data);
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
+    this.configurationsService.getConfigurations().subscribe((data) => this.appService.updateConfigurations(data));
   }
 
   downloadAll(): void {

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.html
@@ -1,7 +1,7 @@
 <div class="wrapper wrapper-content animated fadeInRight">
   <div class="row">
     <app-configuration-tab-list
-      [configurations]="configurations"
+      [configurations]="configurations()"
       [showAll]="true"
       (selectedTabChange)="changeConfiguration($event)"
     ></app-configuration-tab-list>

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-show/configurations-show.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, Signal, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AppService, Configuration } from 'src/app/app.service';
 import { ConfigurationsService } from '../configurations.service';
@@ -17,10 +17,15 @@ import { NgClass } from '@angular/common';
 export class ConfigurationsShowComponent implements OnInit, OnDestroy {
   @ViewChild('editor') editor!: MonacoEditorComponent;
 
-  protected configurations: Configuration[] = [];
   protected selectedConfiguration: string = 'All';
   protected loadedConfiguration: boolean = false;
 
+  private readonly appService: AppService = inject(AppService);
+  protected configurations: Signal<Configuration[]> = this.appService.configurations;
+
+  private readonly router: Router = inject(Router);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
   private configuration: string = '';
   private fragment?: string;
   private selectedAdapter?: string;
@@ -28,19 +33,7 @@ export class ConfigurationsShowComponent implements OnInit, OnDestroy {
   private initialized: boolean = false;
   private configsSubscription: Subscription | null = null;
 
-  constructor(
-    private router: Router,
-    private route: ActivatedRoute,
-    private configurationsService: ConfigurationsService,
-    private appService: AppService,
-  ) {}
-
   ngOnInit(): void {
-    this.configurations = this.appService.configurations;
-    this.configsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-    });
-
     this.route.fragment.subscribe((fragment) => {
       this.fragment = fragment ?? undefined;
       this.removeAdapterAfterLineSelection(fragment);

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-upload/configurations-upload.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-upload/configurations-upload.component.ts
@@ -47,10 +47,11 @@ export class ConfigurationsUploadComponent implements OnInit, OnDestroy {
   private readonly jdbcService: JdbcService = inject(JdbcService);
   private readonly appService: AppService = inject(AppService);
   private file: File | null = null;
+  private appConstants$ = toObservable(this.appService.appConstants);
   private appConstantsSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+    this.appConstantsSubscription = this.appConstants$.subscribe((appConstants) => {
       this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
 

--- a/console/frontend/src/main/frontend/src/app/views/configurations/configurations-upload/configurations-upload.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/configurations/configurations-upload/configurations-upload.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { AppConstants, AppService } from 'src/app/app.service';
+import { Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AppService } from 'src/app/app.service';
 import { InputFileUploadComponent } from 'src/app/components/input-file-upload/input-file-upload.component';
 import { JdbcService } from '../../jdbc/jdbc.service';
 import { ConfigurationsService } from '../configurations.service';
@@ -9,6 +9,7 @@ import { FormsModule } from '@angular/forms';
 
 import { RouterLink } from '@angular/router';
 import { QuickSubmitFormDirective } from '../../../components/quick-submit-form.directive';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 type Form = {
   name: string;
@@ -42,27 +43,25 @@ export class ConfigurationsUploadComponent implements OnInit, OnDestroy {
     automatic_reload: false,
   };
 
+  private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
+  private readonly jdbcService: JdbcService = inject(JdbcService);
+  private readonly appService: AppService = inject(AppService);
   private file: File | null = null;
-  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
   private appConstantsSubscription: Subscription | null = null;
 
-  constructor(
-    private configurationsService: ConfigurationsService,
-    private jdbcService: JdbcService,
-    private appService: AppService,
-  ) {}
-
   ngOnInit(): void {
-    this.appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.form.datasource = this.appConstants['jdbc.datasource.default'] as string;
+    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+      this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
 
     this.jdbcService.getJdbc().subscribe((data) => {
+      const appConstants = this.appService.appConstants();
       Object.assign(this, data);
+
       this.form.datasource =
-        this.appConstants['jdbc.datasource.default'] === undefined
+        appConstants['jdbc.datasource.default'] === undefined
           ? data.datasources[0]
-          : (this.appConstants['jdbc.datasource.default'] as string);
+          : (appConstants['jdbc.datasource.default'] as string);
     });
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/connections/connections.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/connections/connections.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { AppService } from 'src/app/app.service';
 import {
   DataTableColumn,
@@ -26,6 +26,7 @@ type ConnectionsData = Connections['data'][number];
   styleUrls: ['./connections.component.scss'],
 })
 export class ConnectionsComponent implements OnInit {
+  protected minimalTruncateLength = 100;
   protected datasource: DataTableDataSource<ConnectionsData> = new DataTableDataSource();
   protected displayedColumns: DataTableColumn<ConnectionsData>[] = [
     { name: 'adapterName', displayName: 'Adapter Name', property: 'adapterName' },
@@ -35,12 +36,8 @@ export class ConnectionsComponent implements OnInit {
     { name: 'direction', displayName: 'Direction', property: 'direction' },
   ];
 
-  protected minimalTruncateLength = 100;
-
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
 
   ngOnInit(): void {
     this.http.get<Connections>(`${this.appService.absoluteApiPath}connections`).subscribe((response) => {

--- a/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <app-tab-list
       [allTabName]="GLOBAL_TAB_NAME"
-      [tabs]="configurationNames"
+      [tabs]="configurationNames()"
       (selectedTabChange)="changeConfiguration($event)"
     ></app-tab-list>
     <div class="col-lg-12">

--- a/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { AppConstants, AppService, Configuration } from 'src/app/app.service';
+import { Component, computed, inject, OnInit, Signal } from '@angular/core';
+import { AppService } from 'src/app/app.service';
 import { KeyValue } from '@angular/common';
 import { TabListComponent } from '../../components/tab-list/tab-list.component';
 import { FormsModule } from '@angular/forms';
@@ -15,39 +14,27 @@ type keyValueProperty = KeyValue<string, string>;
   templateUrl: './environment-variables.component.html',
   styleUrls: ['./environment-variables.component.scss'],
 })
-export class EnvironmentVariablesComponent implements OnInit, OnDestroy {
+export class EnvironmentVariablesComponent implements OnInit {
   protected readonly GLOBAL_TAB_NAME = 'Global';
   protected searchFilter: string = '';
   protected selectedConfiguration: string = '';
   protected configProperties: keyValueProperty[] = [];
   protected environmentProperties: keyValueProperty[] = [];
   protected systemProperties: keyValueProperty[] = [];
-  protected configurations: Configuration[] = [];
-  protected configurationNames: string[] = [];
 
-  private _subscriptions = new Subscription();
-  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
-
-  constructor(private appService: AppService) {}
+  private readonly appService: AppService = inject(AppService);
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected configurationNames: Signal<string[]> = computed(() =>
+    this.appService.configurations().map((configuration) => configuration.name),
+  );
 
   ngOnInit(): void {
-    const appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.appConstants = this.appService.APP_CONSTANTS;
-    });
-    this._subscriptions.add(appConstantsSubscription);
-
-    this.configurations = this.appService.configurations;
-    this.configurationNames = this.configurations.map((configuration) => configuration.name);
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-      this.configurationNames = this.configurations.map((configuration) => configuration.name);
-    });
-    this._subscriptions.add(configurationsSubscription);
-
-    const environmentVariablesSubscription = this.appService.getEnvironmentVariables().subscribe((data) => {
+    this.appService.getEnvironmentVariables().subscribe((data) => {
       let instanceName = null;
       for (const configName in data['Application Constants']) {
-        this.appConstants[configName] = this.convertPropertiesToArray(data['Application Constants'][configName]);
+        this.appService.appConstants()[configName] = this.convertPropertiesToArray(
+          data['Application Constants'][configName],
+        );
         if (instanceName == null) {
           instanceName = data['Application Constants'][configName]['instance.name'];
         }
@@ -56,16 +43,11 @@ export class EnvironmentVariablesComponent implements OnInit, OnDestroy {
       this.environmentProperties = this.convertPropertiesToArray(data['Environment Variables']);
       this.systemProperties = this.convertPropertiesToArray(data['System Properties']);
     });
-    this._subscriptions.add(environmentVariablesSubscription);
-  }
-
-  ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
   }
 
   changeConfiguration(name: string): void {
     this.selectedConfiguration = name;
-    this.configProperties = this.appConstants[name] as keyValueProperty[];
+    this.configProperties = this.appService.appConstants()[name] as keyValueProperty[];
   }
 
   private convertPropertiesToArray(propertyList: Record<string, string>): keyValueProperty[] {

--- a/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/environment-variables/environment-variables.component.ts
@@ -23,7 +23,6 @@ export class EnvironmentVariablesComponent implements OnInit {
   protected systemProperties: keyValueProperty[] = [];
 
   private readonly appService: AppService = inject(AppService);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected configurationNames: Signal<string[]> = computed(() =>
     this.appService.configurations().map((configuration) => configuration.name),
   );

--- a/console/frontend/src/main/frontend/src/app/views/error/error.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/error/error.component.ts
@@ -44,7 +44,7 @@ export class ErrorComponent implements OnInit, OnDestroy {
     if (httpCode < 400 || httpCode > 502) this.router.navigate(['/status']);
 
     this.cooldownCounter = 60;
-    this.appService.updateStartupError(error);
+    this.appService.startupError.set(error);
     this.stackTrace = stackTrace;
 
     this.interval = window.setInterval(() => {

--- a/console/frontend/src/main/frontend/src/app/views/ibisstore-summary/ibisstore-summary.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/ibisstore-summary/ibisstore-summary.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { first, Subscription } from 'rxjs';
-import { AppConstants, AppService, ServerErrorResponse } from 'src/app/app.service';
+import { AppService, ServerErrorResponse } from 'src/app/app.service';
 import { JdbcService, JdbcSummary, JdbcSummaryForm } from '../jdbc/jdbc.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -8,6 +8,7 @@ import { NgClass } from '@angular/common';
 import { HasAccessToLinkDirective } from '../../components/has-access-to-link.directive';
 import { QuickSubmitFormDirective } from '../../components/quick-submit-form.directive';
 import { FormsModule } from '@angular/forms';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-ibisstore-summary',
@@ -21,29 +22,24 @@ export class IbisstoreSummaryComponent implements OnInit, OnDestroy {
   protected error: string | null = null;
   protected result: JdbcSummary[] = [];
 
-  private _subscriptions = new Subscription();
-  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
-
-  constructor(
-    private router: Router,
-    private route: ActivatedRoute,
-    private appService: AppService,
-    private jdbcService: JdbcService,
-  ) {}
+  private readonly router: Router = inject(Router);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly appService: AppService = inject(AppService);
+  private readonly jdbcService: JdbcService = inject(JdbcService);
+  private appConstantsSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    const appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.appConstants = this.appService.APP_CONSTANTS;
-      this.form.datasource = this.appConstants['jdbc.datasource.default'] as string;
+    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+      this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
-    this._subscriptions.add(appConstantsSubscription);
 
     this.jdbcService.getJdbc().subscribe((data) => {
+      const appConstants = this.appService.appConstants();
       this.datasources = data.datasources;
       this.form.datasource =
-        this.appConstants['jdbc.datasource.default'] === undefined
+        appConstants['jdbc.datasource.default'] === undefined
           ? data.datasources[0]
-          : (this.appConstants['jdbc.datasource.default'] as string);
+          : (appConstants['jdbc.datasource.default'] as string);
     });
     this.route.queryParamMap.pipe(first()).subscribe((parameters) => {
       if (parameters.has('datasource')) this.fetch(parameters.get('datasource')!);
@@ -51,7 +47,7 @@ export class IbisstoreSummaryComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
+    this.appConstantsSubscription?.unsubscribe();
   }
 
   fetch(datasource: string): void {

--- a/console/frontend/src/main/frontend/src/app/views/ibisstore-summary/ibisstore-summary.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/ibisstore-summary/ibisstore-summary.component.ts
@@ -24,12 +24,13 @@ export class IbisstoreSummaryComponent implements OnInit, OnDestroy {
 
   private readonly router: Router = inject(Router);
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
-  private readonly appService: AppService = inject(AppService);
   private readonly jdbcService: JdbcService = inject(JdbcService);
+  private readonly appService: AppService = inject(AppService);
+  private appConstants$ = toObservable(this.appService.appConstants);
   private appConstantsSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+    this.appConstantsSubscription = this.appConstants$.subscribe((appConstants) => {
       this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
 

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug-legacy/iframe-ladybug-legacy.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug-legacy/iframe-ladybug-legacy.component.ts
@@ -1,16 +1,18 @@
 import { Component, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { AppService } from 'src/app/app.service';
-import { BaseIframeComponent, baseImports } from '../iframe.base';
+import { BaseIframeComponent } from '../iframe.base';
 
 @Component({
   selector: 'app-iframe-ladybug-legacy',
-  imports: baseImports,
   templateUrl: '../iframe.component.html',
   styleUrls: ['../iframe.component.scss'],
 })
 export class IframeLadybugLegacyComponent extends BaseIframeComponent implements OnInit {
-  constructor(sanitizer: DomSanitizer, appService: AppService) {
+  constructor(
+    protected override readonly sanitizer: DomSanitizer,
+    protected override readonly appService: AppService,
+  ) {
     super(sanitizer, appService);
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
@@ -1,16 +1,18 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { AppService } from 'src/app/app.service';
-import { BaseIframeComponent, baseImports } from '../iframe.base';
+import { BaseIframeComponent } from '../iframe.base';
 
 @Component({
   selector: 'app-iframe-ladybug',
-  imports: baseImports,
   templateUrl: '../iframe.component.html',
   styleUrls: ['../iframe.component.scss'],
 })
 export class IframeLadybugComponent extends BaseIframeComponent implements OnInit, OnDestroy {
-  constructor(sanitizer: DomSanitizer, appService: AppService) {
+  constructor(
+    protected override readonly sanitizer: DomSanitizer,
+    protected override readonly appService: AppService,
+  ) {
     super(sanitizer, appService);
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-larva/iframe-larva.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-larva/iframe-larva.component.ts
@@ -1,15 +1,17 @@
 import { Component, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { AppService } from 'src/app/app.service';
-import { BaseIframeComponent, baseImports } from '../iframe.base';
+import { BaseIframeComponent } from '../iframe.base';
 @Component({
   selector: 'app-iframe-larva',
-  imports: baseImports,
   templateUrl: '../iframe.component.html',
   styleUrls: ['../iframe.component.scss'],
 })
 export class IframeLarvaComponent extends BaseIframeComponent implements OnInit {
-  constructor(sanitizer: DomSanitizer, appService: AppService) {
+  constructor(
+    protected override readonly sanitizer: DomSanitizer,
+    protected override readonly appService: AppService,
+  ) {
     super(sanitizer, appService);
   }
 

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe.base.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe.base.ts
@@ -1,9 +1,6 @@
 import { Component, HostListener, OnInit, OnDestroy } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { AppService } from 'src/app/app.service';
-import { NgIf } from '@angular/common';
-
-export const baseImports = [NgIf];
 
 @Component({
   template: '',
@@ -15,9 +12,9 @@ export abstract class BaseIframeComponent implements OnInit, OnDestroy {
 
   private topBarHeightPx = 99;
 
-  constructor(
-    protected sanitizer: DomSanitizer,
-    protected appService: AppService,
+  protected constructor(
+    protected readonly sanitizer: DomSanitizer,
+    protected readonly appService: AppService,
   ) {}
 
   ngOnInit(): void {
@@ -41,7 +38,7 @@ export abstract class BaseIframeComponent implements OnInit, OnDestroy {
   protected setIframeSource(ffPage: string): void {
     this.url = `${this.appService.getServerPath()}iaf/${ffPage}`;
     this.iframeSrc = this.sanitizer.bypassSecurityTrustResourceUrl(this.url);
-    this.appService.setIframePopoutUrl(this.url);
+    this.appService.iframePopoutUrl.set(this.url);
   }
 
   getTopBarHeight(): number {

--- a/console/frontend/src/main/frontend/src/app/views/inlinestore/inlinestore.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/inlinestore/inlinestore.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { AppService } from 'src/app/app.service';
 import { getProcessStateIcon, getProcessStateIconColor } from 'src/app/utils';
 import { KeyValuePipe } from '@angular/common';
@@ -21,14 +21,12 @@ type InlineStore = Record<string, { items: stateItemItem[]; totalMessageCount: n
   styleUrls: ['./inlinestore.component.scss'],
 })
 export class InlinestoreComponent implements OnInit {
-  protected result: InlineStore = {};
   protected readonly getProcessStateIconColorFn = getProcessStateIconColor;
   protected readonly getProcessStateIconFn = getProcessStateIcon;
 
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
+  protected result: InlineStore = {};
 
   ngOnInit(): void {
     this.http.get<InlineStore>(`${this.appService.absoluteApiPath}inlinestores/overview`).subscribe((data) => {

--- a/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc-browse-tables/jdbc-browse-tables.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc-browse-tables/jdbc-browse-tables.component.ts
@@ -41,13 +41,14 @@ export class JdbcBrowseTablesComponent implements OnInit, OnDestroy {
   protected result: string[][] = [];
   protected query: string = '';
 
-  private readonly appService: AppService = inject(AppService);
   private readonly jdbcService: JdbcService = inject(JdbcService);
   private readonly webStorageService: WebStorageService = inject(WebStorageService);
+  private readonly appService: AppService = inject(AppService);
+  private appConstants$ = toObservable(this.appService.appConstants);
   private appConstantsSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+    this.appConstantsSubscription = this.appConstants$.subscribe((appConstants) => {
       this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
 

--- a/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc-browse-tables/jdbc-browse-tables.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc-browse-tables/jdbc-browse-tables.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { AppConstants, AppService, ServerErrorResponse } from 'src/app/app.service';
+import { AppService, ServerErrorResponse } from 'src/app/app.service';
 import { JdbcBrowseForm, JdbcService } from '../jdbc.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
@@ -9,6 +9,7 @@ import { LaddaModule } from 'angular2-ladda';
 import { OrderByPipe } from '../../../pipes/orderby.pipe';
 import { QuickSubmitFormDirective } from '../../../components/quick-submit-form.directive';
 import { WebStorageService } from '../../../services/web-storage.service';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 interface ColumnName {
   id: number;
@@ -40,31 +41,29 @@ export class JdbcBrowseTablesComponent implements OnInit, OnDestroy {
   protected result: string[][] = [];
   protected query: string = '';
 
-  private _subscriptions = new Subscription();
-  private appService: AppService = inject(AppService);
-  private jdbcService: JdbcService = inject(JdbcService);
-  private webStorageService: WebStorageService = inject(WebStorageService);
-  private appConstants: AppConstants = this.appService.APP_CONSTANTS;
+  private readonly appService: AppService = inject(AppService);
+  private readonly jdbcService: JdbcService = inject(JdbcService);
+  private readonly webStorageService: WebStorageService = inject(WebStorageService);
+  private appConstantsSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    const appConstantsSubscription = this.appService.appConstants$.subscribe(() => {
-      this.appConstants = this.appService.APP_CONSTANTS;
-      this.form.datasource = this.appConstants['jdbc.datasource.default'] as string;
+    this.appConstantsSubscription = toObservable(this.appService.appConstants).subscribe((appConstants) => {
+      this.form.datasource = appConstants['jdbc.datasource.default'] as string;
     });
-    this._subscriptions.add(appConstantsSubscription);
 
     const browseTablesSession = this.webStorageService.get<JdbcBrowseForm>('browseTables');
 
     this.jdbcService.getJdbc().subscribe((data) => {
+      const appConstants = this.appService.appConstants();
       this.datasources = data.datasources;
 
       if (browseTablesSession) {
         this.form = browseTablesSession;
       } else {
         this.form.datasource =
-          this.appConstants['jdbc.datasource.default'] == undefined
+          appConstants['jdbc.datasource.default'] == undefined
             ? data.datasources[0]
-            : (this.appConstants['jdbc.datasource.default'] as string);
+            : (appConstants['jdbc.datasource.default'] as string);
         this.form.datasource = data.datasources[0] ?? '';
         this.form.resultType = data.resultTypes[0] ?? '';
       }
@@ -72,7 +71,7 @@ export class JdbcBrowseTablesComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
+    this.appConstantsSubscription?.unsubscribe();
   }
 
   submit(formData: JdbcBrowseForm): void {

--- a/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/jdbc/jdbc.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 
@@ -70,10 +70,8 @@ export interface JdbcSummary {
   providedIn: 'root',
 })
 export class JdbcService {
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
 
   getJdbc(): Observable<JDBC> {
     return this.http.get<JDBC>(`${this.appService.absoluteApiPath}jdbc`);

--- a/console/frontend/src/main/frontend/src/app/views/jms/jms.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/jms/jms.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 
@@ -31,10 +31,8 @@ export interface Message {
   providedIn: 'root',
 })
 export class JmsService {
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
 
   getJms(): Observable<{
     connectionFactories: string[];

--- a/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.html
@@ -27,7 +27,7 @@
               <label class="col-sm-3 control-label label-height-30">Configuration</label>
               <div class="col-sm-9">
                 <select class="form-control" name="configuration" [(ngModel)]="form.configuration">
-                  @for (configuration of filteredConfigurations; track configuration.name) {
+                  @for (configuration of filteredConfigurations(); track configuration.name) {
                     <option>
                       {{ configuration.name }}
                     </option>

--- a/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component, computed, inject, Signal } from '@angular/core';
 import { AppService, Configuration, ServerErrorResponse } from 'src/app/app.service';
 import { JdbcService } from '../jdbc/jdbc.service';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -19,7 +18,7 @@ interface Form {
   templateUrl: './liquibase.component.html',
   styleUrls: ['./liquibase.component.scss'],
 })
-export class LiquibaseComponent implements OnInit, OnDestroy {
+export class LiquibaseComponent {
   protected form: Form = {
     configuration: '',
   };
@@ -27,27 +26,13 @@ export class LiquibaseComponent implements OnInit, OnDestroy {
   protected generateSql: boolean = false;
   protected error: string | null = null;
   protected result: string | null = null;
-  protected filteredConfigurations: Configuration[] = [];
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected filteredConfigurations: Signal<Configuration[]> = computed(() =>
+    this.findFirstAvailabeConfiguration(this.appService.configurations()),
+  );
 
-  private configurations: Configuration[] = [];
-  private _subscriptions = new Subscription();
-
-  constructor(
-    private appService: AppService,
-    private jdbcService: JdbcService,
-  ) {}
-
-  ngOnInit(): void {
-    const configurationsSubscription = this.appService.configurations$.subscribe(() =>
-      this.findFirstAvailabeConfiguration(),
-    );
-    this._subscriptions.add(configurationsSubscription);
-    this.findFirstAvailabeConfiguration();
-  }
-
-  ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
-  }
+  private readonly appService: AppService = inject(AppService);
+  private readonly jdbcService: JdbcService = inject(JdbcService);
 
   download(): void {
     window.open(`${this.appService.getServerPath()}iaf/api/jdbc/liquibase`);
@@ -83,17 +68,16 @@ export class LiquibaseComponent implements OnInit, OnDestroy {
     }); // TODO no intercept
   }
 
-  private findFirstAvailabeConfiguration(): void {
-    this.configurations = this.appService.configurations;
-    this.filteredConfigurations = this.configurations.filter((item) => item.jdbcMigrator);
+  private findFirstAvailabeConfiguration(configurations: Configuration[]): Configuration[] {
+    const filteredConfigurations = configurations.filter((item) => item.jdbcMigrator);
 
-    for (const index in this.filteredConfigurations) {
-      const configuration = this.configurations[index];
-
+    for (const configuration of filteredConfigurations) {
       if (configuration.jdbcMigrator) {
         this.form.configuration = configuration.name;
         break;
       }
     }
+
+    return filteredConfigurations;
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/liquibase/liquibase.component.ts
@@ -26,7 +26,6 @@ export class LiquibaseComponent {
   protected generateSql: boolean = false;
   protected error: string | null = null;
   protected result: string | null = null;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected filteredConfigurations: Signal<Configuration[]> = computed(() =>
     this.findFirstAvailabeConfiguration(this.appService.configurations()),
   );

--- a/console/frontend/src/main/frontend/src/app/views/loading/loading.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/loading/loading.component.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AppService } from 'src/app/app.service';
 
@@ -10,10 +10,8 @@ import { AppService } from 'src/app/app.service';
   styleUrls: ['./loading.component.scss'],
 })
 export class LoadingComponent implements OnInit {
-  constructor(
-    private router: Router,
-    private appService: AppService,
-  ) {}
+  private readonly router: Router = inject(Router);
+  private readonly appService: AppService = inject(AppService);
 
   ngOnInit(): void {
     this.appService.getServerHealth().subscribe({

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.html
@@ -18,7 +18,7 @@
               <div class="col-sm-9">
                 <app-combobox
                   name="configuration"
-                  [options]="configurations"
+                  [options]="configurations()"
                   [(selectedOption)]="selectedConfiguration"
                 ></app-combobox>
               </div>

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
@@ -18,7 +18,6 @@ export class MonitorsNewComponent implements OnInit, OnDestroy {
   protected selectedConfiguration: string = '';
   protected monitorName: string = '';
   protected ladda: boolean = false;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected configurations: Signal<Option[]> = computed(() =>
     this.appService.configurations().map((config) => ({ label: config.name })),
   );

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors-new/monitors-new.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit, Signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MonitorsService } from '../monitors.service';
 import { AppService } from '../../../app.service';
@@ -6,10 +6,11 @@ import { FormsModule } from '@angular/forms';
 import { combineLatestWith, Subscription } from 'rxjs';
 import { LaddaModule } from 'angular2-ladda';
 import { ComboboxComponent, Option } from '../../../components/combobox/combobox.component';
+import { QuickSubmitFormDirective } from '../../../components/quick-submit-form.directive';
 
 @Component({
   selector: 'app-monitors-new',
-  imports: [RouterLink, FormsModule, LaddaModule, ComboboxComponent],
+  imports: [RouterLink, FormsModule, LaddaModule, ComboboxComponent, QuickSubmitFormDirective],
   templateUrl: './monitors-new.component.html',
   styleUrl: './monitors-new.component.scss',
 })
@@ -17,36 +18,29 @@ export class MonitorsNewComponent implements OnInit, OnDestroy {
   protected selectedConfiguration: string = '';
   protected monitorName: string = '';
   protected ladda: boolean = false;
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected configurations: Signal<Option[]> = computed(() =>
+    this.appService.configurations().map((config) => ({ label: config.name })),
+  );
 
-  private appService: AppService = inject(AppService);
-
-  protected configurations: Option[] = [];
-
-  private monitorsService: MonitorsService = inject(MonitorsService);
-  private router: Router = inject(Router);
-  private route: ActivatedRoute = inject(ActivatedRoute);
-  private subscriptions: Subscription = new Subscription();
+  private readonly appService: AppService = inject(AppService);
+  private readonly monitorsService: MonitorsService = inject(MonitorsService);
+  private readonly router: Router = inject(Router);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private routeSubscription: Subscription | null = null;
 
   ngOnInit(): void {
-    this.setConfigurations();
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.setConfigurations();
-    });
-    this.subscriptions.add(configurationsSubscription);
-
-    this.route.paramMap.pipe(combineLatestWith(this.route.queryParamMap)).subscribe(([, queryParameters]) => {
-      if (queryParameters.has('configuration')) {
-        this.selectedConfiguration = queryParameters.get('configuration')!;
-      }
-    });
+    this.routeSubscription = this.route.paramMap
+      .pipe(combineLatestWith(this.route.queryParamMap))
+      .subscribe(([, queryParameters]) => {
+        if (queryParameters.has('configuration')) {
+          this.selectedConfiguration = queryParameters.get('configuration')!;
+        }
+      });
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
-
-  private setConfigurations(): void {
-    this.configurations = this.appService.configurations.map((config) => ({ label: config.name }));
+    this.routeSubscription?.unsubscribe();
   }
 
   submit(): void {

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
@@ -37,8 +37,9 @@ export class MonitorsComponent implements OnInit, OnDestroy {
   private subscriptions: Subscription = new Subscription();
 
   private route: ActivatedRoute = inject(ActivatedRoute);
-  private appService: AppService = inject(AppService);
   private monitorsService: MonitorsService = inject(MonitorsService);
+  private appService: AppService = inject(AppService);
+  private configurations$ = toObservable(this.appService.configurations);
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe((parameters) => {
@@ -47,7 +48,7 @@ export class MonitorsComponent implements OnInit, OnDestroy {
         this.updateConfigurations();
       }
     });
-    const configurationsSubscription = toObservable(this.appService.configurations).subscribe((configurations) => {
+    const configurationsSubscription = this.configurations$.subscribe((configurations) => {
       this.configurations = configurations;
       if (this.configurations.length > 0) {
         this.updateConfigurations();

--- a/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/monitors/monitors.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { AppService, Configuration } from 'src/app/app.service';
 import { Monitor, MonitorsService, Trigger } from './monitors.service';
 import { ActivatedRoute, convertToParamMap, ParamMap, RouterLink } from '@angular/router';
@@ -9,6 +9,7 @@ import { HasAccessToLinkDirective } from '../../components/has-access-to-link.di
 import { FormsModule } from '@angular/forms';
 import { QuickSubmitFormDirective } from '../../components/quick-submit-form.directive';
 import { ToDateDirective } from '../../components/to-date.directive';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-monitors',
@@ -30,16 +31,14 @@ export class MonitorsComponent implements OnInit, OnDestroy {
   protected destinations: string[] = [];
   protected eventTypes: string[] = [];
   protected totalRaised: number = 0;
-  protected configurations: Configuration[] = this.appService.configurations;
+  protected configurations: Configuration[] = [];
 
   private routeQueryParams: ParamMap = convertToParamMap({});
   private subscriptions: Subscription = new Subscription();
 
-  constructor(
-    private route: ActivatedRoute,
-    private appService: AppService,
-    private monitorsService: MonitorsService,
-  ) {}
+  private route: ActivatedRoute = inject(ActivatedRoute);
+  private appService: AppService = inject(AppService);
+  private monitorsService: MonitorsService = inject(MonitorsService);
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe((parameters) => {
@@ -48,8 +47,8 @@ export class MonitorsComponent implements OnInit, OnDestroy {
         this.updateConfigurations();
       }
     });
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
+    const configurationsSubscription = toObservable(this.appService.configurations).subscribe((configurations) => {
+      this.configurations = configurations;
       if (this.configurations.length > 0) {
         this.updateConfigurations();
       }

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.component.html
@@ -32,7 +32,7 @@
               <label class="col-sm-3 control-label">Configuration</label>
               <div class="col-sm-9">
                 <select class="form-control" name="configuration" [(ngModel)]="selectedConfiguration">
-                  @for (config of configurations; track config.name) {
+                  @for (config of configurations(); track config.name) {
                     <option [ngValue]="config.name">
                       {{ config.name }}
                     </option>
@@ -50,7 +50,7 @@
                   [disabled]="selectedConfiguration === ''"
                 >
                   @for (
-                    adapter of adapters | configurationFilter: selectedConfiguration | withJavaListener;
+                    adapter of adapters() | configurationFilter: selectedConfiguration | withJavaListener;
                     track adapter.name
                   ) {
                     <option [ngValue]="adapter">

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add-edit-parent.ts
@@ -1,5 +1,6 @@
-import { Adapter, Configuration } from 'src/app/app.service';
+import { Adapter, AppService, Configuration } from 'src/app/app.service';
 import { JobForm } from './scheduler.service';
+import { inject, Signal } from '@angular/core';
 
 interface StateItem {
   type: string;
@@ -22,8 +23,10 @@ export class SchedulerAddEditParent {
     locker: false,
     lockkey: '',
   };
-  protected configurations: Configuration[] = [];
-  protected adapters: Record<string, Adapter> = {};
+
+  private readonly appService: AppService = inject(AppService);
+  protected configurations: Signal<Configuration[]> = this.appService.configurations;
+  protected adapters: Signal<Record<string, Adapter>> = this.appService.adapters;
 
   reset(): void {
     this.form = {

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add/scheduler-add.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-add/scheduler-add.component.ts
@@ -1,9 +1,8 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SchedulerAddEditParent } from '../scheduler-add-edit-parent';
-import { AppService, ServerErrorResponse } from 'src/app/app.service';
+import { ServerErrorResponse } from 'src/app/app.service';
 import { SchedulerService } from '../scheduler.service';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Subscription } from 'rxjs';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap';
 
 import { RouterLink } from '@angular/router';
@@ -29,32 +28,11 @@ import { MonacoEditorComponent } from '../../../components/monaco-editor/monaco-
   templateUrl: '../scheduler-add-edit-parent.component.html',
   styleUrls: ['./scheduler-add.component.scss'],
 })
-export class SchedulerAddComponent extends SchedulerAddEditParent implements OnInit, OnDestroy {
-  private subscriptions: Subscription = new Subscription();
+export class SchedulerAddComponent extends SchedulerAddEditParent {
+  private readonly schedulerService: SchedulerService = inject(SchedulerService);
 
-  constructor(
-    private appService: AppService,
-    private schedulerService: SchedulerService,
-  ) {
+  constructor() {
     super();
-  }
-
-  ngOnInit(): void {
-    this.configurations = this.appService.configurations;
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-    });
-    this.subscriptions.add(configurationsSubscription);
-
-    this.adapters = this.appService.adapters;
-    const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.adapters = this.appService.adapters;
-    });
-    this.subscriptions.add(adaptersSubscription);
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
   }
 
   submit(): void {

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-edit/scheduler-edit.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-edit/scheduler-edit.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { SchedulerAddEditParent } from '../scheduler-add-edit-parent';
-import { AppService } from 'src/app/app.service';
 import { SchedulerService } from '../scheduler.service';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -33,30 +32,13 @@ export class SchedulerEditComponent extends SchedulerAddEditParent implements On
 
   private groupName = '';
   private jobName = '';
-  private subscriptions: Subscription = new Subscription();
+  private routeSubscription: Subscription | null = null;
 
-  constructor(
-    private route: ActivatedRoute,
-    private appService: AppService,
-    private schedulerService: SchedulerService,
-  ) {
-    super();
-  }
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly schedulerService: SchedulerService = inject(SchedulerService);
 
   ngOnInit(): void {
-    this.configurations = this.appService.configurations;
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.configurations = this.appService.configurations;
-    });
-    this.subscriptions.add(configurationsSubscription);
-
-    this.adapters = this.appService.adapters;
-    const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.adapters = this.appService.adapters;
-    });
-    this.subscriptions.add(adaptersSubscription);
-
-    this.route.paramMap.subscribe((parameters) => {
+    this.routeSubscription = this.route.paramMap.subscribe((parameters) => {
       this.groupName = parameters.get('group')!;
       this.jobName = parameters.get('name')!;
 
@@ -79,7 +61,7 @@ export class SchedulerEditComponent extends SchedulerAddEditParent implements On
   }
 
   ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
+    this.routeSubscription?.unsubscribe();
   }
 
   submit(): void {

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-edit/scheduler-edit.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler-edit/scheduler-edit.component.ts
@@ -47,7 +47,7 @@ export class SchedulerEditComponent extends SchedulerAddEditParent implements On
         this.form = {
           name: data.name,
           group: data.group,
-          adapter: Object.values(this.adapters).find((adapter) => adapter.name === data.adapter) ?? null,
+          adapter: Object.values(this.adapters()).find((adapter) => adapter.name === data.adapter) ?? null,
           listener: data.listener,
           cron: data.triggers[0].cronExpression || '',
           interval: data.triggers[0].repeatInterval || '',

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.html
@@ -3,7 +3,7 @@
     <div class="col-lg-12" [hidden]="!scheduler.name">
       <div class="ibox float-e-margins">
         <div class="ibox-title">
-          @if (databaseSchedulesEnabled) {
+          @if (databaseSchedulesEnabled()) {
             <div class="pull-right">
               <button routerLink="new" class="btn btn-xs btn-info pull-right" type="button">
                 <i class="fa fa-plus-circle" aria-hidden="true"></i>

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.ts
@@ -83,7 +83,6 @@ export class SchedulerComponent implements OnInit, OnDestroy {
   protected searchFilter: string = '';
   protected refreshing: boolean = false;
   protected databaseSchedulesEnabled: Signal<boolean> = computed(
-    // eslint-disable-next-line unicorn/consistent-function-scoping
     () => this.appService.appConstants()['loadDatabaseSchedules.active'] === 'true',
   );
   protected jobShowContent: Record<keyof typeof this.jobGroups, boolean> = {};

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, OnDestroy, OnInit, Signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AppService, Message } from 'src/app/app.service';
 import { PollerService } from 'src/app/services/poller.service';
@@ -82,7 +82,10 @@ export class SchedulerComponent implements OnInit, OnDestroy {
   };
   protected searchFilter: string = '';
   protected refreshing: boolean = false;
-  protected databaseSchedulesEnabled: boolean = this.appService.databaseSchedulesEnabled;
+  protected databaseSchedulesEnabled: Signal<boolean> = computed(
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    () => this.appService.appConstants()['loadDatabaseSchedules.active'] === 'true',
+  );
   protected jobShowContent: Record<keyof typeof this.jobGroups, boolean> = {};
   protected selectedJobGroup: string = 'All';
 
@@ -119,10 +122,6 @@ export class SchedulerComponent implements OnInit, OnDestroy {
       },
       5000,
     );
-
-    this.appService.databaseSchedulesEnabled$.subscribe(() => {
-      this.databaseSchedulesEnabled = this.appService.databaseSchedulesEnabled;
-    });
   }
 
   ngOnDestroy(): void {

--- a/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/scheduler/scheduler.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Adapter, AppService } from 'src/app/app.service';
 
@@ -38,10 +38,8 @@ interface JobResponse extends Job {
   providedIn: 'root',
 })
 export class SchedulerService {
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
 
   getJob(group: string, jobName: string): Observable<JobResponse> {
     return this.http.get<JobResponse>(`${this.appService.absoluteApiPath}schedules/${group}/jobs/${jobName}`);

--- a/console/frontend/src/main/frontend/src/app/views/security-items/security-items.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/security-items/security-items.component.ts
@@ -38,7 +38,7 @@ export class SecurityItemsComponent implements OnInit {
   private readonly securityItemsService: SecurityItemsService = inject(SecurityItemsService);
 
   ngOnInit(): void {
-    for (const adapter of Object.values(this.appService.adapters)) {
+    for (const adapter of Object.values(this.appService.adapters())) {
       if (adapter.pipes) {
         for (const p in adapter.pipes) {
           const pipe: Pipe = adapter.pipes[p];

--- a/console/frontend/src/main/frontend/src/app/views/status/configuration-summary/configuration-summary.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/configuration-summary/configuration-summary.component.html
@@ -17,6 +17,8 @@
   <div class="ibox-content">
     <div class="row">
       <div class="col-md-5">
+        @let adapterSummary = adapterSummarySignal();
+        @let receiverSummary = receiverSummarySignal();
         <table class="table">
           <thead>
             <tr>
@@ -94,6 +96,7 @@
         </table>
       </div>
       <div class="col-md-4">
+        @let messageSummary = messageSummarySignal();
         <table class="table">
           <thead>
             <tr>

--- a/console/frontend/src/main/frontend/src/app/views/status/configuration-summary/configuration-summary.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/configuration-summary/configuration-summary.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, Signal } from '@angular/core';
 import { AppService, MessageSummary, Summary } from '../../../app.service';
-import { Subscription } from 'rxjs';
 import { NgClass } from '@angular/common';
 import { FlowComponent } from '../flow/flow.component';
 
@@ -10,7 +9,7 @@ import { FlowComponent } from '../flow/flow.component';
   styleUrl: './configuration-summary.component.scss',
   imports: [NgClass, FlowComponent],
 })
-export class ConfigurationSummaryComponent implements OnInit, OnDestroy {
+export class ConfigurationSummaryComponent {
   @Input({ required: true }) isConfigStubbed: Record<string, boolean> = {};
   @Input({ required: true }) isConfigReloading: Record<string, boolean> = {};
   @Input({ required: true }) isConfigAutoReloadable: Record<string, boolean> = {};
@@ -18,48 +17,8 @@ export class ConfigurationSummaryComponent implements OnInit, OnDestroy {
   @Input({ required: true }) configurationFlowDiagram: string | null = null;
   @Input({ required: true }) reloading: boolean = false;
 
-  protected adapterSummary: Summary = {
-    started: 0,
-    stopped: 0,
-    starting: 0,
-    stopping: 0,
-    exception_starting: 0,
-    exception_stopping: 0,
-    error: 0,
-  };
-  protected receiverSummary: Summary = {
-    started: 0,
-    stopped: 0,
-    starting: 0,
-    stopping: 0,
-    exception_starting: 0,
-    exception_stopping: 0,
-    error: 0,
-  };
-  protected messageSummary: MessageSummary = {
-    info: 0,
-    warn: 0,
-    error: 0,
-  };
-
-  private _subscriptions = new Subscription();
-
-  constructor(private appService: AppService) {}
-
-  ngOnInit(): void {
-    this.adapterSummary = this.appService.adapterSummary;
-    this.receiverSummary = this.appService.receiverSummary;
-    this.messageSummary = this.appService.messageSummary;
-
-    const summariesSubscription = this.appService.summaries$.subscribe(() => {
-      this.adapterSummary = this.appService.adapterSummary;
-      this.receiverSummary = this.appService.receiverSummary;
-      this.messageSummary = this.appService.messageSummary;
-    });
-    this._subscriptions.add(summariesSubscription);
-  }
-
-  ngOnDestroy(): void {
-    this._subscriptions.unsubscribe();
-  }
+  private appService: AppService = inject(AppService);
+  protected adapterSummarySignal: Signal<Summary> = this.appService.adapterSummary;
+  protected receiverSummarySignal: Signal<Summary> = this.appService.receiverSummary;
+  protected messageSummarySignal: Signal<MessageSummary> = this.appService.messageSummary;
 }

--- a/console/frontend/src/main/frontend/src/app/views/status/flow/flow.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/flow/flow.component.ts
@@ -32,10 +32,10 @@ export class FlowComponent implements OnChanges {
   protected loadInline = true;
   protected flowName = '';
 
-  private appService: AppService = inject(AppService);
-  private Misc: MiscService = inject(MiscService);
-  private statusService: StatusService = inject(StatusService);
-  private modalService: NgbModal = inject(NgbModal);
+  private readonly appService: AppService = inject(AppService);
+  private readonly Misc: MiscService = inject(MiscService);
+  private readonly statusService: StatusService = inject(StatusService);
+  private readonly modalService: NgbModal = inject(NgbModal);
 
   ngOnChanges(): void {
     if (!!this.adapter || this.configurationFlowDiagram) {

--- a/console/frontend/src/main/frontend/src/app/views/status/server-warnings/server-warnings.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/server-warnings/server-warnings.component.ts
@@ -17,7 +17,7 @@ export class ServerWarningsComponent {
   @Input({ required: true }) messageLog: Record<string, MessageLog> = {};
   @Input({ required: true }) selectedConfiguration: string = 'All';
   @Input() serverInfo: ServerInfo | null = null;
-  @Input() freeDiskSpacePercentage?: number;
+  @Input() freeDiskSpacePercentage: number | null = null;
 
   protected readonly FREE_DISK_SPACE_ALERT_THRESHOLD = 5;
   protected securityItemsService: SecurityItemsService = inject(SecurityItemsService);

--- a/console/frontend/src/main/frontend/src/app/views/status/server-warnings/server-warnings.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/server-warnings/server-warnings.component.ts
@@ -16,8 +16,8 @@ export class ServerWarningsComponent {
   @Input({ required: true }) alerts: Alert[] = [];
   @Input({ required: true }) messageLog: Record<string, MessageLog> = {};
   @Input({ required: true }) selectedConfiguration: string = 'All';
+  @Input() serverInfo: ServerInfo | null = null;
   @Input() freeDiskSpacePercentage?: number;
-  @Input() serverInfo?: ServerInfo;
 
   protected readonly FREE_DISK_SPACE_ALERT_THRESHOLD = 5;
   protected securityItemsService: SecurityItemsService = inject(SecurityItemsService);

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.html
@@ -3,7 +3,7 @@
     [alerts]="alerts()"
     [messageLog]="messageLog()"
     [selectedConfiguration]="selectedConfiguration"
-    [freeDiskSpacePercentage]="freeDiskSpacePercentage"
+    [freeDiskSpacePercentage]="freeDiskSpacePercentage()"
     [serverInfo]="serverInfo()"
   ></app-server-warnings>
 

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.html
@@ -4,7 +4,7 @@
     [messageLog]="messageLog()"
     [selectedConfiguration]="selectedConfiguration"
     [freeDiskSpacePercentage]="freeDiskSpacePercentage"
-    [serverInfo]="serverInfo"
+    [serverInfo]="serverInfo()"
   ></app-server-warnings>
 
   <div class="row">

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.html
@@ -1,7 +1,7 @@
 <div class="wrapper wrapper-content animated fadeInRight">
   <app-server-warnings
-    [alerts]="alerts"
-    [messageLog]="messageLog"
+    [alerts]="alerts()"
+    [messageLog]="messageLog()"
     [selectedConfiguration]="selectedConfiguration"
     [freeDiskSpacePercentage]="freeDiskSpacePercentage"
     [serverInfo]="serverInfo"
@@ -10,7 +10,7 @@
   <div class="row">
     <app-configuration-tab-list
       queryParamName="configuration"
-      [configurations]="configurations"
+      [configurations]="configurations()"
       [filterIAF_Util]="true"
       (selectedTabChange)="changeConfiguration($event)"
       data-cy="status__configuration-tab-list"
@@ -190,7 +190,7 @@
   <div class="row">
     <div class="col-lg-12">
       <app-configuration-messages
-        [messageLog]="messageLog"
+        [messageLog]="messageLog()"
         [selectedConfiguration]="selectedConfiguration"
       ></app-configuration-messages>
     </div>
@@ -198,7 +198,10 @@
 
   <div class="row">
     @for (
-      adapterKV of adapters | configurationFilter: selectedConfiguration : filter | searchFilter: searchText | keyvalue;
+      adapterKV of adapters()
+        | configurationFilter: selectedConfiguration : filter
+        | searchFilter: searchText
+        | keyvalue;
       track trackAdaptersByFn($index, adapterKV)
     ) {
       <div class="col-lg-12 adapters">

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -174,14 +174,14 @@ export class StatusComponent implements OnInit, OnDestroy {
 
   collapseAll(): void {
     this.loadFlowInline = true;
-    for (const adapter of Object.keys(this.adapters)) {
+    for (const adapter of Object.keys(this.adapters())) {
       this.adapterShowContent[adapter] = false;
     }
   }
 
   expandAll(): void {
     this.loadFlowInline = false;
-    for (const adapter of Object.keys(this.adapters)) {
+    for (const adapter of Object.keys(this.adapters())) {
       this.adapterShowContent[adapter] = true;
     }
   }

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -72,15 +72,11 @@ export class StatusComponent implements OnInit, OnDestroy {
     return adapters;
   });
   // eslint-disable-next-line unicorn/consistent-function-scoping
-  protected serverInfo: Signal<ServerInfo | null> = computed(() => {
-    const serverInfo = this.serverInfoService.serverInfo();
-    if (serverInfo) {
-      this.freeDiskSpacePercentage =
-        Math.round((serverInfo.fileSystem.freeSpace / serverInfo.fileSystem.totalSpace) * 1000) / 10;
-    }
-    return serverInfo;
+  protected freeDiskSpacePercentage: Signal<number | null> = computed(() => {
+    const serverInfo = this.serverInfo();
+    if (serverInfo) return Math.round((serverInfo.fileSystem.freeSpace / serverInfo.fileSystem.totalSpace) * 1000) / 10;
+    return null;
   });
-  protected freeDiskSpacePercentage?: number;
 
   private adapterName = '';
   private _subscriptions = new Subscription();
@@ -90,6 +86,8 @@ export class StatusComponent implements OnInit, OnDestroy {
   private readonly router: Router = inject(Router);
   private readonly statusService: StatusService = inject(StatusService);
   private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected serverInfo: Signal<ServerInfo | null> = this.serverInfoService.serverInfo;
   private readonly appService: AppService = inject(AppService);
   protected readonly alerts: Signal<Alert[]> = this.appService.alerts;
   protected readonly messageLog: Signal<Record<string, MessageLog>> = this.appService.messageLog;

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -50,14 +50,12 @@ export class StatusComponent implements OnInit, OnDestroy {
   protected isConfigAutoReloadable: Record<string, boolean> = {};
   protected adapterShowContent: Record<string, boolean> = {};
   protected loadFlowInline = true;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected readonly configurations: Signal<Configuration[]> = computed(() => {
     const configurations = this.appService.configurations();
     this.check4StubbedConfigs(configurations);
     this.updateConfigurationFlowDiagram(this.selectedConfiguration);
     return configurations;
   });
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected readonly adapters: Signal<Record<string, Adapter>> = computed(() => {
     const adapters = this.appService.adapters();
     if (this.hasExpendedAdaptersLoaded) {
@@ -71,7 +69,6 @@ export class StatusComponent implements OnInit, OnDestroy {
     }
     return adapters;
   });
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected freeDiskSpacePercentage: Signal<number | null> = computed(() => {
     const serverInfo = this.serverInfo();
     if (serverInfo) return Math.round((serverInfo.fileSystem.freeSpace / serverInfo.fileSystem.totalSpace) * 1000) / 10;
@@ -86,9 +83,8 @@ export class StatusComponent implements OnInit, OnDestroy {
   private readonly router: Router = inject(Router);
   private readonly statusService: StatusService = inject(StatusService);
   private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  protected serverInfo: Signal<ServerInfo | null> = this.serverInfoService.serverInfo;
   private readonly appService: AppService = inject(AppService);
+  protected serverInfo: Signal<ServerInfo | null> = this.serverInfoService.serverInfo;
   protected readonly alerts: Signal<Alert[]> = this.appService.alerts;
   protected readonly messageLog: Signal<Record<string, MessageLog>> = this.appService.messageLog;
 

--- a/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/status/status.component.ts
@@ -1,10 +1,9 @@
-import { Component, inject, OnDestroy, OnInit, TrackByFunction } from '@angular/core';
+import { Component, computed, inject, OnDestroy, OnInit, Signal, TrackByFunction } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { ConfigurationFilter, ConfigurationFilterPipe } from 'src/app/pipes/configuration-filter.pipe';
 import { StatusService } from './status.service';
 import { Adapter, AdapterStatus, Alert, AppService, Configuration, MessageLog } from 'src/app/app.service';
-import { PollerService } from 'src/app/services/poller.service';
 import { ServerInfo, ServerInfoService } from '../../services/server-info.service';
 import { KeyValue, KeyValuePipe, NgClass } from '@angular/common';
 import { ServerWarningsComponent } from './server-warnings/server-warnings.component';
@@ -42,8 +41,6 @@ export class StatusComponent implements OnInit, OnDestroy {
     stopped: true,
     warning: true,
   };
-  protected configurations: Configuration[] = [];
-  protected adapters: Record<string, Adapter> = {};
   protected searchText = '';
   protected selectedConfiguration = 'All';
   protected reloading = false;
@@ -51,10 +48,8 @@ export class StatusComponent implements OnInit, OnDestroy {
   protected isConfigStubbed: Record<string, boolean> = {};
   protected isConfigReloading: Record<string, boolean> = {};
   protected isConfigAutoReloadable: Record<string, boolean> = {};
-  protected adapterShowContent: Record<keyof typeof this.adapters, boolean> = {};
+  protected adapterShowContent: Record<string, boolean> = {};
   protected loadFlowInline = true;
-  protected alerts: Alert[] = [];
-  protected messageLog: Record<string, MessageLog> = {};
   protected serverInfo?: ServerInfo;
   protected freeDiskSpacePercentage?: number;
 
@@ -62,20 +57,45 @@ export class StatusComponent implements OnInit, OnDestroy {
   private _subscriptions = new Subscription();
   private hasExpendedAdaptersLoaded = false;
 
-  private route: ActivatedRoute = inject(ActivatedRoute);
-  private router: Router = inject(Router);
-  private statusService: StatusService = inject(StatusService);
-  private appService: AppService = inject(AppService);
-  private serverInfoService: ServerInfoService = inject(ServerInfoService);
+  private readonly route: ActivatedRoute = inject(ActivatedRoute);
+  private readonly router: Router = inject(Router);
+  private readonly statusService: StatusService = inject(StatusService);
+  private readonly serverInfoService: ServerInfoService = inject(ServerInfoService);
+  private readonly appService: AppService = inject(AppService);
+  protected readonly alerts: Signal<Alert[]> = this.appService.alerts;
+  protected readonly messageLog: Signal<Record<string, MessageLog>> = this.appService.messageLog;
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected readonly configurations: Signal<Configuration[]> = computed(() => {
+    const configurations = this.appService.configurations();
+    this.check4StubbedConfigs(configurations);
+    this.updateConfigurationFlowDiagram(this.selectedConfiguration);
+    return configurations;
+  });
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected readonly adapters: Signal<Record<string, Adapter>> = computed(() => {
+    const adapters = this.appService.adapters();
+    if (this.hasExpendedAdaptersLoaded) {
+      this.updateAdapterShownContent(adapters);
+      return adapters;
+    }
+    const adaptersList = Object.values(adapters);
+    if (adaptersList.length > 0 && 'messages' in adaptersList[0]) {
+      this.hasExpendedAdaptersLoaded = true;
+      this.updateAdapterShownContent(adapters);
+    }
+    return adapters;
+  });
 
   ngOnInit(): void {
-    this.route.fragment.subscribe((fragment) => {
+    const fragmentSubscription = this.route.fragment.subscribe((fragment) => {
       if (fragment && fragment != '' && this.adapterName == '') {
         //If the adapter param hasn't explicitly been set
         this.adapterName = fragment;
       }
     });
-    this.route.queryParamMap.subscribe((parameters) => {
+    this._subscriptions.add(fragmentSubscription);
+
+    const queryParameterSubscription = this.route.queryParamMap.subscribe((parameters) => {
       const adapterName = parameters.get('adapter');
       if (adapterName && adapterName != '' && this.adapterName == '') {
         this.adapterName = adapterName;
@@ -101,46 +121,9 @@ export class StatusComponent implements OnInit, OnDestroy {
       const configurationParameter = parameters.get('configuration');
       if (configurationParameter) this.changeConfiguration(configurationParameter);
     });
+    this._subscriptions.add(queryParameterSubscription);
 
-    this.updateConfigurationFlowDiagram(this.selectedConfiguration);
-    this.appService.appConstants$.subscribe(() => {
-      this.updateConfigurationFlowDiagram(this.selectedConfiguration);
-    });
-
-    this.check4StubbedConfigs();
     this.getFreeDiskSpacePercentage();
-    this.alerts = this.appService.alerts;
-    this.messageLog = this.appService.messageLog;
-    this.adapters = this.appService.adapters;
-
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => this.check4StubbedConfigs());
-    this._subscriptions.add(configurationsSubscription);
-
-    const alertsSubscription = this.appService.alerts$.subscribe(() => {
-      this.alerts = [...this.appService.alerts];
-    });
-    this._subscriptions.add(alertsSubscription);
-
-    const messageLogSubscription = this.appService.messageLog$.subscribe(() => {
-      this.messageLog = { ...this.appService.messageLog };
-    });
-    this._subscriptions.add(messageLogSubscription);
-
-    const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.adapters = { ...this.appService.adapters };
-
-      if (this.hasExpendedAdaptersLoaded) {
-        this.updateAdapterShownContent();
-      } else {
-        const adaptersList = Object.values(this.adapters);
-        if (adaptersList.length > 0 && 'messages' in adaptersList[0]) {
-          this.hasExpendedAdaptersLoaded = true;
-          this.updateAdapterShownContent();
-        }
-      }
-    });
-    this._subscriptions.add(adaptersSubscription);
-    this.updateAdapterShownContent();
   }
 
   ngOnDestroy(): void {
@@ -232,10 +215,8 @@ export class StatusComponent implements OnInit, OnDestroy {
     this.configurationFlowDiagram = this.statusService.getConfigurationFlowDiagramUrl(flowUrl);
   }
 
-  check4StubbedConfigs(): void {
-    this.configurations = this.appService.configurations;
-    for (const index in this.appService.configurations) {
-      const config = this.appService.configurations[index];
+  check4StubbedConfigs(configurations: Configuration[]): void {
+    for (const config of configurations) {
       this.isConfigStubbed[config.name] = config.stubbed;
       this.isConfigAutoReloadable[config.name] = config.autoreload ?? false;
       this.isConfigReloading[config.name] = config.state == 'STARTING' || config.state == 'STOPPING'; //Assume reloading when in state STARTING (LOADING) or in state STOPPING (UNLOADING)
@@ -253,8 +234,9 @@ export class StatusComponent implements OnInit, OnDestroy {
 
   // Commented out in template, so unused
   closeAlert(index: number): void {
-    this.appService.alerts.splice(index, 1);
-    this.appService.updateAlerts(this.appService.alerts);
+    const alerts = this.alerts();
+    alerts.splice(index, 1);
+    this.appService.alerts.set(alerts);
   }
 
   changeConfiguration(name: string): void {
@@ -275,7 +257,7 @@ export class StatusComponent implements OnInit, OnDestroy {
 
   private getCompiledAdapterList(): string[] {
     const compiledAdapterList: string[] = [];
-    const adapters = ConfigurationFilter(this.adapters, this.selectedConfiguration, this.filter, this.searchText);
+    const adapters = ConfigurationFilter(this.adapters(), this.selectedConfiguration, this.filter, this.searchText);
     for (const adapter of Object.values(adapters)) {
       const configuration = adapter.configuration;
       const adapterName = adapter.name;
@@ -288,12 +270,12 @@ export class StatusComponent implements OnInit, OnDestroy {
     return adapter.status == 'stopped' || (this.adapterName != '' && adapter.name == this.adapterName);
   }
 
-  private updateAdapterShownContent(): void {
-    for (const adapter in this.adapters) {
+  private updateAdapterShownContent(adapters: Record<string, Adapter>): void {
+    for (const adapter in adapters) {
       if (!this.adapterShowContent.hasOwnProperty(adapter)) {
-        this.adapterShowContent[adapter] = this.determineShowContent(this.adapters[adapter]);
+        this.adapterShowContent[adapter] = this.determineShowContent(adapters[adapter]);
 
-        if (this.adapterName === this.adapters[adapter].name) {
+        if (this.adapterName === adapters[adapter].name) {
           setTimeout(() => {
             document.querySelector(`#${this.adapterName}`)?.scrollIntoView();
           });

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.html
@@ -21,7 +21,7 @@
               <div class="col-sm-9">
                 <app-combobox
                   name="configuration"
-                  [options]="configurationOptions"
+                  [options]="configurationOptions()"
                   [(selectedOption)]="selectedConfiguration"
                   data-cy-test-pipeline="selectConfig"
                   (selectedOptionChange)="setSelectedConfiguration()"

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, computed, inject, OnInit, Signal, ViewChild } from '@angular/core';
 import { Adapter, AppService, Configuration } from 'src/app/app.service';
 import { InputFileUploadComponent } from 'src/app/components/input-file-upload/input-file-upload.component';
-import { Subscription } from 'rxjs';
 import { ComboboxComponent, Option } from '../../components/combobox/combobox.component';
 import { ConfigurationFilter } from '../../pipes/configuration-filter.pipe';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap';
@@ -55,11 +54,18 @@ type TestPipelineSession = {
     LaddaModule,
   ],
 })
-export class TestPipelineComponent implements OnInit, OnDestroy {
+export class TestPipelineComponent implements OnInit {
   @ViewChild(InputFileUploadComponent) formFile!: InputFileUploadComponent;
-  protected configurations: Configuration[] = [];
-  protected configurationOptions: Option[] = [];
-  protected adapters: Record<string, Adapter> = {};
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected configurationOptions: Signal<Option[]> = computed(() =>
+    this.configurations().map((configuration) => ({ label: configuration.name })),
+  );
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  protected adapters: Signal<Record<string, Adapter>> = computed(() => {
+    const adapters = this.appService.adapters();
+    if (this.selectedConfiguration) this.setAdapterOptions(this.selectedConfiguration, adapters);
+    return adapters;
+  });
   protected adapterOptions: Option[] = [];
   protected state: AlertState[] = [];
   protected selectedConfiguration = '';
@@ -83,43 +89,14 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
   };
 
   private file: File | null = null;
-  private subscriptions: Subscription = new Subscription();
 
   private http: HttpClient = inject(HttpClient);
-  private appService: AppService = inject(AppService);
   private webStorageService: WebStorageService = inject(WebStorageService);
+  private appService: AppService = inject(AppService);
+  protected configurations: Signal<Configuration[]> = this.appService.configurations;
 
   ngOnInit(): void {
     this.setTestPipelineSession();
-    this.setConfigurations();
-    const configurationsSubscription = this.appService.configurations$.subscribe(() => {
-      this.setConfigurations();
-    });
-    this.subscriptions.add(configurationsSubscription);
-
-    this.setAdapters();
-    const adaptersSubscription = this.appService.adapters$.subscribe(() => {
-      this.setAdapters();
-    });
-    this.subscriptions.add(adaptersSubscription);
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
-
-  private setConfigurations(): void {
-    this.configurations = this.appService.configurations;
-    this.configurationOptions = this.configurations.map((configuration) => ({
-      label: configuration.name,
-    }));
-  }
-
-  private setAdapters(): void {
-    this.adapters = this.appService.adapters;
-    if (this.selectedConfiguration) {
-      this.setAdapterOptions(this.selectedConfiguration);
-    }
   }
 
   private setTestPipelineSession(): void {
@@ -131,8 +108,8 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
     }
   }
 
-  private setAdapterOptions(selectedConfiguration: string): void {
-    const filteredAdapters = ConfigurationFilter(this.adapters, selectedConfiguration);
+  private setAdapterOptions(selectedConfiguration: string, adapters: Record<string, Adapter>): void {
+    const filteredAdapters = ConfigurationFilter(adapters, selectedConfiguration);
     this.adapterOptions = Object.entries(filteredAdapters).map(([, adapter]) => ({
       label: adapter.name,
       description: adapter.description ?? '',
@@ -250,6 +227,6 @@ export class TestPipelineComponent implements OnInit, OnDestroy {
 
   protected setSelectedConfiguration(): void {
     this.form.adapter = '';
-    this.setAdapterOptions(this.selectedConfiguration);
+    this.setAdapterOptions(this.selectedConfiguration, this.adapters());
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/test-pipeline/test-pipeline.component.ts
@@ -56,11 +56,9 @@ type TestPipelineSession = {
 })
 export class TestPipelineComponent implements OnInit {
   @ViewChild(InputFileUploadComponent) formFile!: InputFileUploadComponent;
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected configurationOptions: Signal<Option[]> = computed(() =>
     this.configurations().map((configuration) => ({ label: configuration.name })),
   );
-  // eslint-disable-next-line unicorn/consistent-function-scoping
   protected adapters: Signal<Record<string, Adapter>> = computed(() => {
     const adapters = this.appService.adapters();
     if (this.selectedConfiguration) this.setAdapterOptions(this.selectedConfiguration, adapters);

--- a/console/frontend/src/main/frontend/src/app/views/webservices/webservices.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/webservices/webservices.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { AppService } from 'src/app/app.service';
 import { ApiListener, Service, WebservicesService, Wsdl } from './webservices.service';
 
@@ -11,15 +11,13 @@ import { HasAccessToLinkDirective } from '../../components/has-access-to-link.di
   imports: [HasAccessToLinkDirective],
 })
 export class WebservicesComponent implements OnInit {
-  protected rootURL: string = this.appService.getServerPath();
   protected services: Service[] = [];
   protected apiListeners: ApiListener[] = [];
   protected wsdls: Wsdl[] = [];
 
-  constructor(
-    private appService: AppService,
-    private wsService: WebservicesService,
-  ) {}
+  private readonly wsService: WebservicesService = inject(WebservicesService);
+  private readonly appService: AppService = inject(AppService);
+  protected rootURL: string = this.appService.getServerPath();
 
   ngOnInit(): void {
     this.wsService.getWebservices().subscribe((data) => {

--- a/console/frontend/src/main/frontend/src/app/views/webservices/webservices.service.ts
+++ b/console/frontend/src/main/frontend/src/app/views/webservices/webservices.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AppService } from 'src/app/app.service';
 
@@ -32,10 +32,8 @@ interface WebServices {
   providedIn: 'root',
 })
 export class WebservicesService {
-  constructor(
-    private http: HttpClient,
-    private appService: AppService,
-  ) {}
+  private readonly http: HttpClient = inject(HttpClient);
+  private readonly appService: AppService = inject(AppService);
 
   getWebservices(): Observable<WebServices> {
     return this.http.get<WebServices>(`${this.appService.absoluteApiPath}webservices`);


### PR DESCRIPTION
This PR replaces RxJS subject/observable based state management with 
Angular's Signals wherever possible in all services, components need to have their own state management analysed on a case by case bases