### PR TITLE
Fix bean names in log and FrankConsole

### DIFF
--- a/commons/src/main/java/org/frankframework/util/ClassUtils.java
+++ b/commons/src/main/java/org/frankframework/util/ClassUtils.java
@@ -158,10 +158,21 @@ public class ClassUtils {
 	}
 
 	/**
-	 * returns the className of the object, without the package name.
+	 * Returns the ClassName or BeanName of the object without the package name AND includes a [name] suffix for a {@link HasName} bean.
 	 */
 	@Nonnull
 	public static String nameOf(Object o) {
+		String head = null;
+		if (isClassPresent("org.springframework.beans.factory.NamedBean")) {
+			// Must be a separate statement because of this optional class
+			if (o instanceof org.springframework.beans.factory.NamedBean namedBean) {
+				head = namedBean.getBeanName();
+			}
+		}
+		if (head == null) {
+			head = classNameOf(o);
+		}
+
 		String tail = null;
 		if (o instanceof HasName object) {
 			String name = object.getName();
@@ -169,11 +180,12 @@ public class ClassUtils {
 				tail = "[" + name + "]";
 			}
 		}
-		return StringUtil.concatStrings(classNameOf(o), " ", tail);
+
+		return StringUtil.concatStrings(head, " ", tail);
 	}
 
 	/**
-	 * returns the className of the object, like {@link #nameOf(Object)}, but without [name] suffix for a {@link HasName}.
+	 * Returns the ClassName of the object (without package name), like {@link #nameOf(Object)}, but without [name] suffix for a {@link HasName}.
 	 */
 	@Nonnull
 	public static String classNameOf(Object o) {

--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.NamedBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -277,7 +276,7 @@ import org.frankframework.util.flow.SpringContextFlowDiagramProvider;
 @Log4j2
 @Category(Category.Type.BASIC)
 @FrankDocGroup(FrankDocGroupValue.OTHER)
-public class Adapter extends GenericApplicationContext implements ManagableLifecycle, FrankElement, InitializingBean, NamedBean, NameAware {
+public class Adapter extends GenericApplicationContext implements ManagableLifecycle, FrankElement, InitializingBean, NameAware {
 	protected Logger msgLog = LogUtil.getLogger(LogUtil.MESSAGE_LOGGER);
 
 	public static final String PROCESS_STATE_OK = "OK";
@@ -1161,14 +1160,6 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 			}
 		}
 		log.trace("No more messages in process - lock released on statsMessageProcessingDuration {}", statsMessageProcessingDuration);
-	}
-
-	/* (non-Javadoc)
-	 * @see org.springframework.beans.factory.NamedBean#getBeanName()
-	 */
-	@Override
-	public String getBeanName() {
-		return name;
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/util/flow/SpringContextFlowDiagramProvider.java
+++ b/core/src/main/java/org/frankframework/util/flow/SpringContextFlowDiagramProvider.java
@@ -17,6 +17,7 @@ package org.frankframework.util.flow;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.NamedBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -36,7 +37,7 @@ import org.frankframework.util.AppConstants;
  * Uses {@link Configuration#getLoadedConfiguration()} (and in case of an Adapter, an xPath on the LoadedConfiguration).
  */
 @Log4j2
-public class SpringContextFlowDiagramProvider implements ConfigurableLifecycle, ApplicationContextAware {
+public class SpringContextFlowDiagramProvider implements ConfigurableLifecycle, ApplicationContextAware, NamedBean {
 	private final boolean suppressWarnings = AppConstants.getInstance().getBoolean(SuppressKeys.FLOW_GENERATION_ERROR.getKey(), false);
 
 	@Setter
@@ -85,5 +86,17 @@ public class SpringContextFlowDiagramProvider implements ConfigurableLifecycle, 
 				ConfigurationWarnings.add((HasApplicationContext) applicationContext, log, "error generating flow diagram", e);
 			}
 		}
+	}
+
+	/**
+	 * Returns `AdapterFlowGenerator` or `AdapterFlowGenerator`.
+	 */
+	@Override
+	public String getBeanName() {
+		if (applicationContext == null) {
+			return null;
+		}
+
+		return "%sFlowGenerator".formatted(applicationContext.getClass().getSimpleName());
 	}
 }


### PR DESCRIPTION
So it uses the Spring `BeanName` instead of the ClassName: `SpringContextFlowDiagramProvider successfully configured` vs `AdapterFlowGenerator successfully configured`
