### PR TITLE
refactor: make HttpSender use shared resource properties via getters

### DIFF
--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -228,6 +228,8 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 		if (StringUtils.isNotBlank(sharedResourceRef)) {
 			try {
 				HttpSession session = getSharedResource(sharedResourceRef);
+				log.debug("Using shared HttpSession [{}]", sharedResourceRef);
+				
 				setHttpClient(session.getHttpClient());
 				setHttpContext(session.getDefaultHttpClientContext());
 			} catch (Exception e) {

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -229,7 +229,7 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 			try {
 				HttpSession session = getSharedResource(sharedResourceRef);
 				log.debug("Using shared HttpSession [{}]", sharedResourceRef);
-				
+
 				setHttpClient(session.getHttpClient());
 				setHttpContext(session.getDefaultHttpClientContext());
 			} catch (Exception e) {

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -477,7 +477,11 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 	}
 
 	private HttpSession getSharedSession() {
-		return StringUtils.isNotBlank(sharedResourceRef) ? getSharedResource(sharedResourceRef) : null;
+		try {
+			return StringUtils.isNotBlank(sharedResourceRef) ? getSharedResource(sharedResourceRef) : null;
+		} catch (NullPointerException e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -63,6 +63,7 @@ import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.stream.Message;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.ClassUtils;
+import org.frankframework.util.CredentialFactory;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.StringUtil;
 import org.frankframework.util.TransformerPool;
@@ -226,7 +227,6 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 	public void start() {
 		if (StringUtils.isNotBlank(sharedResourceRef)) {
 			try {
-
 				HttpSession session = getSharedResource(sharedResourceRef);
 				setHttpClient(session.getHttpClient());
 				setHttpContext(session.getDefaultHttpClientContext());
@@ -472,6 +472,28 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 			return "dynamic url";
 		}
 		return getUrl();
+	}
+
+	private HttpSession getSharedSession() {
+		return StringUtils.isNotBlank(sharedResourceRef) ? getSharedResource(sharedResourceRef) : null;
+	}
+
+	@Override
+	public CredentialFactory getCredentials() {
+		HttpSession sharedSession = getSharedSession();
+		return sharedSession != null ? sharedSession.getCredentials() : super.getCredentials();
+	}
+
+	@Override
+	public String getTokenEndpoint() {
+		HttpSession sharedSession = getSharedSession();
+		return sharedSession != null ? sharedSession.getTokenEndpoint() : super.getTokenEndpoint();
+	}
+
+	@Override
+	public OauthAuthenticationMethod getOauthAuthenticationMethod() {
+		HttpSession sharedSession = getSharedSession();
+		return sharedSession != null ? sharedSession.getOauthAuthenticationMethod() : super.getOauthAuthenticationMethod();
 	}
 
 	/** URL or base of URL to be used. Expects all parts of the URL to already be encoded. */

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -477,11 +477,7 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 	}
 
 	private HttpSession getSharedSession() {
-		try {
-			return StringUtils.isNotBlank(sharedResourceRef) ? getSharedResource(sharedResourceRef) : null;
-		} catch (NullPointerException e) {
-			return null;
-		}
+		return StringUtils.isNotBlank(sharedResourceRef) ? getSharedResource(sharedResourceRef) : null;
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSender.java
@@ -163,8 +163,13 @@ public abstract class AbstractHttpSender extends AbstractHttpSession implements 
 			List<String> overriddenProperties = new ArrayList<>();
 
 			// Check if any properties are set, that will be overridden by the sharedResource
-			if (super.getCredentials() != null) overriddenProperties.add("credentials");
-			if (super.getTokenEndpoint() != null) overriddenProperties.add("tokenEndpoint");
+			if (StringUtils.isNotBlank(super.getUsername())) overriddenProperties.add("username");
+			if (StringUtils.isNotBlank(super.getPassword())) overriddenProperties.add("password");
+			if (StringUtils.isNotBlank(super.getClientAuthAlias())) overriddenProperties.add("clientAuthAlias");
+			if (StringUtils.isNotBlank(super.getAuthAlias())) overriddenProperties.add("alias");
+			if (StringUtils.isNotBlank(super.getClientId())) overriddenProperties.add("clientId");
+			if (StringUtils.isNotBlank(super.getClientSecret())) overriddenProperties.add("clientSecret");
+			if (StringUtils.isNotBlank(super.getTokenEndpoint())) overriddenProperties.add("tokenEndpoint");
 			if (super.getOauthAuthenticationMethod() != null) overriddenProperties.add("oauthMethod");
 
 			if (!overriddenProperties.isEmpty()) {

--- a/core/src/main/java/org/frankframework/http/AbstractHttpSession.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSession.java
@@ -629,8 +629,8 @@ public abstract class AbstractHttpSession implements ConfigurableLifecycle, HasK
 	 * {@link OAuthAccessTokenManager} decides if and when to refresh the access token.
 	 */
 	private void preAuthenticate(HttpClientContext clientContext) {
-		// This is only executed when an authenticator is present within the given context.
-		if (clientContext.getAttribute(AUTHENTICATION_METHOD_KEY) != null) {
+		// This is only executed when credentials are available.
+		if (getCredentials() != null && !StringUtils.isEmpty(getCredentials().getUsername())) {
 			AuthState authState = clientContext.getTargetAuthState();
 			if (authState == null) {
 				authState = new AuthState();

--- a/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
@@ -18,12 +18,10 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.protocol.HttpContext;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-
 import org.springframework.context.ApplicationContext;
 
 import org.frankframework.core.PipeLineSession;

--- a/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
@@ -103,11 +103,13 @@ public class SharedHttpSenderTest {
 
 	@Test
 	public void sharedSenderWithOverriddenPropertiesShouldLogWarning() throws Exception {
-		sender.setSharedResourceRef("dummy");
+		String mockValue = "mockValue";
+        
+        sender.setSharedResourceRef("dummy");
 
 		// set all properties that will be overridden
 		sender.setUsername("test-user");
-		sender.setPassword("test-pass");
+		sender.setPassword(mockValue);
 		sender.setClientAlias("test-client-alias");
 		sender.setAuthAlias("test-alias");
 		sender.setClientId("test-client-id");

--- a/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
@@ -123,7 +123,7 @@ public class SharedHttpSenderTest {
 			sender.configure();
 
 			// Capture the actual call
-			ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+			ArgumentCaptor<String> messageCaptor = forClass(String.class);
 			mockedWarnings.verify(() -> ConfigurationWarnings.add(eq(sender), any(), messageCaptor.capture()));
 
 			// Assert that all property names appear in the message

--- a/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
@@ -19,18 +19,18 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.protocol.HttpContext;
 
-import org.frankframework.core.SharedResource;
-
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.springframework.context.ApplicationContext;
+
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.SharedResource;
 import org.frankframework.http.AbstractHttpSender.HttpMethod;
 import org.frankframework.stream.Message;
 
-import org.springframework.context.ApplicationContext;
 
 public class SharedHttpSenderTest {
 

--- a/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
+++ b/core/src/test/java/org/frankframework/http/SharedHttpSenderTest.java
@@ -103,13 +103,11 @@ public class SharedHttpSenderTest {
 
 	@Test
 	public void sharedSenderWithOverriddenPropertiesShouldLogWarning() throws Exception {
-		String mockValue = "mockValue";
-        
-        sender.setSharedResourceRef("dummy");
+		sender.setSharedResourceRef("dummy");
 
 		// set all properties that will be overridden
 		sender.setUsername("test-user");
-		sender.setPassword(mockValue);
+		sender.setPassword("test-pass");
 		sender.setClientAlias("test-client-alias");
 		sender.setAuthAlias("test-alias");
 		sender.setClientId("test-client-id");


### PR DESCRIPTION
This refactor updates the `AbstractHttpSession` to use getters when accessing credentials, token endpoints, and authentication methods.

By switching to getters, the `AbstractHttpSender` can now override these methods to delegate to a referenced shared resource. This ensures that when a sharedResourceRef is configured, the sender uses the live authentication properties from the shared resource instead of its own local state.

Fixes:
* #9503