### PR TITLE
Update dependencies in 8.0.x

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -26,7 +26,7 @@
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>1.12.687</version>
+			<version>1.12.793</version>
 		</dependency>
 
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -764,17 +764,17 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.78.1</version>
+			<version>1.82</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcutil-jdk18on</artifactId>
-			<version>1.78.1</version>
+			<version>1.82</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpg-jdk18on</artifactId>
-			<version>1.78.1</version>
+			<version>1.82</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
 		<jackson.version>2.16.0</jackson.version>
-		<cxf.version>3.6.5</cxf.version>
-		<spring.version>5.3.39</spring.version>
-		<spring-security.version>5.8.16</spring-security.version>
-		<spring-integration.version>5.5.20</spring-integration.version>
-		<spring.boot.version>2.7.18</spring.boot.version>
-		<apache.tomcat.version>9.0.98</apache.tomcat.version>
+		<cxf.version>3.6.6</cxf.version>
+		<spring.version>5.3.39</spring.version> <!-- latest, eol -->
+		<spring-security.version>5.8.16</spring-security.version> <!-- latest, eol -->
+		<spring-integration.version>5.5.20</spring-integration.version> <!-- latest, eol -->
+		<spring.boot.version>2.7.18</spring.boot.version> <!-- latest, eol -->
+		<apache.tomcat.version>9.0.111</apache.tomcat.version>
 
 		<btm.version>3.0.0-mk1</btm.version>
 		<narayana.version>5.13.1.Final</narayana.version>
@@ -110,7 +110,7 @@
 			<dependency>
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
-				<version>1.9.4</version>
+				<version>1.10.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-fileupload</groupId>
@@ -120,7 +120,7 @@
 			<dependency>
 				<groupId>net.minidev</groupId>
 				<artifactId>json-smart</artifactId>
-				<version>2.5.0</version>
+				<version>2.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jdom</groupId>
@@ -135,12 +135,12 @@
 			<dependency>
 				<groupId>io.netty</groupId>
 				<artifactId>netty-transport-native-epoll</artifactId>
-				<version>4.1.104.Final</version>
+				<version>4.1.125.Final</version>
 			</dependency>
 			<dependency><!-- Can be removed when SQS jar is updated > 2.25.17, with an updated netty-nio-client > 2.25.17 and has a higher version of netty-codec-http. -->
 				<groupId>io.netty</groupId>
 				<artifactId>netty-codec-http</artifactId>
-				<version>4.1.108.Final</version>
+				<version>4.1.125.Final</version>
 			</dependency>
 
 			<dependency>
@@ -151,7 +151,7 @@
 			<dependency><!-- Fixes transitive version of spring-security-oauth2-jose dep -->
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>9.37.3</version>
+				<version>9.48</version>
 			</dependency>
 			<!-- End Lock transient deps -->
 
@@ -549,7 +549,7 @@
 			<dependency>
 				<groupId>com.sun.mail</groupId>
 				<artifactId>jakarta.mail</artifactId>
-				<version>2.0.1</version>
+				<version>2.0.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Updated dependencies where needed based on snyk report. We're very limited since this version still uses the deprecated javax.* namespace instead of jakarta.* (since end of 2022).