### PR TITLE
Deprecate Message.asInputstream(charset)

### DIFF
--- a/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/AmountOfPagesPipe.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/AmountOfPagesPipe.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import com.aspose.pdf.Document;
 import com.aspose.pdf.exceptions.InvalidPasswordException;
 
+import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
@@ -60,6 +61,8 @@ public class AmountOfPagesPipe extends FixedForwardPipe {
 	 * Charset to be used to read the input message.
 	 * Defaults to the message's known charset or UTF-8 when unknown.
 	 */
+	@Deprecated(since = "9.3.0", forRemoval = true)
+	@ConfigurationWarning("Charset property will be removed in a future version. ")
 	public void setCharset(String charset){
 		this.charset = charset;
 	}

--- a/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/PdfPipe.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/PdfPipe.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
@@ -259,6 +260,8 @@ public class PdfPipe extends FixedForwardPipe {
 	 * charset to be used to decode the given input message in case the input is not binary but character stream
 	 * @ff.default UTF-8
 	 */
+	@Deprecated(since = "9.3.0", forRemoval = true)
+	@ConfigurationWarning("Charset property will be removed in a future version. ")
 	public void setCharset(String charset) {
 		this.charset = charset;
 	}

--- a/core/src/main/java/org/frankframework/http/HttpMessageEntity.java
+++ b/core/src/main/java/org/frankframework/http/HttpMessageEntity.java
@@ -101,7 +101,7 @@ public class HttpMessageEntity extends AbstractHttpEntity {
 	// size (getContentLength) and encoding (getContentEncoding) of the InputStream must match the way it is being read / sent!
 	@Override
 	public InputStream getContent() throws IOException {
-		return message.asInputStream(message.getCharset());
+		return message.asInputStream();
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
@@ -973,6 +973,8 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 	 * Charset that is used to read and write BLOBs. This assumes the blob contains character data.
 	 * If blobCharset and blobSmartGet are not set, BLOBs are returned as bytes. Before version 7.6, blobs were base64 encoded after being read to accommodate for the fact that senders need to return a String. This is no longer the case
 	 */
+	@Deprecated(since = "9.3.0", forRemoval = true)
+	@ConfigurationWarning("BlobCharset property will be removed in a future version. ")
 	public void setBlobCharset(String string) {
 		if (StringUtils.isEmpty(string)) {
 			ConfigurationWarnings.add(this, log, "setting blobCharset to empty string does not trigger base64 encoding anymore, BLOBs are returned as byte arrays. If base64 encoding is really necessary, use blobBase64Direction=encode.");

--- a/core/src/main/java/org/frankframework/pipes/Base64Pipe.java
+++ b/core/src/main/java/org/frankframework/pipes/Base64Pipe.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import lombok.Getter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
@@ -108,6 +109,8 @@ public class Base64Pipe extends FixedForwardPipe {
 	}
 
 	/** Character encoding to be used when reading input from strings for direction = encode or writing data for direction = decode. */
+	@Deprecated(since = "9.3.0", forRemoval = true)
+	@ConfigurationWarning("Charset property will be removed in a future version. ")
 	public void setCharset(String string) {
 		charset = string;
 	}


### PR DESCRIPTION
See https://github.com/frankframework/frankframework/issues/9568 for removal after deprecation.