### PR TITLE
Test with jsonPathExpression in a Configuration from a property

### DIFF
--- a/commons/src/test/java/org/frankframework/util/StringResolverTest.java
+++ b/commons/src/test/java/org/frankframework/util/StringResolverTest.java
@@ -33,7 +33,7 @@ public class StringResolverTest {
 
 		InputStream propsStream = propertiesURL.openStream();
 		properties.load(propsStream);
-		assertTrue(!properties.isEmpty(), "did not find any properties!");
+		assertFalse(properties.isEmpty(), "did not find any properties!");
 
 		System.setProperty("authAliases.expansion.allowed", "${allowedAliases}");
 	}
@@ -396,5 +396,19 @@ public class StringResolverTest {
 	void testNeedsResolution(String input, boolean expected) {
 		// Act / Assert
 		assertEquals(expected, StringResolver.needsResolution(input));
+	}
+
+	@Test
+	void testResolveReplacementContainsJson() {
+		// Arrange
+		PropertyLoader props = new PropertyLoader("StringResolver.properties");
+
+		props.setProperty("json.value.prop", "$.preferred_username");
+
+		// Act
+		String result = StringResolver.substVars("${json.value.prop}", props);
+
+		// Assert
+		assertEquals("$.preferred_username", result);
 	}
 }

--- a/test/src/main/configurations/ErrorFormatting/Configuration.xml
+++ b/test/src/main/configurations/ErrorFormatting/Configuration.xml
@@ -77,7 +77,7 @@
 			</Exits>
 			<SenderPipe name="Call Subadapter To Test">
 				<FrankSender scope="ADAPTER">
-					<Param name="target" jsonPathExpression="$.target"/>
+					<Param name="target" jsonPathExpression="${json.test.sender.target}"/>
 				</FrankSender>
 				<!-- SubAdapter "PassViaException" returns exitCode 42 -->
 				<Forward name="42" path="error"/>
@@ -97,7 +97,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<SwitchPipe name="Check Success" jsonPathExpression='concat("result-count=", $.results.length())' notFoundForwardName="result-count-too-many"/>
+			<SwitchPipe name="Check Success" jsonPathExpression='${json.test.result-count}' notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
 				<Forward name="success" path="done"/>
@@ -128,7 +128,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<SwitchPipe name="Check Success" jsonPathExpression='concat("result-count=", $.results.length())' notFoundForwardName="result-count-too-many"/>
+			<SwitchPipe name="Check Success" jsonPathExpression='${json.test.result-count}' notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
 				<Forward name="success" path="done"/>
@@ -158,7 +158,7 @@
 			</Exits>
 			<SenderPipe name="Call Subadapter To Test">
 				<FrankSender scope="LISTENER">
-					<Param name="target" jsonPathExpression="$.target"/>
+					<Param name="target" jsonPathExpression="${json.test.sender.target}"/>
 				</FrankSender>
 				<Forward name="exception" path="ERROR"/>
 				<Forward name="success" path="Extract Name"/>
@@ -178,7 +178,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<JsonPathPipe name="Count nr of results" storeResultInSessionKey="ResultCount" jsonPathExpression='concat("result-count=", $.results.length())'/>
+			<JsonPathPipe name="Count nr of results" storeResultInSessionKey="ResultCount" jsonPathExpression='${json.test.result-count}'/>
 			<XmlSwitchPipe name="Check Success" forwardNameSessionKey="ResultCount" notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
@@ -211,7 +211,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<SwitchPipe name="Check Success" jsonPathExpression='concat("result-count=", $.results.length())' notFoundForwardName="result-count-too-many"/>
+			<SwitchPipe name="Check Success" jsonPathExpression='${json.test.result-count}' notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
 				<Forward name="success" path="done"/>
@@ -239,7 +239,7 @@
 				<Exit name="EXIT" state="SUCCESS" />
 				<Exit name="ERROR" state="ERROR"/>
 			</Exits>
-			<JsonPathPipe name="Get Target SubAdapter" storeResultInSessionKey="target" jsonPathExpression="$.target"/>
+			<JsonPathPipe name="Get Target SubAdapter" storeResultInSessionKey="target" jsonPathExpression="${json.test.sender.target}"/>
 			<SenderPipe name="Call Subadapter To Test" getInputFromSessionKey="originalMessage">
 				<IbisLocalSender javaListenerSessionKey="target"/>
 				<Forward name="exception" path="ERROR"/>
@@ -260,7 +260,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<JsonPathPipe name="Count nr of results" storeResultInSessionKey="ResultCount" jsonPathExpression='concat("result-count=", $.results.length())'/>
+			<JsonPathPipe name="Count nr of results" storeResultInSessionKey="ResultCount" jsonPathExpression='${json.test.result-count}'/>
 			<XmlSwitchPipe name="Check Success" forwardNameSessionKey="ResultCount" notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
@@ -293,7 +293,7 @@
 				<Exit name="error" state="ERROR"/>
 			</Exits>
 
-			<SwitchPipe name="Check Success" jsonPathExpression='concat("result-count=", $.results.length())' notFoundForwardName="result-count-too-many"/>
+			<SwitchPipe name="Check Success" jsonPathExpression='${json.test.result-count}' notFoundForwardName="result-count-too-many"/>
 
 			<EchoPipe name="result-count=1" getInputFromSessionKey="originalMessage">
 				<Forward name="success" path="done"/>

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -265,3 +265,7 @@ framework.api.user.alias=
 larva.parallel.blacklistDirs=MessageStoreSenderAndListener,QuerySender,Receivers,BlockEnabledSenders,TransactionHandling,BatchFileTransformerPipe,JdbcListener
 
 receiver.defaultMaxBackoffDelay=0
+
+# Property used specifically in a Configuration, for tests
+json.test.sender.target=$.target
+json.test.result-count=concat("result-count=", $.results.length())


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Add a test that validates JSON Path Expressions in Configuration attributes can be loaded from a Properties file and will apply correctly.

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] #9768 Test that demonstrates that loading a JSON Path Expression from a Properties configuration file can work.

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PR for 9.3: #9810
