### PR TITLE
Store test logs and Cypress results as artifact when workflow fails

### DIFF
--- a/.github/workflows/full-maven-build.yml
+++ b/.github/workflows/full-maven-build.yml
@@ -145,6 +145,20 @@ jobs:
         name: java${{ env.JDK_VERSION }}_Surefire
         path: ${{ github.workspace }}/*/target/surefire-reports/*
 
+    - name: Store Test Logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: java${{ env.JDK_VERSION }}_Logs
+        path: ${{ github.workspace }}/*/target/test-logs/*
+      
+    - name: Store Cypress Results
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: java${{ env.JDK_VERSION }}_Cypress
+        path: ${{ github.workspace }}/*/target/test-classes/e2e/cypress/**
+
     - name: Store FrankDoc XSD
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This pull request enhances the `.github/workflows/full-maven-build.yml` workflow by adding steps to store additional test-related artifacts in case of failure. These changes aim to improve debugging and troubleshooting for failed builds.

### Workflow improvements:
* Added a step to store test logs (`target/test-logs/*`) as an artifact when the workflow fails. This will help in diagnosing issues with unit tests.
* Added a step to store Cypress end-to-end test results (`target/test-classes/e2e/cypress/**`) as an artifact upon workflow failure, aiding in debugging E2E test failures.