### PR TITLE
Fix HttpSender validation errors that clientId is not set, when clientAlias is used instead

### DIFF
--- a/core/src/main/java/org/frankframework/http/authentication/AbstractClientCredentials.java
+++ b/core/src/main/java/org/frankframework/http/authentication/AbstractClientCredentials.java
@@ -15,18 +15,18 @@
 */
 package org.frankframework.http.authentication;
 
-import lombok.extern.log4j.Log4j2;
+import java.util.List;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.message.BasicNameValuePair;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.http.AbstractHttpSession;
-
-import java.util.List;
 
 @Log4j2
 public abstract class AbstractClientCredentials extends AbstractOauthAuthenticator {
@@ -37,13 +37,7 @@ public abstract class AbstractClientCredentials extends AbstractOauthAuthenticat
 
 	@Override
 	public final void configure() throws ConfigurationException {
-		if (session.getClientId() == null) {
-			throw new ConfigurationException("clientId is required");
-		}
-
-		if (session.getClientSecret() == null) {
-			throw new ConfigurationException("clientSecret is required");
-		}
+		super.configure();
 
 		if (session.getUsername() != null) {
 			ConfigurationWarnings.add(session, log, "Username should not be set");

--- a/core/src/main/java/org/frankframework/http/authentication/AbstractResourceOwnerPasswordCredentials.java
+++ b/core/src/main/java/org/frankframework/http/authentication/AbstractResourceOwnerPasswordCredentials.java
@@ -15,31 +15,19 @@
 */
 package org.frankframework.http.authentication;
 
+import java.util.List;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.message.BasicNameValuePair;
 
-import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.http.AbstractHttpSession;
-
-import java.util.List;
 
 public abstract class AbstractResourceOwnerPasswordCredentials extends AbstractOauthAuthenticator {
 
 	AbstractResourceOwnerPasswordCredentials(AbstractHttpSession session) throws HttpAuthenticationException {
 		super(session);
-	}
-
-	@Override
-	public final void configure() throws ConfigurationException {
-		if (session.getClientId() == null) {
-			throw new ConfigurationException("clientId is required");
-		}
-
-		if (session.getClientSecret() == null) {
-			throw new ConfigurationException("clientSecret is required");
-		}
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/authentication/ClientCredentialsBasicAuth.java
+++ b/core/src/main/java/org/frankframework/http/authentication/ClientCredentialsBasicAuth.java
@@ -15,19 +15,19 @@
 */
 package org.frankframework.http.authentication;
 
-import com.nimbusds.jose.util.Base64;
+import static org.apache.http.entity.mime.MIME.UTF8_CHARSET;
+
+import java.net.URLEncoder;
+import java.util.List;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
+import com.nimbusds.jose.util.Base64;
+
 import org.frankframework.http.AbstractHttpSession;
-
-import java.net.URLEncoder;
-import java.util.List;
-
-import static org.apache.http.entity.mime.MIME.UTF8_CHARSET;
 
 public class ClientCredentialsBasicAuth extends AbstractClientCredentials {
 
@@ -36,9 +36,9 @@ public class ClientCredentialsBasicAuth extends AbstractClientCredentials {
 	}
 
 	private String createAuthorizationHeaderValue() {
-		String value = URLEncoder.encode(session.getClientId(), UTF8_CHARSET) +
+		String value = URLEncoder.encode(clientCredentials.getUsername(), UTF8_CHARSET) +
 				':' +
-				URLEncoder.encode(session.getClientSecret(), UTF8_CHARSET);
+				URLEncoder.encode(clientCredentials.getPassword(), UTF8_CHARSET);
 
 		return "Basic " + Base64.encode(value.getBytes(UTF8_CHARSET));
 	}

--- a/core/src/main/java/org/frankframework/http/authentication/ClientCredentialsQueryParameters.java
+++ b/core/src/main/java/org/frankframework/http/authentication/ClientCredentialsQueryParameters.java
@@ -15,15 +15,14 @@
 */
 package org.frankframework.http.authentication;
 
+import java.util.List;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-
 import org.apache.http.message.BasicNameValuePair;
 
 import org.frankframework.http.AbstractHttpSession;
-
-import java.util.List;
 
 public class ClientCredentialsQueryParameters extends AbstractClientCredentials {
 
@@ -33,8 +32,8 @@ public class ClientCredentialsQueryParameters extends AbstractClientCredentials 
 
 	@Override
 	protected HttpEntityEnclosingRequestBase createRequest(Credentials credentials, List<NameValuePair> parameters) throws HttpAuthenticationException {
-		parameters.add(new BasicNameValuePair("client_secret", session.getClientSecret()));
-		parameters.add(new BasicNameValuePair("client_id", session.getClientId()));
+		parameters.add(new BasicNameValuePair("client_secret", clientCredentials.getPassword()));
+		parameters.add(new BasicNameValuePair("client_id", clientCredentials.getUsername()));
 
 		return super.createRequest(credentials, parameters);
 	}

--- a/core/src/main/java/org/frankframework/http/authentication/ResourceOwnerPasswordCredentialsBasicAuth.java
+++ b/core/src/main/java/org/frankframework/http/authentication/ResourceOwnerPasswordCredentialsBasicAuth.java
@@ -15,19 +15,19 @@
 */
 package org.frankframework.http.authentication;
 
-import com.nimbusds.jose.util.Base64;
+import static org.apache.http.entity.mime.MIME.UTF8_CHARSET;
+
+import java.net.URLEncoder;
+import java.util.List;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 
+import com.nimbusds.jose.util.Base64;
+
 import org.frankframework.http.AbstractHttpSession;
-
-import java.net.URLEncoder;
-import java.util.List;
-
-import static org.apache.http.entity.mime.MIME.UTF8_CHARSET;
 
 public class ResourceOwnerPasswordCredentialsBasicAuth extends AbstractResourceOwnerPasswordCredentials {
 
@@ -36,9 +36,9 @@ public class ResourceOwnerPasswordCredentialsBasicAuth extends AbstractResourceO
 	}
 
 	private String createAuthorizationHeaderValue() {
-		String value = URLEncoder.encode(session.getClientId(), UTF8_CHARSET) +
+		String value = URLEncoder.encode(clientCredentials.getUsername(), UTF8_CHARSET) +
 				':' +
-				URLEncoder.encode(session.getClientSecret(), UTF8_CHARSET);
+				URLEncoder.encode(clientCredentials.getPassword(), UTF8_CHARSET);
 
 		return "Basic " + Base64.encode(value.getBytes(UTF8_CHARSET));
 	}

--- a/core/src/main/java/org/frankframework/http/authentication/ResourceOwnerPasswordCredentialsQueryParameters.java
+++ b/core/src/main/java/org/frankframework/http/authentication/ResourceOwnerPasswordCredentialsQueryParameters.java
@@ -15,15 +15,14 @@
 */
 package org.frankframework.http.authentication;
 
+import java.util.List;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-
 import org.apache.http.message.BasicNameValuePair;
 
 import org.frankframework.http.AbstractHttpSession;
-
-import java.util.List;
 
 public class ResourceOwnerPasswordCredentialsQueryParameters extends AbstractResourceOwnerPasswordCredentials {
 
@@ -33,8 +32,8 @@ public class ResourceOwnerPasswordCredentialsQueryParameters extends AbstractRes
 
 	@Override
 	protected HttpEntityEnclosingRequestBase createRequest(Credentials credentials, List<NameValuePair> parameters) throws HttpAuthenticationException {
-		parameters.add(new BasicNameValuePair("client_id", session.getClientId()));
-		parameters.add(new BasicNameValuePair("client_secret", session.getClientSecret()));
+		parameters.add(new BasicNameValuePair("client_id", clientCredentials.getUsername()));
+		parameters.add(new BasicNameValuePair("client_secret", clientCredentials.getPassword()));
 
 		return super.createRequest(credentials, parameters);
 	}

--- a/core/src/main/java/org/frankframework/http/authentication/SamlAssertionOauth.java
+++ b/core/src/main/java/org/frankframework/http/authentication/SamlAssertionOauth.java
@@ -41,10 +41,6 @@ import org.apache.xml.security.algorithms.MessageDigestAlgorithm;
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.signature.XMLSignature;
 import org.apache.xml.security.transforms.Transforms;
-
-import org.frankframework.util.DomBuilderException;
-import org.frankframework.util.XmlUtils;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -52,6 +48,8 @@ import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.encryption.EncryptionException;
 import org.frankframework.encryption.PkiUtil;
 import org.frankframework.http.AbstractHttpSession;
+import org.frankframework.util.DomBuilderException;
+import org.frankframework.util.XmlUtils;
 
 public class SamlAssertionOauth extends AbstractOauthAuthenticator {
 
@@ -71,13 +69,7 @@ public class SamlAssertionOauth extends AbstractOauthAuthenticator {
 
 	@Override
 	public void configure() throws ConfigurationException {
-		if (session.getClientId() == null) {
-			throw new ConfigurationException("clientId is required");
-		}
-
-		if (session.getClientSecret() == null) {
-			throw new ConfigurationException("clientSecret is required");
-		}
+		super.configure();
 
 		try {
 			privateKey = PkiUtil.getPrivateKey(session, "Creation of SAML assertion");
@@ -188,7 +180,7 @@ public class SamlAssertionOauth extends AbstractOauthAuthenticator {
 
 		Element attributeValue = doc.createElementNS(SAML2_NAMESPACE_URI, "saml2:AttributeValue");
 		attributeValue.setAttribute("xsi:type", "xs:string");
-		attributeValue.setTextContent(session.getClientId());
+		attributeValue.setTextContent(clientCredentials.getUsername());
 
 		attribute.appendChild(attributeValue);
 		attributeStatement.appendChild(attribute);
@@ -238,8 +230,8 @@ public class SamlAssertionOauth extends AbstractOauthAuthenticator {
 	@Override
 	protected HttpEntityEnclosingRequestBase createRequest(Credentials credentials, List<NameValuePair> parameters) throws HttpAuthenticationException {
 		parameters.add(new BasicNameValuePair("grant_type", SAML2_BEARER_GRANT_TYPE));
-		parameters.add(new BasicNameValuePair("client_id", session.getClientId()));
-		parameters.add(new BasicNameValuePair("client_secret", session.getClientSecret()));
+		parameters.add(new BasicNameValuePair("client_id", clientCredentials.getUsername()));
+		parameters.add(new BasicNameValuePair("client_secret", clientCredentials.getPassword()));
 
 		if (session.getScope() != null) {
 			parameters.add(getScopeHeader());

--- a/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/HttpSenderAuthenticationTest.java
@@ -216,6 +216,40 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 		assertNotNull(result.asString());
 	}
 
+	@Test
+	void testOAuthAuthenticationWithoutAuthenticatedTokenRequestUsingAuthAlias1() throws Exception {
+		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPath);
+		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
+		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
+		sender.setClientAlias("alias3"); // Alias does not exist, fallback to configured values
+		sender.setClientId(MockTokenServer.CLIENT_ID);
+		sender.setClientSecret(MockTokenServer.CLIENT_SECRET);
+		sender.setAuthenticatedTokenRequest(false);
+
+		sender.configure();
+		sender.start();
+
+		result = sendMessage();
+		assertEquals("200", session.getString(RESULT_STATUS_CODE_SESSIONKEY));
+		assertNotNull(result.asString());
+	}
+
+	@Test
+	void testOAuthAuthenticationWithoutAuthenticatedTokenRequestUsingAuthAlias2() throws Exception {
+		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPath);
+		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
+		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
+		sender.setClientAlias("alias1"); // Alias should exist, no fallback to configured values
+		sender.setAuthenticatedTokenRequest(false);
+
+		sender.configure();
+		sender.start();
+
+		result = sendMessage();
+		assertEquals("200", session.getString(RESULT_STATUS_CODE_SESSIONKEY));
+		assertNotNull(result.asString());
+	}
+
 
 	@Test
 	void testOAuthAuthenticationUnchallenged() throws Exception {
@@ -233,15 +267,43 @@ public class HttpSenderAuthenticationTest extends SenderTestBase<HttpSender> {
 		assertNotNull(result.asString());
 	}
 
+	@Test
+	void testOAuthAuthenticationUnchallengedUsingAuthAlias() throws Exception {
+		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPathUnchallenged);
+		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
+		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
+		sender.setClientAlias("alias3"); // Alias does not exist, fallback to configured values
+		sender.setClientId(MockTokenServer.CLIENT_ID);
+		sender.setClientSecret(MockTokenServer.CLIENT_SECRET);
+
+		sender.configure();
+		sender.start();
+
+		result = sendMessage();
+		assertEquals("200", session.getString(RESULT_STATUS_CODE_SESSIONKEY));
+		assertNotNull(result.asString());
+	}
+
 
 	@Test
-	void testOAuthAuthenticationNoCredentials() throws Exception {
+	void testOAuthAuthenticationNoCredentials() {
 		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPath);
 		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
 		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
 
 		ConfigurationException exception = assertThrows(ConfigurationException.class, ()->sender.configure());
 		assertThat(exception.getMessage(), containsString("clientId is required"));
+	}
+
+	@Test
+	void testOAuthAuthenticationNoCredentialsUsingAuthAlias() {
+		sender.setUrl(getServiceEndpoint() + MockAuthenticatedService.oauthPath);
+		sender.setResultStatusCodeSessionKey(RESULT_STATUS_CODE_SESSIONKEY);
+		sender.setTokenEndpoint(getTokenEndpoint() + MockTokenServer.PATH);
+		sender.setClientAlias("alias3"); // Alias does not exist
+
+		ConfigurationException exception = assertThrows(ConfigurationException.class, ()->sender.configure());
+		assertThat(exception.getMessage(), containsString("clientId not set"));
 	}
 
 	@Test


### PR DESCRIPTION
## Changes
Fix HttpSender validation errors that clientId is not set, when clientAlias is used instead and the client_id and client_secret can be looked up via the Credential Provider.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] This is a 9.0 specific fix for issue #9503 which blocks NN from upgrading to 9.0

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [x] Backport PRs N/A

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [x] FF! Doc updated (N/A)
- [x] FF! Manual updated (N/A)
- [x] Javadoc updated/generated (N/A)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [x] E2E/Integration tests added/updated (N/A)

