### PR TITLE
Fix the CredentialProvider and Kubernetes module

### DIFF
--- a/credentialProvider/pom.xml
+++ b/credentialProvider/pom.xml
@@ -142,6 +142,16 @@
 						</goals>
 						<phase>package</phase>
 						<configuration>
+							<filters>
+								<filter>
+									<artifact>org.springframework:spring-web</artifact>
+									<excludes>
+										<!-- Remove unused serviceloader classes to prevent ClassNotFoundExceptions. -->
+										<exclude>META-INF/web-fragment.xml</exclude>
+										<exclude>META-INF/services/jakarta.servlet.ServletContainerInitializer</exclude>
+									</excludes>
+								</filter>
+							</filters>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<minimizeJar>true</minimizeJar>
 							<shadedArtifactAttached>true</shadedArtifactAttached>

--- a/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
+++ b/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
@@ -31,7 +31,7 @@ FileViewer.permission.rules=${credentialFactory.filesystem.root:-/dev/null} * de
 org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource,org.frankframework.credentialprovider.CredentialProvidingPropertySource
 
 # Configures the `Frank!Framework CredentialManager`, to load credentials from the `credentials.properties` file.
-credentialFactory.class=nl.nn.credentialprovider.PropertyFileCredentialFactory
+credentialFactory.class=org.frankframework.credentialprovider.KubernetesCredentialFactory,org.frankframework.credentialprovider.PropertyFileCredentialFactory
 credentialFactory.map.properties=/opt/frank/secrets/credentials.properties
 
 # Allow Frank!Framework `Web Resources` to be loaded in directly.
@@ -43,5 +43,6 @@ application.security.http.transportGuarantee=NONE
 
 # Make sure the docker image also logs everything to stdout in json format
 log4j.configurationFile=log4j4ibis.xml,log4j2stdout.xml
+
 # Ensures all logging (CredentialProvider) goes to Log4j2
 java.util.logging.manager=org.apache.logging.log4j.jul.LogManager

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -14,18 +14,20 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.frankframework</groupId>
-			<artifactId>frankframework-commons</artifactId>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-client</artifactId>
+			<version>6.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
 
+		<!-- Provided scoped dependencies -->
 		<dependency>
-			<groupId>io.fabric8</groupId>
-			<artifactId>kubernetes-client</artifactId>
-			<version>6.14.0</version>
+			<groupId>org.frankframework</groupId>
+			<artifactId>frankframework-commons</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.frankframework</groupId>
@@ -69,7 +71,6 @@
 						<phase>package</phase>
 						<configuration>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
-							<minimizeJar>true</minimizeJar>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>fatjar</shadedClassifierName>
 						</configuration>

--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesCredentialFactory.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesCredentialFactory.java
@@ -43,7 +43,7 @@ import org.frankframework.credentialprovider.util.CredentialConstants;
  *     <li>{@code credentialFactory.kubernetes.username} - the username for authenticating with the Kubernetes cluster</li>
  *     <li>{@code credentialFactory.kubernetes.password} - the password for authenticating with the Kubernetes cluster</li>
  *     <li>{@code credentialFactory.kubernetes.masterUrl} - the master URL of the Kubernetes cluster</li>
- *     <li>{@code credentialFactory.kubernetes.namespace} - the namespace from which secrets should be fetched (default value: 'default')</li>
+ *     <li>{@code credentialFactory.kubernetes.namespace} - the namespace from which secrets should be fetched (default value: 'current-namespace')</li>
  * </ul>
  *
  * <p>Example configuration:</p>

--- a/pom.xml
+++ b/pom.xml
@@ -1358,10 +1358,6 @@
 				<artifactId>directory-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.glassfish.copyright</groupId>
-				<artifactId>glassfish-copyright-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>org.jasig.maven</groupId>
 				<artifactId>notice-maven-plugin</artifactId>
 			</plugin>
@@ -1403,14 +1399,6 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.cyclonedx</groupId>
-				<artifactId>cyclonedx-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.spdx</groupId>
-				<artifactId>spdx-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>
@@ -1730,6 +1718,26 @@
 					</plugin>
 				</plugins>
 			</reporting>
+		</profile>
+		<profile>
+			<id>ci</id>
+			<build>
+				<plugins>
+					<!-- Niels: The Copyright plugin adds 13 minutes to the build. -->
+					<plugin>
+						<groupId>org.glassfish.copyright</groupId>
+						<artifactId>glassfish-copyright-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.cyclonedx</groupId>
+						<artifactId>cyclonedx-maven-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.spdx</groupId>
+						<artifactId>spdx-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<!-- https://stackoverflow.com/a/12598554/17193564 -->


### PR DESCRIPTION
There were three issues.
- The CredentialProvider was minimizing the jar and shading too many classes.
Not all of them were required, but due to Spring's initialization sequence this causes stacktraces

- The kubernetes client was also minimizing the jar, leaving out essential classes. Since I'm unsure which are required I've remove the minimization option, the jar has grown 1 mb. (but not actually works!)

- The Maven Copyright plugin is extremely slow for some reason, adding over 10 minutes to my Maven builds. I've added it to the `ci` profile.