### PR TITLE
Parameter jsonPathExpression should not throw exception when no value found in input

### DIFF
--- a/core/src/main/java/org/frankframework/json/JsonPathNotFoundException.java
+++ b/core/src/main/java/org/frankframework/json/JsonPathNotFoundException.java
@@ -1,0 +1,22 @@
+/*
+   Copyright 2025 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.json;
+
+public class JsonPathNotFoundException extends JsonException {
+	public JsonPathNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/core/src/main/java/org/frankframework/json/JsonUtil.java
+++ b/core/src/main/java/org/frankframework/json/JsonUtil.java
@@ -172,6 +172,8 @@ public class JsonUtil {
 			Message inputMessage = MessageUtils.convertToJsonMessage(input);
 			Object result = jsonPath.read(inputMessage.asInputStream());
 			return getJsonPathResult(result);
+		} catch (PathNotFoundException e) {
+			throw new JsonPathNotFoundException("Cannot find path in input", e);
 		} catch (Exception e) {
 			throw new JsonException("Cannot evaluate JSonPathExpression on parameter value", e);
 		}

--- a/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
+++ b/core/src/main/java/org/frankframework/parameters/AbstractParameter.java
@@ -66,6 +66,7 @@ import org.frankframework.documentbuilder.ObjectBuilder;
 import org.frankframework.documentbuilder.XmlDocumentBuilder;
 import org.frankframework.jdbc.StoredProcedureQuerySender;
 import org.frankframework.json.JsonException;
+import org.frankframework.json.JsonPathNotFoundException;
 import org.frankframework.json.JsonUtil;
 import org.frankframework.pipes.PutSystemDateInSession;
 import org.frankframework.stream.Message;
@@ -401,9 +402,11 @@ public abstract class AbstractParameter implements IConfigurable, IWithParameter
 			} else {
 				input = null;
 			}
-			if (input != null) {
+			if (input != null && !(input instanceof Message m && m.isEmpty())) {
 				try {
 					result = JsonUtil.evaluateJsonPath(jsonPath, input);
+				} catch (JsonPathNotFoundException e) {
+					log.debug("Parameter [{}] jsonpath exception, cannot find path in input [{}]:", jsonPathExpression, input, e);
 				} catch (JsonException e) {
 					throw new ParameterException(getName(), e);
 				}

--- a/core/src/test/java/org/frankframework/parameters/ParameterTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterTest.java
@@ -2015,6 +2015,66 @@ public class ParameterTest {
 	}
 
 	@Test
+	public void testParameterWithJsonPathExpressionUsesDefaultValueWhenInputIsNullMessage() throws Exception {
+		// Arrange
+		Parameter parameter = new Parameter();
+		parameter.setName("p1");
+		parameter.setJsonPathExpression("$.root.a");
+		parameter.setDefaultValue("based");
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = Message.nullMessage();
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertEquals("based", result);
+	}
+
+	@Test
+	public void testParameterWithJsonPathExpressionUsesDefaultValueWhenInputIsEmpty() throws Exception {
+		// Arrange
+		Parameter parameter = new Parameter();
+		parameter.setName("p1");
+		parameter.setJsonPathExpression("$.root.a");
+		parameter.setDefaultValue("based");
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = Message.asMessage("");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertEquals("based", result);
+	}
+
+	@Test
+	public void testParameterWithJsonPathExpressionUsesDefaultValueWhenInputDoesNotContainPath() throws Exception {
+		// Arrange
+		Parameter parameter = new Parameter();
+		parameter.setName("p1");
+		parameter.setJsonPathExpression("$.root.a");
+		parameter.setDefaultValue("based");
+		parameter.configure();
+
+		ParameterValueList alreadyResolvedParameters = new ParameterValueList();
+		Message message = Message.asMessage("{\"B\": 52}");
+		PipeLineSession session = new PipeLineSession();
+
+		// Act
+		Object result = parameter.getValue(alreadyResolvedParameters, message, session, true);
+
+		// Assert
+		assertEquals("based", result);
+	}
+
+	@Test
 	public void testParameterCannotHaveBothXPathAndJsonPathExpression() {
 		// Arrange
 		Parameter parameter = new Parameter();


### PR DESCRIPTION
## Changes
JSON Path expressions on parameters should not throw an exception when the message is empty, or the path is not found in the input.
Instead, the parameter default value should be used.

### Issues
- [x] Closes #9768

### Backports
- [x] Backport PR for 9.3: https://github.com/frankframework/frankframework/pull/9812

