### PR TITLE
Message store disable button when its not current action

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list-dt/storage-list-dt.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list-dt/storage-list-dt.component.html
@@ -1,8 +1,9 @@
-@if (message) {
-  <input type="checkbox" [(ngModel)]="storageService.selectedMessages[message.id]" />
-  @if (!storageService.selectedMessages[message.id]) {
+@if (message()) {
+  @let msg = message()!;
+  <input type="checkbox" [(ngModel)]="storageService.selectedMessages[msg.id]" />
+  @if (!storageService.selectedMessages[msg.id]) {
     <div>
-      <a class="btn btn-info btn-xs" type="button" [routerLink]="['messages', message.id]"
+      <a class="btn btn-info btn-xs" type="button" [routerLink]="['messages', msg.id]"
         ><i class="fa fa-file-text-o"></i> View</a
       >
       <button
@@ -10,7 +11,7 @@
         title="Download Message"
         class="btn btn-info btn-xs"
         type="button"
-        (click)="storageService.downloadMessage(message.id)"
+        (click)="storageService.downloadMessage(msg.id)"
       >
         <i class="fa fa-arrow-circle-o-down"></i> Download
       </button>
@@ -21,8 +22,8 @@
           title="Move Message to Error"
           class="btn btn-danger btn-xs"
           type="button"
-          [ladda]="message.processing"
-          (click)="moveMessage()"
+          [ladda]="msg.processing"
+          (click)="moveMessage(msg)"
         >
           <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
           Move to Error
@@ -35,8 +36,9 @@
           title="Resend Message"
           class="btn btn-warning btn-xs"
           type="button"
-          [ladda]="message.processing"
-          (click)="storageService.resendMessage(message)"
+          [ladda]="msg.processing && resendAction"
+          [disabled]="msg.processing && !resendAction"
+          (click)="resendMessage(msg)"
         >
           <i class="fa fa-repeat"></i> Resend
         </button>
@@ -46,8 +48,9 @@
           title="Delete Message"
           class="btn btn-danger btn-xs"
           type="button"
-          [ladda]="message.processing"
-          (click)="storageService.deleteMessage(message)"
+          [ladda]="msg.processing && !resendAction"
+          [disabled]="msg.processing && resendAction"
+          (click)="deleteMessage(msg)"
         >
           <i class="fa fa-times"></i> Delete
         </button>

--- a/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list-dt/storage-list-dt.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/storage/storage-list/storage-list-dt/storage-list-dt.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { PartialMessage, StorageService } from '../../storage.service';
 
 import { FormsModule } from '@angular/forms';
@@ -14,12 +14,14 @@ import { SweetalertService } from '../../../../services/sweetalert.service';
   imports: [FormsModule, RouterLink, HasAccessToLinkDirective, LaddaModule],
 })
 export class StorageListDtComponent {
-  @Input({ required: true }) message!: PartialMessage;
+  public readonly message = input<PartialMessage>();
 
-  protected storageService: StorageService = inject(StorageService);
-  private sweetAlert: SweetalertService = inject(SweetalertService);
+  protected readonly storageService: StorageService = inject(StorageService);
+  protected resendAction = false;
 
-  moveMessage(): void {
+  private readonly sweetAlert: SweetalertService = inject(SweetalertService);
+
+  moveMessage(message: PartialMessage): void {
     this.sweetAlert
       .warning({
         title: 'Move Message State',
@@ -30,8 +32,18 @@ export class StorageListDtComponent {
       })
       .then((value) => {
         if (value.isConfirmed) {
-          this.storageService.moveMessage(this.message);
+          this.storageService.moveMessage(message);
         }
       });
+  }
+
+  resendMessage(message: PartialMessage): void {
+    this.resendAction = true;
+    this.storageService.resendMessage(message);
+  }
+
+  deleteMessage(message: PartialMessage): void {
+    this.resendAction = false;
+    this.storageService.deleteMessage(message);
   }
 }


### PR DESCRIPTION
The resend or delete button will now show as disabled instead of also 
having a loading icon when the message is being processed while the 
button is not for the current action