### PR TITLE
Batch Files with no key and no newlines

### DIFF
--- a/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
+++ b/batch/src/main/java/org/frankframework/batch/FixedPositionRecordHandlerManager.java
@@ -78,7 +78,7 @@ public class FixedPositionRecordHandlerManager extends RecordHandlerManager {
 	@Override
 	public String getFirstPartOfNextRecord(BufferedReader reader) throws IOException {
 		if (!isNewLineSeparated()) {
-			return readUpToXChars(reader, endPosition);
+			return readUpToXChars(reader, endPosition<=0 ? 1 : endPosition); // try to read at least 1 character, to be able to detect EOF
 		}
 		return super.getFirstPartOfNextRecord(reader);
 	}

--- a/batch/src/test/java/org/frankframework/batch/FixedPositionRecordHandlerManagerTest.java
+++ b/batch/src/test/java/org/frankframework/batch/FixedPositionRecordHandlerManagerTest.java
@@ -1,6 +1,7 @@
 package org.frankframework.batch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -63,13 +64,72 @@ class FixedPositionRecordHandlerManagerTest {
 
 		flow.configure(manager, managerMap, handlerMap, resulthandlerMap, null);
 
+		// first record
 		String firstPart = manager.getFirstPartOfNextRecord(reader);
 		assertEquals("abcd", firstPart);
 		assertEquals("abcd1234", manager.getFullRecord(reader, flow, firstPart));
 
+		// second record
 		firstPart = manager.getFirstPartOfNextRecord(reader);
 		assertEquals("efgh", firstPart);
 		assertEquals("efgh3456", manager.getFullRecord(reader, flow, firstPart));
+
+		// last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("pqrs", firstPart);
+		assertEquals("pqrs6789", manager.getFullRecord(reader, flow, firstPart));
+	
+		// after last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertNull(firstPart);
+	}
+
+	@Test
+	public void testRawRecordsIncompleteLast() throws ConfigurationException, IOException {
+		BufferedReader reader = new BufferedReader(new StringReader("abcd1234efgh3456pqrs67"));
+
+		FixedPositionRecordHandlerManager manager = new FixedPositionRecordHandlerManager();
+		manager.setStartPosition(2);
+		manager.setEndPosition(4);
+		manager.setNewLineSeparated(false);
+
+		RecordXmlTransformer handler = new RecordXmlTransformer();
+		handler.setName("main");
+		handler.setInputFields("2, 2, 4");
+		handler.setOutputFields("pre,key,tail");
+
+		RecordHandlingFlow flow = new RecordHandlingFlow();
+		flow.setRecordKey("*");
+		flow.setRecordHandler(handler);
+
+		Map<String,IRecordHandlerManager> managerMap = new HashMap<>();
+		managerMap.put("mgr", manager);
+
+		Map<String,IRecordHandler> handlerMap = new HashMap<>();
+		handlerMap.put("main", handler);
+
+		Map<String,IResultHandler> resulthandlerMap = new HashMap<>();
+
+		flow.configure(manager, managerMap, handlerMap, resulthandlerMap, null);
+
+		// first record
+		String firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("abcd", firstPart);
+		assertEquals("abcd1234", manager.getFullRecord(reader, flow, firstPart));
+
+		// second record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("efgh", firstPart);
+		assertEquals("efgh3456", manager.getFullRecord(reader, flow, firstPart));
+
+		// last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("pqrs", firstPart);
+		assertEquals("pqrs67", manager.getFullRecord(reader, flow, firstPart));
+	
+		// after last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertNull(firstPart);
 	}
 
 	@Test
@@ -107,6 +167,52 @@ class FixedPositionRecordHandlerManagerTest {
 		firstPart = manager.getFirstPartOfNextRecord(reader);
 		assertEquals("1234", firstPart);
 		assertEquals("1234", manager.getFullRecord(reader, flow, firstPart));
+	}
+
+	@Test
+	public void testRawRecordsNoKey() throws ConfigurationException, IOException {
+		BufferedReader reader = new BufferedReader(new StringReader("abcd1234efgh3456pqrs6789"));
+
+		FixedPositionRecordHandlerManager manager = new FixedPositionRecordHandlerManager();
+		manager.setNewLineSeparated(false);
+
+		RecordXmlTransformer handler = new RecordXmlTransformer();
+		handler.setName("main");
+		handler.setInputFields("2, 2, 4");
+		handler.setOutputFields("pre,key,tail");
+
+		RecordHandlingFlow flow = new RecordHandlingFlow();
+		flow.setRecordKey("*");
+		flow.setRecordHandler(handler);
+
+		Map<String,IRecordHandlerManager> managerMap = new HashMap<>();
+		managerMap.put("mgr", manager);
+
+		Map<String,IRecordHandler> handlerMap = new HashMap<>();
+		handlerMap.put("main", handler);
+
+		Map<String,IResultHandler> resulthandlerMap = new HashMap<>();
+
+		flow.configure(manager, managerMap, handlerMap, resulthandlerMap, null);
+
+		// first record
+		String firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("a", firstPart);
+		assertEquals("abcd1234", manager.getFullRecord(reader, flow, firstPart));
+
+		// second record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("e", firstPart);
+		assertEquals("efgh3456", manager.getFullRecord(reader, flow, firstPart));
+
+		// last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertEquals("p", firstPart);
+		assertEquals("pqrs6789", manager.getFullRecord(reader, flow, firstPart));
+	
+		// after last record
+		firstPart = manager.getFirstPartOfNextRecord(reader);
+		assertNull(firstPart);
 	}
 
 }


### PR DESCRIPTION
Solved a bug when newLineSeparated=false and no key is specified