### PR TITLE
Remove domain method and use annotations instead

### DIFF
--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -68,6 +68,8 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import org.frankframework.aws.AwsUtil;
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.doc.Mandatory;
 import org.frankframework.filesystem.utils.AmazonEncodingUtils;
 import org.frankframework.stream.Message;
@@ -77,8 +79,8 @@ import org.frankframework.util.StreamUtil;
 import org.frankframework.util.StringUtil;
 
 @Log4j2
+@DestinationType(Type.FILE_SYSTEM)
 public class AmazonS3FileSystem extends AbstractFileSystem<S3FileRef> implements IWritableFileSystem<S3FileRef>, ISupportsCustomFileAttributes<S3FileRef> {
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private static final String FILE_DELIMITER = "/";
 

--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -78,7 +78,7 @@ import org.frankframework.util.StringUtil;
 
 @Log4j2
 public class AmazonS3FileSystem extends AbstractFileSystem<S3FileRef> implements IWritableFileSystem<S3FileRef>, ISupportsCustomFileAttributes<S3FileRef> {
-	private final @Getter String domain = "Amazon";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private static final String FILE_DELIMITER = "/";
 

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
@@ -15,18 +15,17 @@
  */
 package org.frankframework.extensions.cmis;
 
-import lombok.Getter;
-
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.extensions.cmis.server.CmisEvent;
 import org.frankframework.extensions.cmis.server.CmisEventDispatcher;
 import org.frankframework.http.PushingListenerAdapter;
 import org.frankframework.util.EnumUtils;
 
+@DestinationType(Type.CMIS)
 public class CmisEventListener extends PushingListenerAdapter implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.CMIS;
 
 	private CmisEvent cmisEvent = null;
 

--- a/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/CmisEventListener.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Nationale-Nederlanden, 2020-2021 WeAreFrank!
+   Copyright 2019 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import org.frankframework.util.EnumUtils;
 
 public class CmisEventListener extends PushingListenerAdapter implements HasPhysicalDestination {
 
-	private final @Getter String domain = "CMIS Event";
+	private final @Getter DestinationType domain = DestinationType.CMIS;
+
 	private CmisEvent cmisEvent = null;
 
 	@Override

--- a/core/src/main/java/org/frankframework/core/DestinationType.java
+++ b/core/src/main/java/org/frankframework/core/DestinationType.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2025 WeAreFrank!
+   Copyright 2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,13 +15,24 @@
 */
 package org.frankframework.core;
 
-/**
- * Allows objects to declare that they have a physical destination.
- * This is used for instance in ShowConfiguration, to show the physical destination of receivers
- * that have one.
- *
- * @author Gerrit van Brakel
- */
-public interface HasPhysicalDestination {
-	String getPhysicalDestinationName();
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.frankframework.doc.Label;
+
+@Target(TYPE)
+@Label(name = "TYPE")
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DestinationType {
+
+	Type value();
+
+	enum Type {
+		HTTP, MQTT, JVM, ADAPTER, CMIS, KAFKA, IDIN, JDBC, JMS, MONGODB, MAIL, SAP, FILE_SYSTEM;
+	}
 }

--- a/core/src/main/java/org/frankframework/core/HasPhysicalDestination.java
+++ b/core/src/main/java/org/frankframework/core/HasPhysicalDestination.java
@@ -24,5 +24,10 @@ package org.frankframework.core;
  */
 public interface HasPhysicalDestination {
 	String getPhysicalDestinationName();
-	String getDomain();
+
+	DestinationType getDomain();
+
+	public enum DestinationType {
+		HTTP, MQTT, JVM, LOCAL, CMIS, KAFKA, IDIN, JDBC, JMS, MONGODB, MAIL, SAP, FILE_SYSTEM;
+	}
 }

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -52,6 +52,7 @@ import org.frankframework.core.Resource;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Forward;
 import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.parameters.IParameter;
@@ -99,7 +100,7 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 	public static final String MESSAGE_ID_HEADER = "Message-Id";
 	public static final String CORRELATION_ID_HEADER = "Correlation-Id";
 
-	private final @Getter String domain = "Http";
+	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private @Setter String sharedResourceRef;
 

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -44,6 +44,8 @@ import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.CanUseSharedResource;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ISenderWithParameters;
 import org.frankframework.core.ParameterException;
@@ -52,7 +54,6 @@ import org.frankframework.core.Resource;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Forward;
 import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.parameters.IParameter;
@@ -92,6 +93,7 @@ import org.frankframework.util.XmlUtils;
  * @since	7.0
  *
  */
+@DestinationType(Type.HTTP)
 @Forward(name = "*", description = "statuscode of the HTTP response")
 public abstract class AbstractHttpSender extends AbstractHttpSession implements HasPhysicalDestination, ISenderWithParameters, CanUseSharedResource<HttpSession> {
 
@@ -99,8 +101,6 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 	private static final String CONTEXT_KEY_REASON_PHRASE = "Http.ReasonPhrase";
 	public static final String MESSAGE_ID_HEADER = "Message-Id";
 	public static final String CORRELATION_ID_HEADER = "Correlation-Id";
-
-	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private @Setter String sharedResourceRef;
 

--- a/core/src/main/java/org/frankframework/http/RestListener.java
+++ b/core/src/main/java/org/frankframework/http/RestListener.java
@@ -30,6 +30,7 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.http.rest.ApiListener;
 import org.frankframework.pipes.JsonPipe;
 import org.frankframework.pipes.JsonPipe.Direction;
@@ -52,7 +53,8 @@ import org.frankframework.stream.Message;
  */
 public class RestListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
 
-	private final @Getter String domain = "Http";
+	private final @Getter DestinationType domain = DestinationType.HTTP;
+
 	private @Getter String uriPattern;
 	private @Getter String method;
 	private @Getter String etagSessionKey;

--- a/core/src/main/java/org/frankframework/http/RestListener.java
+++ b/core/src/main/java/org/frankframework/http/RestListener.java
@@ -25,12 +25,13 @@ import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.HasSpecialDefaultValues;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.http.rest.ApiListener;
 import org.frankframework.pipes.JsonPipe;
 import org.frankframework.pipes.JsonPipe.Direction;
@@ -51,9 +52,8 @@ import org.frankframework.stream.Message;
  * @author  Niels Meijer
  * @author  Gerrit van Brakel
  */
+@DestinationType(Type.HTTP)
 public class RestListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
-
-	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private @Getter String uriPattern;
 	private @Getter String method;

--- a/core/src/main/java/org/frankframework/http/WebServiceListener.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceListener.java
@@ -69,7 +69,8 @@ import org.frankframework.util.XmlBuilder;
  */
 public class WebServiceListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
 
-	private final @Getter String domain = "Http";
+	private final @Getter DestinationType domain = DestinationType.HTTP;
+
 	private @Getter boolean soap = true;
 	private @Getter String serviceNamespaceURI;
 	private SoapWrapper soapWrapper = null;

--- a/core/src/main/java/org/frankframework/http/WebServiceListener.java
+++ b/core/src/main/java/org/frankframework/http/WebServiceListener.java
@@ -33,6 +33,8 @@ import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.HasSpecialDefaultValues;
 import org.frankframework.configuration.SuppressKeys;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
@@ -67,9 +69,8 @@ import org.frankframework.util.XmlBuilder;
  * @author Jaco de Groot
  * @author Niels Meijer
  */
+@DestinationType(Type.HTTP)
 public class WebServiceListener extends PushingListenerAdapter implements HasPhysicalDestination, HasSpecialDefaultValues {
-
-	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private @Getter boolean soap = true;
 	private @Getter String serviceNamespaceURI;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -37,9 +37,10 @@ import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.SuppressKeys;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Default;
 import org.frankframework.http.AbstractHttpSender;
 import org.frankframework.http.HttpEntityType;
@@ -89,6 +90,7 @@ import org.frankframework.util.StringUtil;
  *
  * @author Niels Meijer
  */
+@DestinationType(Type.HTTP)
 public class ApiListener extends PushingListenerAdapter implements HasPhysicalDestination, ReceiverAware<Message> {
 
 	private static final Pattern VALID_URI_PATTERN_RE = Pattern.compile("([^/]\\*|\\*[^/\\n])");
@@ -98,8 +100,6 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * These are names that are never allowed as HTTP parameters, because the Frank!Framework sets these names as session variables.
 	 */
 	public static final Set<String> RESERVED_NAMES = Set.of(PipeLineSession.ORIGINAL_MESSAGE_KEY, PipeLineSession.API_PRINCIPAL_KEY, PipeLineSession.HTTP_METHOD_KEY, PipeLineSession.HTTP_REQUEST_KEY, PipeLineSession.HTTP_RESPONSE_KEY, PipeLineSession.SECURITY_HANDLER_KEY, "ClaimsSet", "allowedMethods", "headers", ApiListenerServlet.UPDATE_ETAG_CONTEXT_KEY, "uri", "remoteAddr", ApiListenerServlet.AUTHENTICATION_COOKIE_NAME, MultipartUtils.MULTIPART_ATTACHMENTS_SESSION_KEY);
-
-	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private @Getter String uriPattern;
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);

--- a/core/src/main/java/org/frankframework/http/rest/ApiListener.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListener.java
@@ -39,6 +39,7 @@ import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.configuration.SuppressKeys;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Default;
 import org.frankframework.http.AbstractHttpSender;
 import org.frankframework.http.HttpEntityType;
@@ -98,7 +99,8 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 */
 	public static final Set<String> RESERVED_NAMES = Set.of(PipeLineSession.ORIGINAL_MESSAGE_KEY, PipeLineSession.API_PRINCIPAL_KEY, PipeLineSession.HTTP_METHOD_KEY, PipeLineSession.HTTP_REQUEST_KEY, PipeLineSession.HTTP_RESPONSE_KEY, PipeLineSession.SECURITY_HANDLER_KEY, "ClaimsSet", "allowedMethods", "headers", ApiListenerServlet.UPDATE_ETAG_CONTEXT_KEY, "uri", "remoteAddr", ApiListenerServlet.AUTHENTICATION_COOKIE_NAME, MultipartUtils.MULTIPART_ATTACHMENTS_SESSION_KEY);
 
-	private final @Getter String domain = "Http";
+	private final @Getter DestinationType domain = DestinationType.HTTP;
+
 	private @Getter String uriPattern;
 	private @Getter boolean updateEtag = AppConstants.getInstance().getBoolean("api.etag.enabled", false);
 	private @Getter String operationId;

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -87,8 +87,8 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 
 	private static final List<String> IGNORE_HEADERS = List.of("connection", "transfer-encoding", "content-type", "authorization");
 
-	private final int authTTL = AppConstants.getInstance().getInt("api.auth.token-ttl", 60 * 60 * 24 * 7); //Defaults to 7 days
-	private final String corsAllowOrigin = AppConstants.getInstance().getString("api.auth.cors.allowOrigin", "*"); //Defaults to everything
+	private final int authTTL = AppConstants.getInstance().getInt("api.auth.token-ttl", 60 * 60 * 24 * 7); // Defaults to 7 days
+	private final String corsAllowOrigin = AppConstants.getInstance().getString("api.auth.cors.allowOrigin", "*"); // Defaults to everything
 	private final String corsExposeHeaders = AppConstants.getInstance().getString("api.auth.cors.exposeHeaders", "Allow, ETag, Content-Disposition");
 
 	private ApiServiceDispatcher dispatcher = null;

--- a/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
@@ -29,12 +29,13 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.FrankElement;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IXAEnabled;
 import org.frankframework.core.NameAware;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.dbms.DbmsSupportFactory;
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.dbms.JdbcException;
@@ -61,14 +62,13 @@ import org.frankframework.util.LogUtil;
  * @author  Gerrit van Brakel
  * @since 	4.1
  */
+@DestinationType(Type.JDBC)
 public class JdbcFacade implements HasPhysicalDestination, IXAEnabled, ConfigurableLifecycle, FrankElement, NameAware {
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 
 	private @Getter String name;
-
-	private final @Getter DestinationType domain = DestinationType.JDBC;
 
 	private String datasourceName = null;
 	@Getter private String authAlias = null;

--- a/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcFacade.java
@@ -34,6 +34,7 @@ import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IXAEnabled;
 import org.frankframework.core.NameAware;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.dbms.DbmsSupportFactory;
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.dbms.JdbcException;
@@ -67,7 +68,8 @@ public class JdbcFacade implements HasPhysicalDestination, IXAEnabled, Configura
 
 	private @Getter String name;
 
-	private final @Getter String domain = "JDBC";
+	private final @Getter DestinationType domain = DestinationType.JDBC;
+
 	private String datasourceName = null;
 	@Getter private String authAlias = null;
 	@Getter private String username = null;

--- a/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
@@ -20,14 +20,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Map;
 
-import lombok.Getter;
-
 import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IDataIterator;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.doc.ReferTo;
 import org.frankframework.parameters.IParameter;
@@ -42,9 +38,7 @@ import org.frankframework.util.SpringUtils;
  * @author  Gerrit van Brakel
  * @since   4.7
  */
-public abstract class JdbcIteratingPipeBase extends StringIteratorPipe implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.JDBC;
+public abstract class JdbcIteratingPipeBase extends StringIteratorPipe {
 
 	protected MixedQuerySender querySender = new MixedQuerySender();
 
@@ -134,11 +128,6 @@ public abstract class JdbcIteratingPipeBase extends StringIteratorPipe implement
 	@Override
 	public void addParameter(IParameter p) {
 		querySender.addParameter(p);
-	}
-
-	@Override
-	public String getPhysicalDestinationName() {
-		return querySender.getPhysicalDestinationName();
 	}
 
 	/** The SQL query text to be excecuted each time sendMessage() is called. When not set, the input message is taken as the query */

--- a/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcIteratingPipeBase.java
@@ -27,6 +27,7 @@ import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IDataIterator;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.doc.ReferTo;
 import org.frankframework.parameters.IParameter;
@@ -43,7 +44,8 @@ import org.frankframework.util.SpringUtils;
  */
 public abstract class JdbcIteratingPipeBase extends StringIteratorPipe implements HasPhysicalDestination {
 
-	private final @Getter String domain = "JDBC";
+	private final @Getter DestinationType domain = DestinationType.JDBC;
+
 	protected MixedQuerySender querySender = new MixedQuerySender();
 
 	protected class MixedQuerySender extends DirectQuerySender {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.messaging.Message;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.core.Adapter;
 import org.frankframework.core.HasPhysicalDestination;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.core.IListener;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ISender;
@@ -52,10 +53,10 @@ public class ConnectionOverview extends BusEndpointBase {
 			for(Adapter adapter: config.getRegisteredAdapters()) {
 				for (Receiver<?> receiver: adapter.getReceivers()) {
 					IListener<?> listener=receiver.getListener();
-					if (listener instanceof HasPhysicalDestination) {
-						String destination = ((HasPhysicalDestination)receiver.getListener()).getPhysicalDestinationName();
-						String domain = ((HasPhysicalDestination)receiver.getListener()).getDomain();
-						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain));
+					if (listener instanceof HasPhysicalDestination physicalDestination) {
+						String destination = physicalDestination.getPhysicalDestinationName();
+						DestinationType domain = physicalDestination.getDomain();
+						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain.name()));
 					}
 				}
 
@@ -65,15 +66,15 @@ public class ConnectionOverview extends BusEndpointBase {
 						ISender sender = msp.getSender();
 						if (sender instanceof HasPhysicalDestination physicalDestination) {
 							String destination = physicalDestination.getPhysicalDestinationName();
-							String domain = physicalDestination.getDomain();
-							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", domain));
+							DestinationType domain = physicalDestination.getDomain();
+							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", domain.name()));
 						}
 						if (pipe instanceof AsyncSenderWithListenerPipe slp) {
 							IListener<?> listener = slp.getListener();
 							if (listener instanceof HasPhysicalDestination physicalDestination) {
 								String destination = physicalDestination.getPhysicalDestinationName();
-								String domain = physicalDestination.getDomain();
-								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain));
+								DestinationType domain = physicalDestination.getDomain();
+								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain.name()));
 							}
 						}
 					}

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
@@ -23,12 +23,13 @@ import java.util.Map;
 
 import jakarta.annotation.security.RolesAllowed;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.messaging.Message;
 
 import org.frankframework.configuration.Configuration;
 import org.frankframework.core.Adapter;
+import org.frankframework.core.DestinationType;
 import org.frankframework.core.HasPhysicalDestination;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.core.IListener;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ISender;
@@ -55,8 +56,8 @@ public class ConnectionOverview extends BusEndpointBase {
 					IListener<?> listener=receiver.getListener();
 					if (listener instanceof HasPhysicalDestination physicalDestination) {
 						String destination = physicalDestination.getPhysicalDestinationName();
-						DestinationType domain = physicalDestination.getDomain();
-						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain.name()));
+						DestinationType type = AnnotationUtils.findAnnotation(listener.getClass(), DestinationType.class);
+						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", type.value().name()));
 					}
 				}
 
@@ -66,15 +67,15 @@ public class ConnectionOverview extends BusEndpointBase {
 						ISender sender = msp.getSender();
 						if (sender instanceof HasPhysicalDestination physicalDestination) {
 							String destination = physicalDestination.getPhysicalDestinationName();
-							DestinationType domain = physicalDestination.getDomain();
-							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", domain.name()));
+							DestinationType type = AnnotationUtils.findAnnotation(sender.getClass(), DestinationType.class);
+							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", type.value().name()));
 						}
 						if (pipe instanceof AsyncSenderWithListenerPipe slp) {
 							IListener<?> listener = slp.getListener();
 							if (listener instanceof HasPhysicalDestination physicalDestination) {
 								String destination = physicalDestination.getPhysicalDestinationName();
-								DestinationType domain = physicalDestination.getDomain();
-								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", domain.name()));
+								DestinationType type = AnnotationUtils.findAnnotation(listener.getClass(), DestinationType.class);
+								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", type.value().name()));
 							}
 						}
 					}

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/ConnectionOverview.java
@@ -54,10 +54,11 @@ public class ConnectionOverview extends BusEndpointBase {
 			for(Adapter adapter: config.getRegisteredAdapters()) {
 				for (Receiver<?> receiver: adapter.getReceivers()) {
 					IListener<?> listener=receiver.getListener();
+					DestinationType type = AnnotationUtils.findAnnotation(listener.getClass(), DestinationType.class);
+					String typeName = type != null ? type.value().name() : "-";
 					if (listener instanceof HasPhysicalDestination physicalDestination) {
 						String destination = physicalDestination.getPhysicalDestinationName();
-						DestinationType type = AnnotationUtils.findAnnotation(listener.getClass(), DestinationType.class);
-						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", type.value().name()));
+						connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", typeName));
 					}
 				}
 
@@ -68,14 +69,16 @@ public class ConnectionOverview extends BusEndpointBase {
 						if (sender instanceof HasPhysicalDestination physicalDestination) {
 							String destination = physicalDestination.getPhysicalDestinationName();
 							DestinationType type = AnnotationUtils.findAnnotation(sender.getClass(), DestinationType.class);
-							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", type.value().name()));
+							String typeName = type != null ? type.value().name() : "-";
+							connectionsIncoming.add(addToMap(adapter.getName(), destination, sender.getName(), "Outbound", typeName));
 						}
 						if (pipe instanceof AsyncSenderWithListenerPipe slp) {
 							IListener<?> listener = slp.getListener();
 							if (listener instanceof HasPhysicalDestination physicalDestination) {
 								String destination = physicalDestination.getPhysicalDestinationName();
 								DestinationType type = AnnotationUtils.findAnnotation(listener.getClass(), DestinationType.class);
-								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", type.value().name()));
+								String typeName = type != null ? type.value().name() : "-";
+								connectionsIncoming.add(addToMap(adapter.getName(), destination, listener.getName(), "Inbound", typeName));
 							}
 						}
 					}

--- a/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
+++ b/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
@@ -87,7 +87,8 @@ import org.frankframework.util.StringResolver;
  */
 public class MongoDbSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
 
-	private final @Getter String domain = "Mongo";
+	private final @Getter DestinationType domain = DestinationType.MONGODB;
+
 	public static final String PARAM_DATABASE="database";
 	public static final String PARAM_COLLECTION="collection";
 	public static final String PARAM_FILTER="filter";

--- a/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
+++ b/core/src/main/java/org/frankframework/mongodb/MongoDbSender.java
@@ -54,6 +54,8 @@ import lombok.Lombok;
 import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
@@ -85,9 +87,8 @@ import org.frankframework.util.StringResolver;
  * @author Gerrit van Brakel
  *
  */
+@DestinationType(Type.MONGODB)
 public class MongoDbSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.MONGODB;
 
 	public static final String PARAM_DATABASE="database";
 	public static final String PARAM_COLLECTION="collection";

--- a/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/Json2XmlValidator.java
@@ -43,7 +43,6 @@ import org.frankframework.align.XmlAligner;
 import org.frankframework.align.XmlTypeToJsonSchemaConverter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
-import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
@@ -70,10 +69,9 @@ import org.frankframework.xml.XmlWriter;
  *
  * @author Gerrit van Brakel
  */
-public class Json2XmlValidator extends XmlValidator implements HasPhysicalDestination {
+public class Json2XmlValidator extends XmlValidator {
 
 	public static final int READ_AHEAD_LIMIT = 1024;
-	private final @Getter String domain = "XML Schema";
 	public static final String INPUT_FORMAT_SESSION_KEY_PREFIX = "Json2XmlValidator.inputFormat ";
 
 	private @Getter boolean compactJsonArrays=true;
@@ -214,7 +212,7 @@ public class Json2XmlValidator extends XmlValidator implements HasPhysicalDestin
 	private Message determineJsonInputMessage(Message input, PipeLineSession session, boolean responseMode, DocumentFormat inputFormat) {
 		Message messageToValidate;
 		if (inputFormat == null) {
-			storeInputFormat(getOutputFormat(), input, session, responseMode); //Message is empty, but could be either XML or JSON. Look at the accept header, and if not set fall back to the default OutputFormat.
+			storeInputFormat(getOutputFormat(), input, session, responseMode); // Message is empty, but could be either XML or JSON. Look at the accept header, and if not set fall back to the default OutputFormat.
 
 			messageToValidate = new Message("{}");
 		} else {
@@ -446,26 +444,6 @@ public class Json2XmlValidator extends XmlValidator implements HasPhysicalDestin
 		XmlTypeToJsonSchemaConverter converter = new XmlTypeToJsonSchemaConverter(models, isCompactJsonArrays(), !isJsonWithRootElements(), getSchemaLocation());
 		return converter.createJsonSchema(elementName, namespace);
 	}
-
-	@Override
-	public String getPhysicalDestinationName() {
-		StringBuilder result = new StringBuilder();
-		if (StringUtils.isNotEmpty(getRoot())) {
-			result.append("request message [")
-					.append(getRoot())
-					.append("]");
-		}
-		if (StringUtils.isNotEmpty(getResponseRoot())) {
-			if (!result.isEmpty()) {
-				result.append("; ");
-			}
-			result.append("response message [")
-					.append(getResponseRoot())
-					.append("]");
-		}
-		return result.toString();
-	}
-
 
 	/** Only for JSON input: namespace of the resulting XML. Need only be specified when the namespace of root name is ambiguous in the schema */
 	public void setTargetNamespace(String targetNamespace) {

--- a/core/src/main/java/org/frankframework/receivers/FrankListener.java
+++ b/core/src/main/java/org/frankframework/receivers/FrankListener.java
@@ -32,6 +32,8 @@ import lombok.extern.log4j.Log4j2;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationAware;
 import org.frankframework.core.Adapter;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IMessageHandler;
 import org.frankframework.core.IPushingListener;
@@ -40,7 +42,6 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.RequestReplyListener;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.stream.Message;
@@ -53,11 +54,10 @@ import org.frankframework.stream.Message;
  * <br/>
  * See the {@link org.frankframework.senders.FrankSender} documentation for more information.
  */
+@DestinationType(Type.ADAPTER)
 @Category(Category.Type.BASIC)
 @Log4j2
 public class FrankListener implements RequestReplyListener, IPushingListener<Message>, HasPhysicalDestination, ServiceClient, ConfigurationAware {
-
-	private final @Getter DestinationType domain = DestinationType.JVM;
 
 	private static final ConcurrentMap<String, FrankListener> listeners = new ConcurrentHashMap<>();
 

--- a/core/src/main/java/org/frankframework/receivers/FrankListener.java
+++ b/core/src/main/java/org/frankframework/receivers/FrankListener.java
@@ -40,6 +40,7 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.RequestReplyListener;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.stream.Message;
@@ -56,9 +57,10 @@ import org.frankframework.stream.Message;
 @Log4j2
 public class FrankListener implements RequestReplyListener, IPushingListener<Message>, HasPhysicalDestination, ServiceClient, ConfigurationAware {
 
+	private final @Getter DestinationType domain = DestinationType.JVM;
+
 	private static final ConcurrentMap<String, FrankListener> listeners = new ConcurrentHashMap<>();
 
-	private final @Getter String domain = "JVM";
 	private @Setter @Getter ApplicationContext applicationContext;
 	private @Setter Configuration configuration;
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();

--- a/core/src/main/java/org/frankframework/receivers/JavaListener.java
+++ b/core/src/main/java/org/frankframework/receivers/JavaListener.java
@@ -43,6 +43,7 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.RequestReplyListener;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Mandatory;
 import org.frankframework.errormessageformatters.ErrorMessageFormatter;
@@ -77,7 +78,8 @@ import org.frankframework.util.LogUtil;
 @Category(Category.Type.BASIC)
 public class JavaListener<M> implements RequestReplyListener, IPushingListener<M>, RequestProcessor, HasPhysicalDestination, ServiceClient {
 
-	private final @Getter String domain = "JVM";
+	private final @Getter DestinationType domain = DestinationType.JVM;
+
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/core/src/main/java/org/frankframework/receivers/JavaListener.java
+++ b/core/src/main/java/org/frankframework/receivers/JavaListener.java
@@ -24,17 +24,19 @@ import java.util.Set;
 import jakarta.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 
 import nl.nn.adapterframework.dispatcher.DispatcherManagerFactory;
 import nl.nn.adapterframework.dispatcher.RequestProcessor;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IMessageHandler;
 import org.frankframework.core.IPushingListener;
@@ -43,7 +45,6 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.RequestReplyListener;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Mandatory;
 import org.frankframework.errormessageformatters.ErrorMessageFormatter;
@@ -51,7 +52,6 @@ import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.senders.IbisJavaSender;
 import org.frankframework.senders.IbisLocalSender;
 import org.frankframework.stream.Message;
-import org.frankframework.util.LogUtil;
 
 
 /**
@@ -75,12 +75,11 @@ import org.frankframework.util.LogUtil;
  * </p>
  * @author Gerrit van Brakel
  */
+@Log4j2
+@DestinationType(Type.JVM)
 @Category(Category.Type.BASIC)
 public class JavaListener<M> implements RequestReplyListener, IPushingListener<M>, RequestProcessor, HasPhysicalDestination, ServiceClient {
 
-	private final @Getter DestinationType domain = DestinationType.JVM;
-
-	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 	private @Getter @Setter ExceptionHandlingMethod onException = ExceptionHandlingMethod.RETHROW;
@@ -143,7 +142,7 @@ public class JavaListener<M> implements RequestReplyListener, IPushingListener<M
 
 	// ### RequestProcessor
 	@Override
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public String processRequest(String correlationId, String rawMessage, HashMap context) throws ListenerException {
 		try (PipeLineSession processContext = new PipeLineSession()) {
 			if (context != null) {

--- a/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
+++ b/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
@@ -260,13 +260,13 @@ public class PullingListenerContainer<M> implements IThreadCountControllable {
 								if (receiver.isOnErrorContinue()) {
 									increaseRetryIntervalAndWait(e);
 								} else {
-									receiver.exceptionThrown("exception occurred while retrieving message", e); //actually use ON_ERROR and don't just stop the receiver
+									receiver.exceptionThrown("exception occurred while retrieving message", e); // Actually use ON_ERROR and don't just stop the receiver
 									return;
 								}
 							}
 							if (rawMessage == null) {
 								if (txStatus!=null) {
-									log.trace("Rollback; raw message == null"); //Why do we do a rollback here? There is no message to process?
+									log.trace("Rollback; raw message == null"); // Why do we do a rollback here? There is no message to process?
 									txManager.rollback(txStatus);
 								}
 								return;
@@ -346,7 +346,7 @@ public class PullingListenerContainer<M> implements IThreadCountControllable {
 								if (receiver.isOnErrorContinue()) {
 									receiver.error("caught Exception processing message, will continue processing next message", e);
 								} else {
-									receiver.exceptionThrown("exception occurred while processing message", e); //actually use ON_ERROR and don't just stop the receiver
+									receiver.exceptionThrown("exception occurred while processing message", e); // Actually use ON_ERROR and don't just stop the receiver
 								}
 							}
 						}
@@ -386,7 +386,7 @@ public class PullingListenerContainer<M> implements IThreadCountControllable {
 						receiver.error("Exception closing listener thread", e);
 					}
 				}
-				ThreadContext.removeStack(); //Cleanup the MDC stack that was created during message processing
+				ThreadContext.removeStack(); // Cleanup the MDC stack that was created during message processing
 			}
 		}
 

--- a/core/src/main/java/org/frankframework/senders/AbstractMailSender.java
+++ b/core/src/main/java/org/frankframework/senders/AbstractMailSender.java
@@ -41,6 +41,8 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.parameters.ParameterValue;
 import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.stream.Message;
@@ -71,6 +73,7 @@ import org.frankframework.util.XmlUtils;
  * </pre></code>
  *
  */
+@DestinationType(Type.MAIL)
 public abstract class AbstractMailSender extends AbstractSenderWithParameters {
 
 	private @Getter String authAlias;
@@ -674,7 +677,7 @@ public abstract class AbstractMailSender extends AbstractSenderWithParameters {
 	 */
 	public static class EMail {
 		private final InternetAddress emailAddress;
-		private final String type; //"cc", "to", "from", "bcc"
+		private final String type; // "cc", "to", "from", "bcc"
 
 		public EMail(String address, String name, String type) throws SenderException {
 			try {

--- a/core/src/main/java/org/frankframework/senders/CommandSender.java
+++ b/core/src/main/java/org/frankframework/senders/CommandSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2021, 2022 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class CommandSender extends AbstractSenderWithParameters {
 
 	@Override
 	public @Nonnull SenderResult sendMessage(@Nonnull Message message, @Nonnull PipeLineSession session) throws SenderException, TimeoutException {
-		List commandline;
+		List<String> commandline;
 		if (StringUtils.isNotEmpty(getCommand())) {
 			commandline = commandToList(getCommand());
 		} else {
@@ -68,7 +68,7 @@ public class CommandSender extends AbstractSenderWithParameters {
 			throw new SenderException("Could not extract parametervalues",e);
 		}
 		for(ParameterValue pv : pvl) {
-			commandline.add(pv.getValue());
+			commandline.add(pv.asStringValue());
 		}
 		return new SenderResult(ProcessUtil.executeCommand(commandline, timeout));
 	}

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -37,6 +37,8 @@ import org.frankframework.configuration.ConfigurationAware;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLine;
@@ -272,6 +274,7 @@ import org.frankframework.util.MessageUtils;
  * @ff.parameter target Determine target dynamically at runtime. If the parameter value is empty, fall back to the target configured via the attribute.
  * @ff.parameters All parameters except {@code scope} and {@code target} are copied to the {@link PipeLineSession} of the adapter called.
  */
+@DestinationType(Type.ADAPTER)
 @Forward(name = "*", description = "Exit code")
 @Category(Category.Type.BASIC)
 public class FrankSender extends AbstractSenderWithParameters implements HasPhysicalDestination, IThreadCreator, ConfigurationAware {
@@ -341,19 +344,6 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 			result.append(getTarget());
 		}
 		return result.toString();
-	}
-
-	@Override
-	public DestinationType getDomain() {
-		ParameterList pl = getParameterList();
-		if (pl.hasParameter(SCOPE_PARAM_NAME)) {
-			return DestinationType.JVM; // It could be anything?
-		} else {
-			return switch (getScope()) {
-				case ADAPTER, LISTENER -> DestinationType.LOCAL;
-				case JVM, DLL -> DestinationType.JVM;
-			};
-		}
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -344,12 +344,15 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	}
 
 	@Override
-	public String getDomain() {
+	public DestinationType getDomain() {
 		ParameterList pl = getParameterList();
 		if (pl.hasParameter(SCOPE_PARAM_NAME)) {
-			return "Dynamic";
+			return DestinationType.JVM; // It could be anything?
 		} else {
-			return getScope().name();
+			return switch (getScope()) {
+				case ADAPTER, LISTENER -> DestinationType.LOCAL;
+				case JVM, DLL -> DestinationType.JVM;
+			};
 		}
 	}
 

--- a/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
@@ -34,6 +34,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Forward;
 import org.frankframework.receivers.JavaListener;
@@ -71,7 +72,7 @@ import org.frankframework.stream.Message;
 @Category(Category.Type.ADVANCED)
 public class IbisJavaSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
 
-	private final @Getter String domain = "JVM";
+	private final @Getter DestinationType domain = DestinationType.JVM;
 
 	private @Getter String serviceName;
 	private @Getter String serviceNameSessionKey;

--- a/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisJavaSender.java
@@ -27,6 +27,8 @@ import lombok.Getter;
 import nl.nn.adapterframework.dispatcher.DispatcherManager;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ParameterException;
 import org.frankframework.core.PipeLine.ExitState;
@@ -34,7 +36,6 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Forward;
 import org.frankframework.receivers.JavaListener;
@@ -68,11 +69,10 @@ import org.frankframework.stream.Message;
  * @author  Gerrit van Brakel
  * @since   4.4.5
  */
+@DestinationType(Type.JVM)
 @Forward(name = "*", description = "Exit code")
 @Category(Category.Type.ADVANCED)
 public class IbisJavaSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.JVM;
 
 	private @Getter String serviceName;
 	private @Getter String serviceNameSessionKey;

--- a/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
@@ -39,6 +39,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Forward;
 import org.frankframework.http.WebServiceListener;
@@ -113,7 +114,7 @@ import org.frankframework.util.MessageUtils;
 @Category(Category.Type.BASIC)
 public class IbisLocalSender extends AbstractSenderWithParameters implements HasPhysicalDestination, IThreadCreator, ConfigurationAware {
 
-	private final @Getter String domain = "Local";
+	private final @Getter DestinationType domain = DestinationType.LOCAL;
 
 	private @Setter Configuration configuration;
 	private @Getter String serviceName;

--- a/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/org/frankframework/senders/IbisLocalSender.java
@@ -30,6 +30,8 @@ import lombok.Setter;
 import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationAware;
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.ParameterException;
@@ -39,7 +41,6 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Category;
 import org.frankframework.doc.Forward;
 import org.frankframework.http.WebServiceListener;
@@ -110,11 +111,10 @@ import org.frankframework.util.MessageUtils;
  * @author Gerrit van Brakel
  * @since  4.2
  */
+@DestinationType(Type.ADAPTER)
 @Forward(name = "*", description = "Exit code")
 @Category(Category.Type.BASIC)
 public class IbisLocalSender extends AbstractSenderWithParameters implements HasPhysicalDestination, IThreadCreator, ConfigurationAware {
-
-	private final @Getter DestinationType domain = DestinationType.LOCAL;
 
 	private @Setter Configuration configuration;
 	private @Getter String serviceName;

--- a/core/src/main/java/org/frankframework/senders/MailSender.java
+++ b/core/src/main/java/org/frankframework/senders/MailSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2019 Nationale-Nederlanden, 2020-2024 WeAreFrank!
+   Copyright 2013, 2019 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -105,6 +105,8 @@ import org.frankframework.util.XmlUtils;
 @Category(Category.Type.ADVANCED)
 public class MailSender extends AbstractMailSender implements HasPhysicalDestination {
 
+	private final @Getter DestinationType domain = DestinationType.MAIL;
+
 	private @Getter String smtpHost;
 	private @Getter int smtpPort=25;
 	/**
@@ -134,7 +136,7 @@ public class MailSender extends AbstractMailSender implements HasPhysicalDestina
 			properties.put("mail.smtp.user", userId);
 			properties.put("mail.smtp.password", getCredentialFactory().getPassword());
 		}
-		//Even though this is called mail.smtp.from, it actually adds the Return-Path header and does not overwrite the MAIL FROM header
+		// Even though this is called mail.smtp.from, it actually adds the Return-Path header and does not overwrite the MAIL FROM header
 		if(StringUtils.isNotEmpty(getBounceAddress())) {
 			properties.put("mail.smtp.from", getBounceAddress());
 		}
@@ -398,11 +400,6 @@ public class MailSender extends AbstractMailSender implements HasPhysicalDestina
 	@Override
 	public String getPhysicalDestinationName() {
 		return getSmtpHost() + ":" + getSmtpPort() + "; TLS=" + useSsl;
-	}
-
-	@Override
-	public String getDomain() {
-		return "SMTP";
 	}
 
 	public class MailSession extends MailSessionBase {

--- a/core/src/main/java/org/frankframework/senders/MailSender.java
+++ b/core/src/main/java/org/frankframework/senders/MailSender.java
@@ -101,11 +101,8 @@ import org.frankframework.util.XmlUtils;
  * @author Johan Verrips
  * @author Gerrit van Brakel
  */
-
 @Category(Category.Type.ADVANCED)
 public class MailSender extends AbstractMailSender implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.MAIL;
 
 	private @Getter String smtpHost;
 	private @Getter int smtpPort=25;
@@ -151,7 +148,7 @@ public class MailSender extends AbstractMailSender implements HasPhysicalDestina
 	 */
 	@Override
 	public void start() {
-		createSession(); //Test connection to SMTP host
+		createSession(); // Test connection to SMTP host
 	}
 
 	/**
@@ -280,7 +277,7 @@ public class MailSender extends AbstractMailSender implements HasPhysicalDestina
 			}
 		}
 
-		//Even though this is called EnvelopeFrom/mail.smtp.from, it actually adds the Return-Path header and does not overwrite the MAIL FROM header
+		// Even though this is called EnvelopeFrom/mail.smtp.from, it actually adds the Return-Path header and does not overwrite the MAIL FROM header
 		if (StringUtils.isNotEmpty(mailSession.getBounceAddress())) {
 			//TODO: use session.setProperty("mail.smtp.from", mailSession.getBounceAddress()); here, or do not globally share the session...
 			msg.setEnvelopeFrom(mailSession.getBounceAddress());

--- a/core/src/main/java/org/frankframework/senders/ParallelSenders.java
+++ b/core/src/main/java/org/frankframework/senders/ParallelSenders.java
@@ -146,7 +146,7 @@ public class ParallelSenders extends SenderSeries {
 	protected TaskExecutor createTaskExecutor() {
 		SimpleAsyncTaskExecutor executor = SpringUtils.createBean(getApplicationContext());
 
-		if (getMaxConcurrentThreads() > 0) { //ConcurrencyLimit defaults to NONE so only this technically limits it!
+		if (getMaxConcurrentThreads() > 0) { // ConcurrencyLimit defaults to NONE so only this technically limits it!
 			executor.setConcurrencyLimit(getMaxConcurrentThreads());
 		} else {
 			executor.setConcurrencyLimit(ConcurrencyThrottleSupport.UNBOUNDED_CONCURRENCY);

--- a/core/src/main/java/org/frankframework/senders/SendGridSender.java
+++ b/core/src/main/java/org/frankframework/senders/SendGridSender.java
@@ -247,7 +247,7 @@ public class SendGridSender extends AbstractMailSender implements HasKeystore, H
 		}
 	}
 
-	//Properties inherited from HttpSessionBase
+	// Properties inherited from HttpSessionBase
 
 	@Override
 	@ReferTo(AbstractHttpSession.class)

--- a/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
@@ -35,6 +35,7 @@ import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLine;
@@ -192,12 +193,14 @@ class FrankSenderTest {
 
 	@ParameterizedTest
 	@CsvSource({
-			"ADAPTER, false, ADAPTER",
-			"DLL, false, DLL",
+			"ADAPTER, false, LOCAL",
+			"DLL, false, JVM",
 			"JVM, false, JVM",
-			"JVM, true, Dynamic",
-			"DLL, true, Dynamic",
-			"ADAPTER, true, Dynamic",
+			"JVM, true, JVM",
+			"LISTENER, false, LOCAL",
+			"LISTENER, true, JVM",
+			"DLL, true, JVM",
+			"ADAPTER, true, JVM",
 	})
 	void getDomain(FrankSender.Scope scope, boolean scopeParam, String expected) {
 		// Arrange
@@ -208,10 +211,10 @@ class FrankSenderTest {
 		}
 
 		// Act
-		String actual = sender.getDomain();
+		DestinationType actual = sender.getDomain();
 
 		// Assert
-		assertEquals(expected, actual);
+		assertEquals(expected, actual.name());
 	}
 
 	@ParameterizedTest

--- a/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
@@ -35,7 +35,6 @@ import org.frankframework.configuration.Configuration;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.IbisManager;
 import org.frankframework.core.Adapter;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.core.IPipe;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLine;
@@ -189,32 +188,6 @@ class FrankSenderTest {
 
 		// Assert
 		assertEquals(expected, actual);
-	}
-
-	@ParameterizedTest
-	@CsvSource({
-			"ADAPTER, false, LOCAL",
-			"DLL, false, JVM",
-			"JVM, false, JVM",
-			"JVM, true, JVM",
-			"LISTENER, false, LOCAL",
-			"LISTENER, true, JVM",
-			"DLL, true, JVM",
-			"ADAPTER, true, JVM",
-	})
-	void getDomain(FrankSender.Scope scope, boolean scopeParam, String expected) {
-		// Arrange
-		FrankSender sender = new FrankSender();
-		sender.setScope(scope);
-		if (scopeParam) {
-			sender.addParameter(ParameterBuilder.create("scope", ""));
-		}
-
-		// Act
-		DestinationType actual = sender.getDomain();
-
-		// Assert
-		assertEquals(expected, actual.name());
 	}
 
 	@ParameterizedTest

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
@@ -21,12 +21,16 @@ import java.util.Iterator;
 
 import lombok.extern.log4j.Log4j2;
 
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
+
 /**
  * Baseclass for {@link IBasicFileSystem FileSystems}.
  *
  * @author Gerrit van Brakel
  */
 @Log4j2
+@DestinationType(Type.FILE_SYSTEM)
 public abstract class AbstractFileSystem<F> implements IBasicFileSystem<F> {
 	private int maxNumberOfMessagesToList=-1;
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
@@ -252,7 +252,7 @@ public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<
 	}
 
 	@Override
-	public String getDomain() {
+	public DestinationType getDomain() {
 		return getFileSystem().getDomain();
 	}
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
@@ -39,6 +39,7 @@ import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
+import org.frankframework.core.DestinationType;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IMessageBrowser;
 import org.frankframework.core.IProvidesMessageBrowsers;
@@ -47,6 +48,7 @@ import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.ProcessState;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.documentbuilder.DocumentFormat;
 import org.frankframework.documentbuilder.ObjectBuilder;
 import org.frankframework.documentbuilder.XmlDocumentBuilder;
@@ -75,6 +77,7 @@ import org.frankframework.xml.XmlWriter;
  *
  */
 @Log4j2
+@DestinationType(Type.FILE_SYSTEM)
 public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<F>> implements IPullingListener<F>, HasPhysicalDestination, IProvidesMessageBrowsers<F> {
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
@@ -249,11 +252,6 @@ public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<
 
 		log.trace("Physical destination name: [{}]", destination);
 		return destination.toString();
-	}
-
-	@Override
-	public DestinationType getDomain() {
-		return getFileSystem().getDomain();
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemPipe.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019-2024 WeAreFrank!
+   Copyright 2019-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -24,12 +24,14 @@ import jakarta.annotation.Nullable;
 import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ParameterException;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.doc.EnterpriseIntegrationPattern;
 import org.frankframework.doc.Forward;
 import org.frankframework.doc.ReferTo;
@@ -55,11 +57,12 @@ import org.frankframework.util.SpringUtils;
  *
  * @author Gerrit van Brakel
  */
+@DestinationType(Type.FILE_SYSTEM)
+@EnterpriseIntegrationPattern(EnterpriseIntegrationPattern.Type.ENDPOINT)
 @Forward(name = "fileNotFound", description = "the input file was expected to exist, but was not found")
 @Forward(name = "folderNotFound", description = "the folder does not exist")
 @Forward(name = "fileAlreadyExists", description = "a file that should have been created as new already exists, or if a file already exists when it should have been created as folder")
 @Forward(name = "folderAlreadyExists", description = "a folder is to be created that already exists.")
-@EnterpriseIntegrationPattern(EnterpriseIntegrationPattern.Type.ENDPOINT)
 public abstract class AbstractFileSystemPipe<F, FS extends IBasicFileSystem<F>> extends FixedForwardPipe implements HasPhysicalDestination {
 
 	private final FileSystemActor<F, FS> actor = new FileSystemActor<>();
@@ -129,11 +132,6 @@ public abstract class AbstractFileSystemPipe<F, FS extends IBasicFileSystem<F>> 
 	@Override
 	public String getPhysicalDestinationName() {
 		return getFileSystem().getPhysicalDestinationName();
-	}
-
-	@Override
-	public DestinationType getDomain() {
-		return getFileSystem().getDomain();
 	}
 
 	protected void setFileSystem(FS fileSystem) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemPipe.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemPipe.java
@@ -132,7 +132,7 @@ public abstract class AbstractFileSystemPipe<F, FS extends IBasicFileSystem<F>> 
 	}
 
 	@Override
-	public String getDomain() {
+	public DestinationType getDomain() {
 		return getFileSystem().getDomain();
 	}
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemSender.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemSender.java
@@ -121,7 +121,7 @@ public abstract class AbstractFileSystemSender<F, S extends IBasicFileSystem<F>>
 	}
 
 	@Override
-	public String getDomain() {
+	public DestinationType getDomain() {
 		return getFileSystem().getDomain();
 	}
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemSender.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemSender.java
@@ -20,12 +20,14 @@ import java.util.List;
 import jakarta.annotation.Nonnull;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.ParameterException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.doc.EnterpriseIntegrationPattern;
 import org.frankframework.doc.Forward;
 import org.frankframework.doc.ReferTo;
@@ -50,6 +52,7 @@ import org.frankframework.util.SpringUtils;
  *
  * @author Gerrit van Brakel
  */
+@DestinationType(Type.FILE_SYSTEM)
 @EnterpriseIntegrationPattern(EnterpriseIntegrationPattern.Type.ENDPOINT)
 @Forward(name = "fileNotFound", description = "if the input file was expected to exist, but was not found")
 @Forward(name = "folderNotFound", description = "if the folder does not exist")
@@ -118,11 +121,6 @@ public abstract class AbstractFileSystemSender<F, S extends IBasicFileSystem<F>>
 	@Override
 	public String getPhysicalDestinationName() {
 		return getFileSystem().getPhysicalDestinationName();
-	}
-
-	@Override
-	public DestinationType getDomain() {
-		return getFileSystem().getDomain();
 	}
 
 	public void setFileSystem(S fileSystem) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractMailListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractMailListener.java
@@ -146,4 +146,9 @@ public abstract class AbstractMailListener<M, A, S extends IMailFileSystem<M,A>>
 	public void setMessageType(MessageType messageType) {
 		super.setMessageType(messageType);
 	}
+
+	@Override
+	public MessageType getMessageType() {
+		return (MessageType) super.getMessageType();
+	}
 }

--- a/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
@@ -65,7 +65,7 @@ import org.frankframework.xml.SaxElementBuilder;
 
 @Log4j2
 public class ImapFileSystem extends AbstractMailFileSystem<Message, MimeBodyPart, IMAPFolder> {
-	private final @Getter String domain = "IMAP";
+	private final @Getter DestinationType domain = DestinationType.MAIL;
 
 	private @Getter String host;
 	private @Getter int port = 993;

--- a/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
@@ -57,6 +57,8 @@ import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.http.PartMessage;
 import org.frankframework.stream.MessageContext;
 import org.frankframework.util.CredentialFactory;
@@ -64,8 +66,8 @@ import org.frankframework.util.StringUtil;
 import org.frankframework.xml.SaxElementBuilder;
 
 @Log4j2
+@DestinationType(Type.MAIL)
 public class ImapFileSystem extends AbstractMailFileSystem<Message, MimeBodyPart, IMAPFolder> {
-	private final @Getter DestinationType domain = DestinationType.MAIL;
 
 	private @Getter String host;
 	private @Getter int port = 993;

--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -47,6 +47,8 @@ import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.doc.Default;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.PathMessage;
@@ -58,9 +60,9 @@ import org.frankframework.stream.PathMessage;
  *
  */
 @Log4j2
+@DestinationType(Type.FILE_SYSTEM)
 public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritableFileSystem<Path>, ISupportsCustomFileAttributes<Path> {
 	public static final String ORIGINAL_LAST_MODIFIED_TIME_ATTRIBUTE = "originalLastModifiedTime";
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter boolean createRootFolder = false;
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -60,7 +60,7 @@ import org.frankframework.stream.PathMessage;
 @Log4j2
 public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritableFileSystem<Path>, ISupportsCustomFileAttributes<Path> {
 	public static final String ORIGINAL_LAST_MODIFIED_TIME_ATTRIBUTE = "originalLastModifiedTime";
-	private final @Getter String domain = "LocalFilesystem";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter boolean createRootFolder = false;
 

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
@@ -34,6 +34,7 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.encryption.HasKeystore;
 import org.frankframework.encryption.HasTruststore;
 import org.frankframework.encryption.KeystoreType;
@@ -71,7 +72,8 @@ import org.frankframework.util.StringUtil;
  */
 @Log4j2
 public class ExchangeFileSystem extends AbstractFileSystem<MailItemId> implements HasKeystore, HasTruststore, ApplicationContextAware {
-	private final @Getter String domain = "Azure";
+	private final @Getter DestinationType domain = DestinationType.MAIL;
+
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 	private final @Getter String name = "ExchangeFileSystem";

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
@@ -34,7 +34,6 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.encryption.HasKeystore;
 import org.frankframework.encryption.HasTruststore;
 import org.frankframework.encryption.KeystoreType;
@@ -72,7 +71,6 @@ import org.frankframework.util.StringUtil;
  */
 @Log4j2
 public class ExchangeFileSystem extends AbstractFileSystem<MailItemId> implements HasKeystore, HasTruststore, ApplicationContextAware {
-	private final @Getter DestinationType domain = DestinationType.MAIL;
 
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019-2024 WeAreFrank!
+   Copyright 2019-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -34,9 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPReply;
-import org.apache.logging.log4j.Logger;
 
 import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.filesystem.FileAlreadyExistsException;
 import org.frankframework.filesystem.FileNotFoundException;
@@ -48,7 +48,6 @@ import org.frankframework.filesystem.IWritableFileSystem;
 import org.frankframework.filesystem.TypeFilter;
 import org.frankframework.stream.Message;
 import org.frankframework.stream.SerializableFileReference;
-import org.frankframework.util.LogUtil;
 
 /**
  * Implementation of FTP and FTPs FileSystem
@@ -56,12 +55,12 @@ import org.frankframework.util.LogUtil;
  * @author Daniël Meyer
  * @author Niels Meijer
  */
+@Log4j2
 public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTPFileRef> {
-	private final Logger log = LogUtil.getLogger(this);
 
-	private final @Getter String domain = "FTP";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
+
 	private String remoteDirectory = "";
-
 	private FTPClient ftpClient;
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
@@ -35,9 +35,10 @@ import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPReply;
 
-import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.filesystem.FileAlreadyExistsException;
 import org.frankframework.filesystem.FileNotFoundException;
 import org.frankframework.filesystem.FileSystemException;
@@ -56,9 +57,8 @@ import org.frankframework.stream.SerializableFileReference;
  * @author Niels Meijer
  */
 @Log4j2
+@DestinationType(Type.FILE_SYSTEM)
 public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTPFileRef> {
-
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private String remoteDirectory = "";
 	private FTPClient ftpClient;
@@ -336,7 +336,7 @@ public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTP
 
 	@Override
 	public String getCanonicalName(FTPFileRef f) {
-		return f.getName(); //Should include folder structure if known
+		return f.getName(); // Should include folder structure if known
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023-2024 WeAreFrank!
+   Copyright 2023-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ import org.frankframework.util.LogUtil;
 public class SftpFileSystem extends SftpSession implements IWritableFileSystem<SftpFileRef> {
 	private final Logger log = LogUtil.getLogger(this);
 
-	private final @Getter String domain = "FTP";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 	private String remoteDirectory = "";
 
 	private ChannelSftp ftpClient;

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -37,8 +37,8 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
 import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.SftpException;
 
-import lombok.Getter;
-
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.filesystem.FileAlreadyExistsException;
 import org.frankframework.filesystem.FileNotFoundException;
 import org.frankframework.filesystem.FileSystemException;
@@ -56,10 +56,10 @@ import org.frankframework.util.LogUtil;
  *
  * @author Niels Meijer
  */
+@DestinationType(Type.FILE_SYSTEM)
 public class SftpFileSystem extends SftpSession implements IWritableFileSystem<SftpFileRef> {
 	private final Logger log = LogUtil.getLogger(this);
 
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 	private String remoteDirectory = "";
 
 	private ChannelSftp ftpClient;
@@ -202,7 +202,7 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 				if (folder.startsWith("/")) {
 					ftpClient.cd(folder);
 				} else {
-					ftpClient.cd(pwd + "/" + folder); //Faster and more fail-safe method to ensure the target is a folder and not secretly a file
+					ftpClient.cd(pwd + "/" + folder); // Faster and more fail-safe method to ensure the target is a folder and not secretly a file
 				}
 				return true;
 			} finally {

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
@@ -57,7 +57,7 @@ import org.frankframework.util.CredentialFactory;
  */
 @Log4j2
 public class Samba1FileSystem extends AbstractFileSystem<SmbFile> implements IWritableFileSystem<SmbFile> {
-	private final @Getter String domain = "SMB";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter String share = null;
 	private @Getter String username = null;

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba1FileSystem.java
@@ -57,7 +57,6 @@ import org.frankframework.util.CredentialFactory;
  */
 @Log4j2
 public class Samba1FileSystem extends AbstractFileSystem<SmbFile> implements IWritableFileSystem<SmbFile> {
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter String share = null;
 	private @Getter String username = null;
@@ -79,8 +78,8 @@ public class Samba1FileSystem extends AbstractFileSystem<SmbFile> implements IWr
 		if(!getShare().endsWith("/"))
 			setShare(getShare()+"/");
 
-		//Setup credentials if applied, may be null.
-		//NOTE: When using NtmlPasswordAuthentication without username it returns GUEST
+		// Setup credentials if applied, may be null.
+		// NOTE: When using NtmlPasswordAuthentication without username it returns GUEST
 		CredentialFactory cf = new CredentialFactory(getAuthAlias(), getUsername(), getPassword());
 		if (StringUtils.isNotEmpty(cf.getUsername())) {
 			auth = new NtlmPasswordAuthentication(getAuthenticationDomain(), cf.getUsername(), cf.getPassword());

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
@@ -97,7 +97,6 @@ import org.frankframework.util.CredentialFactory;
  */
 @Log4j2
 public class Samba2FileSystem extends AbstractFileSystem<SmbFileRef> implements IWritableFileSystem<SmbFileRef> {
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter Samba2AuthType authType = Samba2AuthType.SPNEGO;
 	private @Getter String share = null;
@@ -440,7 +439,7 @@ public class Samba2FileSystem extends AbstractFileSystem<SmbFileRef> implements 
 
 	@Override
 	public String getCanonicalName(SmbFileRef f) {
-		return f.getName(); //Should include folder structure if known
+		return f.getName(); // Should include folder structure if known
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/smb/Samba2FileSystem.java
@@ -97,7 +97,7 @@ import org.frankframework.util.CredentialFactory;
  */
 @Log4j2
 public class Samba2FileSystem extends AbstractFileSystem<SmbFileRef> implements IWritableFileSystem<SmbFileRef> {
-	private final @Getter String domain = "SMB";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 
 	private @Getter Samba2AuthType authType = Samba2AuthType.SPNEGO;
 	private @Getter String share = null;

--- a/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
+++ b/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
@@ -59,6 +59,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.senders.AbstractSenderWithParameters;
 import org.frankframework.stream.Message;
 import org.frankframework.util.CredentialFactory;
@@ -74,7 +75,8 @@ import org.frankframework.util.StreamUtil;
 @ConfigurationWarning("NTLM authentication is unsecure and should be avoided.")
 public class WebServiceNtlmSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
 
-	private final @Getter String domain = "Http";
+	private final @Getter DestinationType domain = DestinationType.HTTP;
+
 	private String contentType = "text/xml; charset="+ StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 	private String url;
 	private int timeout = 10000;

--- a/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
+++ b/filesystem/src/main/java/org/frankframework/http/WebServiceNtlmSender.java
@@ -54,12 +54,13 @@ import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.senders.AbstractSenderWithParameters;
 import org.frankframework.stream.Message;
 import org.frankframework.util.CredentialFactory;
@@ -71,11 +72,10 @@ import org.frankframework.util.StreamUtil;
  *
  * @author  Peter Leeuwenburgh
  */
+@DestinationType(Type.HTTP)
 @Deprecated(forRemoval = true, since = "8.0")
 @ConfigurationWarning("NTLM authentication is unsecure and should be avoided.")
 public class WebServiceNtlmSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
-
-	private final @Getter DestinationType domain = DestinationType.HTTP;
 
 	private String contentType = "text/xml; charset="+ StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 	private String url;

--- a/filesystem/src/main/java/org/frankframework/receivers/DirectoryListener.java
+++ b/filesystem/src/main/java/org/frankframework/receivers/DirectoryListener.java
@@ -65,4 +65,8 @@ public class DirectoryListener extends AbstractFileSystemListener<Path, LocalFil
 		super.setMessageType(messageType);
 	}
 
+	@Override
+	public MessageType getMessageType() {
+		return (MessageType) super.getMessageType();
+	}
 }

--- a/filesystem/src/main/java/org/frankframework/receivers/FtpFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/receivers/FtpFileSystemListener.java
@@ -40,4 +40,8 @@ public class FtpFileSystemListener extends AbstractFileSystemListener<FTPFileRef
 		super.setMessageType(messageType);
 	}
 
+	@Override
+	public MessageType getMessageType() {
+		return (MessageType) super.getMessageType();
+	}
 }

--- a/filesystem/src/main/java/org/frankframework/receivers/Samba2Listener.java
+++ b/filesystem/src/main/java/org/frankframework/receivers/Samba2Listener.java
@@ -40,4 +40,8 @@ public class Samba2Listener extends AbstractFileSystemListener<SmbFileRef, Samba
 		super.setMessageType(messageType);
 	}
 
+	@Override
+	public MessageType getMessageType() {
+		return (MessageType) super.getMessageType();
+	}
 }

--- a/filesystem/src/main/java/org/frankframework/receivers/SftpFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/receivers/SftpFileSystemListener.java
@@ -40,4 +40,8 @@ public class SftpFileSystemListener extends AbstractFileSystemListener<SftpFileR
 		super.setMessageType(messageType);
 	}
 
+	@Override
+	public MessageType getMessageType() {
+		return (MessageType) super.getMessageType();
+	}
 }

--- a/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
@@ -40,7 +40,6 @@ import org.frankframework.stream.Message;
 import org.frankframework.util.LogUtil;
 
 public class MockFileSystem<M extends MockFile> extends MockFolder implements IWritableFileSystem<M>, ISupportsCustomFileAttributes<M>, ApplicationContextAware {
-	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 	protected Logger log = LogUtil.getLogger(this);
 
 	private boolean configured=false;

--- a/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
@@ -40,7 +40,7 @@ import org.frankframework.stream.Message;
 import org.frankframework.util.LogUtil;
 
 public class MockFileSystem<M extends MockFile> extends MockFolder implements IWritableFileSystem<M>, ISupportsCustomFileAttributes<M>, ApplicationContextAware {
-	private final @Getter String domain = "MockFilesystem";
+	private final @Getter DestinationType domain = DestinationType.FILE_SYSTEM;
 	protected Logger log = LogUtil.getLogger(this);
 
 	private boolean configured=false;

--- a/idin/src/main/java/org/frankframework/extensions/idin/IdinSender.java
+++ b/idin/src/main/java/org/frankframework/extensions/idin/IdinSender.java
@@ -73,7 +73,7 @@ import org.frankframework.util.XmlUtils;
  * @author Niels Meijer
  */
 public class IdinSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
-	private @Getter final String domain = "iDin";
+	private final @Getter DestinationType domain = DestinationType.IDIN;
 
 	private @Getter String merchantID = null;
 	private @Getter int merchantSubID = 0;

--- a/idin/src/main/java/org/frankframework/extensions/idin/IdinSender.java
+++ b/idin/src/main/java/org/frankframework/extensions/idin/IdinSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018 Nationale-Nederlanden, 2024 WeAreFrank!
+   Copyright 2018 Nationale-Nederlanden, 2024-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -52,10 +52,12 @@ import net.bankid.merchant.library.StatusResponse;
 import net.bankid.merchant.library.internal.DirectoryResponseBase.Issuer;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.doc.Mandatory;
 import org.frankframework.senders.AbstractSenderWithParameters;
 import org.frankframework.stream.Message;
@@ -72,8 +74,8 @@ import org.frankframework.util.XmlUtils;
  *
  * @author Niels Meijer
  */
+@DestinationType(Type.IDIN)
 public class IdinSender extends AbstractSenderWithParameters implements HasPhysicalDestination {
-	private final @Getter DestinationType domain = DestinationType.IDIN;
 
 	private @Getter String merchantID = null;
 	private @Getter int merchantSubID = 0;

--- a/messaging/src/main/java/org/frankframework/extensions/kafka/AbstractKafkaFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/kafka/AbstractKafkaFacade.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2023-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,11 +37,13 @@ import lombok.extern.log4j.Log4j2;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IConfigurable;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.lifecycle.LifecycleException;
 
 @Log4j2
 public abstract class AbstractKafkaFacade implements HasPhysicalDestination, IConfigurable {
-	private final @Getter String domain = "KAFKA";
+	private final @Getter DestinationType domain = DestinationType.KAFKA;
+
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 

--- a/messaging/src/main/java/org/frankframework/extensions/kafka/AbstractKafkaFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/kafka/AbstractKafkaFacade.java
@@ -32,17 +32,16 @@ import org.springframework.context.ApplicationContext;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IConfigurable;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.lifecycle.LifecycleException;
 
-@Log4j2
+@DestinationType(Type.KAFKA)
 public abstract class AbstractKafkaFacade implements HasPhysicalDestination, IConfigurable {
-	private final @Getter DestinationType domain = DestinationType.KAFKA;
 
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
@@ -17,17 +17,19 @@ package org.frankframework.extensions.mqtt;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.paho.client.mqttv3.MqttClient;
-import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.core.FrankElement;
-import org.frankframework.core.HasPhysicalDestination;
-import org.frankframework.core.IConfigurable;
-import org.frankframework.core.NameAware;
-import org.frankframework.core.HasPhysicalDestination.DestinationType;
-import org.frankframework.doc.Mandatory;
 import org.springframework.context.ApplicationContext;
 
 import lombok.Getter;
 import lombok.Setter;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
+import org.frankframework.core.FrankElement;
+import org.frankframework.core.HasPhysicalDestination;
+import org.frankframework.core.IConfigurable;
+import org.frankframework.core.NameAware;
+import org.frankframework.doc.Mandatory;
 
 /**
  * Requires a resource to be configured. Example {@literal resources.yml}:
@@ -49,9 +51,8 @@ import lombok.Setter;
  * Inbound and outbound messages are persisted while they are in flight to prevent data loss. The default is an in memory store, but the {@literal persistenceDirectory}
  * flag can be used to set the disk storage location.
  */
+@DestinationType(Type.MQTT)
 public abstract class MqttFacade implements HasPhysicalDestination, IConfigurable, NameAware, FrankElement {
-
-	private final @Getter DestinationType domain = DestinationType.MQTT;
 
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;

--- a/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
+++ b/messaging/src/main/java/org/frankframework/extensions/mqtt/MqttFacade.java
@@ -22,6 +22,7 @@ import org.frankframework.core.FrankElement;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IConfigurable;
 import org.frankframework.core.NameAware;
+import org.frankframework.core.HasPhysicalDestination.DestinationType;
 import org.frankframework.doc.Mandatory;
 import org.springframework.context.ApplicationContext;
 
@@ -49,7 +50,9 @@ import lombok.Setter;
  * flag can be used to set the disk storage location.
  */
 public abstract class MqttFacade implements HasPhysicalDestination, IConfigurable, NameAware, FrankElement {
-	private final @Getter String domain = "MQTT";
+
+	private final @Getter DestinationType domain = DestinationType.MQTT;
+
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 

--- a/messaging/src/main/java/org/frankframework/jms/JMSFacade.java
+++ b/messaging/src/main/java/org/frankframework/jms/JMSFacade.java
@@ -58,6 +58,8 @@ import lombok.SneakyThrows;
 
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.FrankElement;
 import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IXAEnabled;
@@ -90,6 +92,7 @@ import org.frankframework.util.XmlException;
  *
  * @author 	Gerrit van Brakel
  */
+@DestinationType(Type.JMS)
 public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankElement, NameAware, HasPhysicalDestination, IXAEnabled {
 	protected Logger log = LogUtil.getLogger(this);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
@@ -99,7 +102,6 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 
 	public static final String JMS_MESSAGECLASS_KEY = "jms.messageClass.default";
 
-	private final @Getter DestinationType domain = DestinationType.JMS;
 	private final boolean createDestination = AppConstants.getInstance().getBoolean("jms.createDestination", true);
 	private final MessageClass messageClassDefault = AppConstants.getInstance().getOrDefault(JMS_MESSAGECLASS_KEY, MessageClass.AUTO);
 	private @Getter MessageClass messageClass = messageClassDefault;

--- a/messaging/src/main/java/org/frankframework/jms/JMSFacade.java
+++ b/messaging/src/main/java/org/frankframework/jms/JMSFacade.java
@@ -99,7 +99,7 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 
 	public static final String JMS_MESSAGECLASS_KEY = "jms.messageClass.default";
 
-	private final @Getter String domain = "JMS";
+	private final @Getter DestinationType domain = DestinationType.JMS;
 	private final boolean createDestination = AppConstants.getInstance().getBoolean("jms.createDestination", true);
 	private final MessageClass messageClassDefault = AppConstants.getInstance().getOrDefault(JMS_MESSAGECLASS_KEY, MessageClass.AUTO);
 	private @Getter MessageClass messageClass = messageClassDefault;
@@ -116,7 +116,7 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 	private @Getter String authAlias;
 	private @Getter boolean lookupDestination = AppConstants.getInstance().getBoolean("jms.lookupDestination", true);
 
-	private @Getter DestinationType destinationType = DestinationType.QUEUE; // QUEUE or TOPIC
+	private @Getter JmsDestinationType destinationType = JmsDestinationType.QUEUE;
 
 	protected MessagingSource messagingSource;
 	private final Map<String,Destination> destinations = new ConcurrentHashMap<>();
@@ -204,7 +204,7 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 		TRANSIENT
 	}
 
-	public enum DestinationType {
+	public enum JmsDestinationType {
 		QUEUE,
 		TOPIC
 	}
@@ -549,14 +549,14 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 
 	@Override
 	public String getPhysicalDestinationName() {
-		StringBuilder builder = new StringBuilder(getDestinationType().toString());
+		StringBuilder builder = new StringBuilder(destinationType.toString());
 		builder.append("(").append(getDestinationName()).append(") [").append(getPhysicalDestinationShortName()).append("]");
 		if (StringUtils.isNotEmpty(getMessageSelector())) {
 			builder.append(" selector [").append(getMessageSelector()).append("]");
 		}
 
 		builder.append(" on (");
-		builder.append(destinationType == DestinationType.QUEUE ? getQueueConnectionFactoryName() : getTopicConnectionFactoryName());
+		builder.append(destinationType == JmsDestinationType.QUEUE ? getQueueConnectionFactoryName() : getTopicConnectionFactoryName());
 		builder.append(")");
 
 		return builder.toString();
@@ -808,14 +808,14 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 	}
 
 	/**
-	 * Type of the messageing destination.
+	 * Type of the messaging destination.
 	 * This function also sets the <code>useTopicFunctions</code> field,
 	 * that controls whether Topic functions are used or Queue functions.
 	 * @ff.default QUEUE
 	 */
-	public void setDestinationType(DestinationType destinationType) {
+	public void setDestinationType(JmsDestinationType destinationType) {
 		this.destinationType=destinationType;
-		useTopicFunctions = this.destinationType==DestinationType.TOPIC;
+		useTopicFunctions = this.destinationType == JmsDestinationType.TOPIC;
 	}
 
 	/**
@@ -845,7 +845,7 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 	}
 
 	/**
-	 * Used when {@link #setDestinationType destinationType} = {@link DestinationType#QUEUE QUEUE}.
+	 * Used when {@link #setDestinationType destinationType} = {@link JmsDestinationType#QUEUE QUEUE}.
 	 * The JNDI-name of the queueConnectionFactory to use to connect to a <code>queue</code> if {@link #isTransacted()} returns <code>false</code>.
 	 * The corresponding connection factory should be configured not to support XA transactions.
 	 */
@@ -854,7 +854,7 @@ public class JMSFacade extends JndiBase implements ConfigurableLifecycle, FrankE
 	}
 
 	/**
-	 * Used when {@link #setDestinationType destinationType} = {@link DestinationType#TOPIC TOPIC}.
+	 * Used when {@link #setDestinationType destinationType} = {@link JmsDestinationType#TOPIC TOPIC}.
 	 * The JNDI-name of the connection factory to use to connect to a <i>topic</i> if {@link #isTransacted()} returns <code>false</code>.
 	 * The corresponding connection factory should be configured not to support XA transactions.
 	 */

--- a/messaging/src/main/java/org/frankframework/jms/JmsTransactionalStorage.java
+++ b/messaging/src/main/java/org/frankframework/jms/JmsTransactionalStorage.java
@@ -71,7 +71,7 @@ public class JmsTransactionalStorage<S extends Serializable> extends AbstractJms
 		super();
 		setTransacted(true);
 		setPersistent(true);
-		setDestinationType(DestinationType.QUEUE);
+		setDestinationType(JmsDestinationType.QUEUE);
 	}
 
 	@Override

--- a/messaging/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
+++ b/messaging/src/main/java/org/frankframework/jms/XmlJmsBrowserSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2021, 2022 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2021-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SenderException;
 import org.frankframework.core.SenderResult;
 import org.frankframework.core.TimeoutException;
-import org.frankframework.jms.JMSFacade.DestinationType;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.senders.AbstractSenderWithParameters;
 import org.frankframework.stream.Message;
 import org.frankframework.util.EnumUtils;
@@ -97,14 +97,14 @@ public class XmlJmsBrowserSender extends AbstractSenderWithParameters {
 		String jmsRealm = null;
 		String queueConnectionFactoryName = null;
 		String destinationName = null;
-		DestinationType destinationType = null;
+		JmsDestinationType destinationType = null;
 		try {
 			queueBrowserElement = XmlUtils.buildElement(message.asString());
 			root = queueBrowserElement.getTagName();
 			jmsRealm = XmlUtils.getChildTagAsString(queueBrowserElement, "jmsRealm");
 			queueConnectionFactoryName = XmlUtils.getChildTagAsString(queueBrowserElement, "queueConnectionFactoryName");
 			destinationName = XmlUtils.getChildTagAsString(queueBrowserElement, "destinationName");
-			destinationType = EnumUtils.parse(DestinationType.class,XmlUtils.getChildTagAsString(queueBrowserElement, "destinationType"));
+			destinationType = EnumUtils.parse(JmsDestinationType.class,XmlUtils.getChildTagAsString(queueBrowserElement, "destinationType"));
 		} catch (Exception e) {
 			throw new SenderException("got exception parsing [" + message + "]", e);
 		}

--- a/messaging/src/main/java/org/frankframework/management/bus/endpoints/BrowseQueue.java
+++ b/messaging/src/main/java/org/frankframework/management/bus/endpoints/BrowseQueue.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.frankframework.core.IMessageBrowsingIterator;
 import org.frankframework.core.IMessageBrowsingIteratorItem;
 import org.frankframework.core.ListenerException;
 import org.frankframework.jms.IConnectionFactoryFactory;
-import org.frankframework.jms.JMSFacade.DestinationType;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.jms.JmsBrowser;
 import org.frankframework.jms.JmsMessageBrowserIteratorItem;
 import org.frankframework.jms.JmsRealmFactory;
@@ -83,7 +83,7 @@ public class BrowseQueue extends BusEndpointBase {
 		boolean lookupDestination = BusMessageUtils.getBooleanHeader(message, "lookupDestination", false);
 		boolean showPayload = BusMessageUtils.getBooleanHeader(message, "showPayload", false);
 		boolean rowNumbersOnly = BusMessageUtils.getBooleanHeader(message, "rowNumbersOnly", false);
-		DestinationType type = BusMessageUtils.getEnumHeader(message, "type", DestinationType.class);
+		JmsDestinationType type = BusMessageUtils.getEnumHeader(message, "type", JmsDestinationType.class);
 		if(type == null) {
 			throw new BusException("a DestinationType must be provided");
 		}
@@ -94,7 +94,7 @@ public class BrowseQueue extends BusEndpointBase {
 			@SuppressWarnings("unchecked")
 			JmsBrowser<jakarta.jms.Message> jmsBrowser = createBean(JmsBrowser.class);
 			jmsBrowser.setName("BrowseQueueAction");
-			if(type == DestinationType.QUEUE) {
+			if(type == JmsDestinationType.QUEUE) {
 				jmsBrowser.setQueueConnectionFactoryName(connectionFactory);
 			} else {
 				jmsBrowser.setTopicConnectionFactoryName(connectionFactory);

--- a/messaging/src/main/java/org/frankframework/management/bus/endpoints/SendJmsMessage.java
+++ b/messaging/src/main/java/org/frankframework/management/bus/endpoints/SendJmsMessage.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2023 WeAreFrank!
+   Copyright 2022-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.springframework.messaging.Message;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.jms.JMSFacade;
-import org.frankframework.jms.JMSFacade.DestinationType;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.jms.JmsSender;
 import org.frankframework.management.bus.ActionSelector;
 import org.frankframework.management.bus.BusAction;
@@ -58,7 +58,7 @@ public class SendJmsMessage extends BusEndpointBase {
 		JMSFacade.MessageClass messageClass = BusMessageUtils.getEnumHeader(message, "messageClass", JMSFacade.MessageClass.class, JMSFacade.MessageClass.AUTO);
 		String replyTo = BusMessageUtils.getHeader(message, "replyTo", null);
 		String messageProperty = BusMessageUtils.getHeader(message, "messageProperty", null);
-		DestinationType type = BusMessageUtils.getEnumHeader(message, "type", DestinationType.class);
+		JmsDestinationType type = BusMessageUtils.getEnumHeader(message, "type", JmsDestinationType.class);
 		if(type == null) {
 			throw new BusException("a DestinationType must be provided");
 		}
@@ -83,10 +83,10 @@ public class SendJmsMessage extends BusEndpointBase {
 		return p;
 	}
 
-	private JmsSender createJmsSender(String connectionFactory, String destination, boolean persistent, DestinationType type, String replyTo, boolean synchronous, boolean lookupDestination, JMSFacade.MessageClass messageClass) {
+	private JmsSender createJmsSender(String connectionFactory, String destination, boolean persistent, JmsDestinationType type, String replyTo, boolean synchronous, boolean lookupDestination, JMSFacade.MessageClass messageClass) {
 		JmsSender qms = createBean(JmsSender.class);
 		qms.setName("SendJmsMessageAction");
-		if(type == DestinationType.QUEUE) {
+		if(type == JmsDestinationType.QUEUE) {
 			qms.setQueueConnectionFactoryName(connectionFactory);
 		} else {
 			qms.setTopicConnectionFactoryName(connectionFactory);

--- a/messaging/src/test/java/org/frankframework/jms/JmsFacadeDocumentedEnumTest.java
+++ b/messaging/src/test/java/org/frankframework/jms/JmsFacadeDocumentedEnumTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import org.frankframework.jms.JMSFacade.AcknowledgeMode;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.jms.JMSFacade.DeliveryMode;
-import org.frankframework.jms.JMSFacade.DestinationType;
 import org.frankframework.jms.JMSFacade.SubscriberType;
 
 public class JmsFacadeDocumentedEnumTest {
@@ -17,7 +17,7 @@ public class JmsFacadeDocumentedEnumTest {
 	public void testDefaults() {
 		JMSFacade jms = new JMSFacade();
 		assertEquals(AcknowledgeMode.AUTO_ACKNOWLEDGE, jms.getAcknowledgeMode());
-		assertEquals(DestinationType.QUEUE, jms.getDestinationType());
+		assertEquals(JmsDestinationType.QUEUE, jms.getDestinationType());
 		assertEquals(SubscriberType.DURABLE, jms.getSubscriberType());
 	}
 
@@ -36,17 +36,17 @@ public class JmsFacadeDocumentedEnumTest {
 	public void testDestinationType() {
 		JMSFacade jms = new JMSFacade();
 		assertFalse(jms.isUseTopicFunctions());
-		jms.setDestinationType(DestinationType.TOPIC);
-		assertEquals(DestinationType.TOPIC, jms.getDestinationType());
+		jms.setDestinationType(JmsDestinationType.TOPIC);
+		assertEquals(JmsDestinationType.TOPIC, jms.getDestinationType());
 		assertTrue(jms.isUseTopicFunctions());
 	}
 
 	@Test
 	public void testDeliveryMode() {
 		JmsSender jms = new JmsSender();
-		assertEquals(DeliveryMode.NOT_SET, jms.getDeliveryMode()); //Default
+		assertEquals(DeliveryMode.NOT_SET, jms.getDeliveryMode()); // Default
 		jms.setDeliveryMode(DeliveryMode.PERSISTENT);
 		assertEquals(DeliveryMode.PERSISTENT, jms.getDeliveryMode());
-		assertEquals(DeliveryMode.NON_PERSISTENT, DeliveryMode.parse(1)); //Tests parsing programmatic setter
+		assertEquals(DeliveryMode.NON_PERSISTENT, DeliveryMode.parse(1)); // Tests parsing programmatic setter
 	}
 }

--- a/messaging/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseQueue.java
+++ b/messaging/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseQueue.java
@@ -8,7 +8,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.mockrunner.mock.jms.MockMessage;
 
-import org.frankframework.jms.JMSFacade.DestinationType;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.jms.JmsRealm;
 import org.frankframework.jms.JmsRealmFactory;
 import org.frankframework.jms.JmsTransactionalStorage;
@@ -50,7 +50,7 @@ public class TestBrowseQueue extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.QUEUE, BusAction.FIND);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
 		request.setHeader("destination", "testTable");
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		MockMessage mockMessage = new MockMessage();
 		mockMessage.setJMSMessageID("dummyMessageId");

--- a/messaging/src/test/java/org/frankframework/management/bus/endpoints/TestSendJmsMessage.java
+++ b/messaging/src/test/java/org/frankframework/management/bus/endpoints/TestSendJmsMessage.java
@@ -17,7 +17,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import org.frankframework.jms.JMSFacade;
-import org.frankframework.jms.JMSFacade.DestinationType;
+import org.frankframework.jms.JMSFacade.JmsDestinationType;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusTestBase;
@@ -34,6 +34,7 @@ public class TestSendJmsMessage extends BusTestBase {
 
 	protected MockRunnerConnectionFactoryFactory mockConnectionFactoryFactory;
 
+	@Override
 	@BeforeEach
 	public void setUp() throws Exception {
 		super.setUp();
@@ -45,7 +46,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		String payload = "<dummy message=\"true\" />";
 		MessageBuilder<String> request = createRequestMessage(payload, BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("destination", DUMMY_DESTINATION);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		try {
 			callAsyncGateway(request);
@@ -61,7 +62,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		String payload = "<dummy message=\"true\" />";
 		MessageBuilder<String> request = createRequestMessage(payload, BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		try {
 			callAsyncGateway(request);
@@ -94,7 +95,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		MessageBuilder<InputStream> request = createRequestMessage(payload.asInputStream(), BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
 		request.setHeader("destination", DUMMY_DESTINATION);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		mockConnectionFactoryFactory.addEchoReceiverOnQueue(DUMMY_DESTINATION);
 
@@ -116,7 +117,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		MessageBuilder<InputStream> request = createRequestMessage(payload.asInputStream(), BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
 		request.setHeader("destination", DUMMY_DESTINATION);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 		request.setHeader("messageClass", JMSFacade.MessageClass.TEXT.name());
 
 		mockConnectionFactoryFactory.addEchoReceiverOnQueue(DUMMY_DESTINATION);
@@ -143,7 +144,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage(payload, BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
 		request.setHeader("destination", DUMMY_DESTINATION);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		mockConnectionFactoryFactory.addEchoReceiverOnQueue(DUMMY_DESTINATION);
 
@@ -162,7 +163,7 @@ public class TestSendJmsMessage extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage(payload, BusTopic.QUEUE, BusAction.UPLOAD);
 		request.setHeader("connectionFactory", MockRunnerConnectionFactoryFactory.MOCK_CONNECTION_FACTORY_NAME);
 		request.setHeader("destination", DUMMY_DESTINATION);
-		request.setHeader("type", DestinationType.QUEUE.name());
+		request.setHeader("type", JmsDestinationType.QUEUE.name());
 
 		callAsyncGateway(request);
 

--- a/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020, 2022 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ import org.frankframework.util.XmlUtils;
  * @since   5.0
  */
 public abstract class SapFunctionFacade implements ISapFunctionFacade, FrankElement, NameAware {
-	private final @Getter String domain = "SAP";
+	private final @Getter DestinationType domain = DestinationType.SAP;
+
 	protected static Logger log = LogUtil.getLogger(SapFunctionFacade.class);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
@@ -94,10 +95,10 @@ public abstract class SapFunctionFacade implements ISapFunctionFacade, FrankElem
 			sapSystem.openSystem();
 			log.info("open SapSystem [{}]", sapSystem);
 
-			//Something has changed, so remove the cached templates
+			// Something has changed, so remove the cached templates
 			SapSystemDataProvider.getInstance().updateSystem(sapSystem);
 
-			if (StringUtils.isNotEmpty(getFunctionName())) { //Listeners and IdocSenders don't use a functionName
+			if (StringUtils.isNotEmpty(getFunctionName())) { // Listeners and IdocSenders don't use a functionName
 				ftemplate = getFunctionTemplate(sapSystem, getFunctionName());
 				log.debug("found JCoFunctionTemplate [{}]", ftemplate);
 				try {

--- a/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
+++ b/sap/src/main/java/org/frankframework/extensions/sap/jco3/SapFunctionFacade.java
@@ -31,6 +31,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.DestinationType;
+import org.frankframework.core.DestinationType.Type;
 import org.frankframework.core.FrankElement;
 import org.frankframework.core.NameAware;
 import org.frankframework.extensions.sap.ISapFunctionFacade;
@@ -51,8 +53,8 @@ import org.frankframework.util.XmlUtils;
  * @author  Jaco de Groot
  * @since   5.0
  */
+@DestinationType(Type.SAP)
 public abstract class SapFunctionFacade implements ISapFunctionFacade, FrankElement, NameAware {
-	private final @Getter DestinationType domain = DestinationType.SAP;
 
 	protected static Logger log = LogUtil.getLogger(SapFunctionFacade.class);
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();


### PR DESCRIPTION
At least now we consistently use the same names.
I think we should use annotation or something in the future..
With a test method scan for all listeners and senders, and see if the use the annotation.