### PR TITLE
Update nightly release workflow to set tag name

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           _input-text: "${{ github.ref_name }}"
           -release: ''
+          release/: ''
       - name: Set tag name
         run: echo "TAG=${{ steps.branch.outputs.result }}-nightly" >> $GITHUB_ENV
       - name: Update nightly release


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Change the tag name of the nightlies to `x.x-nightly` 

@nielsm5 should the tag include a `v` or not?
