### PR TITLE
Add custom log.xml that sends all logs to system out with json format

### DIFF
--- a/core/src/main/resources/log4j4k8s.xml
+++ b/core/src/main/resources/log4j4k8s.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<log4j2:Configuration status="WARN" name="${ff:instance.name}" strict="true" xmlns="http://logging.apache.org/log4j/2.0/config" xmlns:log4j2="log4j-config.xsd">
+	<!-- https://logging.apache.org/log4j/2.x/manual/customloglevels.html -->
+
+
+	<!--  This is for logging with Loki in kubernetes  -->
+	<Appenders>
+		<Appender name="json-stdout" type="Console">
+			<JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json"  />
+		</Appender>
+	</Appenders>
+
+	<Loggers>
+		<Root>
+			<AppenderRef ref="json-stdout"/>
+		</Root>
+	</Loggers>
+</log4j2:Configuration>


### PR DESCRIPTION
With this config Loki can easily collect logs and make them queryable, because Loki likes the JSON format.
It can be turned on by adding the name of the `xml` file to the property `log4j.configurationFile`.

To add to overwrite an existing log config:
```properties
log4j.configurationFile=log4j4ibis.xml,log4j-leaklog.xml,log4j4k8s.xml
```
To only use this config:
```properties
log4j.configurationFile=log4j4k8s.xml
```