### PR TITLE
Don't verify if target Adapter exists when it's in a different Configuration to prevent startup-order errors.

### DIFF
--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -330,11 +330,14 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 		int configNameSeparator = targetAdapter.indexOf(CONFIG_NAME_SEPARATOR);
 		if (configNameSeparator > 0) {
 			String configName = targetAdapter.substring(0, configNameSeparator);
-			if (configuration != null && !configName.equals(configuration.getName())) {
+			if (configuration == null || !configName.equals(configuration.getName())) {
 				// Do not validate the target adapter if it's in a different configuration, since that configuration may not have started up yet.
 				// If the target configuration will not be loaded at all, then there will be an error in runtime.
 				return;
 			}
+		} else if (configuration == null) {
+			// Configuration is not set when the FrankSender is created inside a Larva scenario. In this case the configuration-name must be set as part of the target.
+			throw new ConfigurationException("This FrankSender is not part of a configuration, therefore [target] must contain the name of the targeted configuration.");
 		}
 		try {
 			findAdapter(targetAdapter);

--- a/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
+++ b/core/src/test/java/org/frankframework/senders/FrankSenderTest.java
@@ -200,7 +200,7 @@ class FrankSenderTest {
 			"configurationName/adapterName",
 			"/adapterName"
 	})
-	void findAdapterSuccess(String target) throws SenderException, ConfigurationException {
+	void testFindAdapterSuccessInConfigure(String target) throws SenderException, ConfigurationException {
 		// Arrange
 		configuration = new TestConfiguration(false);
 		FrankSender sender = configuration.createBean();
@@ -228,24 +228,68 @@ class FrankSenderTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = {
+			"configurationName/noSuchAdapter",
 			"noSuchAdapter",
 			"/noSuchAdapter"
 	})
-	void findAdapterFailure(String target) {
+	void testFindAdapterFailureInConfigure(String target) {
 		// Arrange
 		FrankSender sender = new FrankSender();
 		sender.setTarget(target);
 		sender.setScope(Scope.ADAPTER);
 
-		Adapter adapter = mock();
 		Configuration mockConfiguration = mock();
+		when(mockConfiguration.getName()).thenReturn("configurationName");
 		IbisManager ibisManager = mock();
 
 		sender.setIbisManager(ibisManager);
 		sender.setConfiguration(mockConfiguration);
 
 		when(ibisManager.getConfiguration("configurationName")).thenReturn(mockConfiguration);
-		when(mockConfiguration.getRegisteredAdapter("adapterName")).thenReturn(adapter);
+
+		// Act / Assert
+		assertThrows(ConfigurationException.class, sender::configure);
+	}
+
+	@Test
+	void testNoFailureInConfigureWhenDifferentConfiguration() {
+		// Arrange
+		String target = "otherConfiguration/noSuchAdapter";
+		FrankSender sender = new FrankSender();
+		sender.setTarget(target);
+		sender.setScope(Scope.ADAPTER);
+
+		Configuration mockConfiguration = mock();
+		when(mockConfiguration.getName()).thenReturn("configurationName");
+
+		IbisManager ibisManager = mock();
+		sender.setIbisManager(ibisManager);
+		sender.setConfiguration(mockConfiguration);
+
+		// Act / Assert
+		assertDoesNotThrow(sender::configure);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"noSuchAdapter",
+			"/noSuchAdapter"
+	})
+	void testFailureWhenNoConfigurationInTargetOrSender(String target) {
+		// Arrange
+		FrankSender sender = new FrankSender();
+		sender.setTarget(target);
+		sender.setScope(Scope.ADAPTER);
+
+		Configuration mockConfiguration = mock();
+		IbisManager ibisManager = mock();
+
+		sender.setIbisManager(ibisManager);
+		// No configuration for this FrankSender; this happens when it is created from a Larva scenario.
+		// The target should contain name of configuration.
+		sender.setConfiguration(null);
+
+		when(ibisManager.getConfiguration("configurationName")).thenReturn(mockConfiguration);
 
 		// Act / Assert
 		assertThrows(ConfigurationException.class, sender::configure);
@@ -256,21 +300,18 @@ class FrankSenderTest {
 			"configurationName/noSuchAdapter",
 			"noSuchConfig/adapterName",
 	})
-	void findAdapterNoFailureInConfigureWhenDifferentConfiguration(String target) {
+	void testNoFailureInConfigureWhenConfigurationOnlyInTarget(String target) {
 		// Arrange
 		FrankSender sender = new FrankSender();
 		sender.setTarget(target);
 		sender.setScope(Scope.ADAPTER);
 
-		Adapter adapter = mock();
-		Configuration mockConfiguration = mock();
 		IbisManager ibisManager = mock();
-
 		sender.setIbisManager(ibisManager);
-		sender.setConfiguration(mockConfiguration);
 
-		when(ibisManager.getConfiguration("configurationName")).thenReturn(mockConfiguration);
-		when(mockConfiguration.getRegisteredAdapter("adapterName")).thenReturn(adapter);
+		// No configuration for this FrankSender; this happens when it is created from a Larva scenario.
+		// The target should contain name of configuration.
+		sender.setConfiguration(null);
 
 		// Act / Assert
 		assertDoesNotThrow(sender::configure);


### PR DESCRIPTION
## Changes
Don't verify if target Adapter exists when it's in a different Configuration to prevent startup-order errors.


### Issues
- [x] Closes #9774

### Backports
- [x] Backport PRs created (if needed) and linked

### Documentation
N/A

### Tests
- [x] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable) -- Unsure this is needed

### Breaking changes
N/A
