### PR TITLE
Speed up test execution and cleanup

### DIFF
--- a/core/src/test/java/org/frankframework/scheduler/DatabaseSchedulerTest.java
+++ b/core/src/test/java/org/frankframework/scheduler/DatabaseSchedulerTest.java
@@ -27,7 +27,7 @@ public class DatabaseSchedulerTest extends Mockito {
 	@BeforeEach
 	public void setup() throws Exception {
 		configuration = new TestConfiguration();
-		configuration.getIbisManager(); //Sets a dummy IbisManager if non is found
+		configuration.getIbisManager(); //Sets a dummy IbisManager if none is found
 
 		job = configuration.createBean();
 		job.setName("testJob");
@@ -37,7 +37,7 @@ public class DatabaseSchedulerTest extends Mockito {
 	@AfterEach
 	public void tearDown() {
 		configuration.close();
-		configuration = null; // <- force GC to cleanup!
+		configuration = null; // <- Allow GC to clean up
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/testutil/TransactionManagerType.java
+++ b/core/src/test/java/org/frankframework/testutil/TransactionManagerType.java
@@ -113,18 +113,17 @@ public enum TransactionManagerType {
 			Iterator<TestConfiguration> it = datasourceConfigurations.values().iterator();
 			while(it.hasNext()) {
 				TestConfiguration ac = it.next();
-				if(ac != null) {
-					ac.close();
-				}
 				it.remove();
+				if(ac != null) {
+					ac.closeAsync();
+				}
 			}
 		} else {
-			TestConfiguration ac = transactionManagerConfigurations.remove(this);
-			if(ac != null) {
-				ac.close();
-			}
-			if (ac != null) {
-				removePreviousTxLogFiles(ac);
+			TestConfiguration testConfiguration = transactionManagerConfigurations.remove(this);
+			if(testConfiguration != null) {
+				testConfiguration
+						.closeAsync()
+						.thenRun(() -> removePreviousTxLogFiles(testConfiguration));
 			}
 		}
 		LogManager.getLogger(this.getClass()).info("Closed transaction manager configuration context [{}]", this);


### PR DESCRIPTION
Speed up some tests by making closing of contexts async. ReceiverTest is sped up by almost 2 minutes by this change.