### PR TITLE
Do not show Save button in Larva when saving is not possible

### DIFF
--- a/larva/src/main/java/org/frankframework/larva/LarvaConfig.java
+++ b/larva/src/main/java/org/frankframework/larva/LarvaConfig.java
@@ -37,13 +37,14 @@ public class LarvaConfig {
 	private @Getter @Setter boolean scenarioPropertyOverridesIncluded = AppConstants.getInstance().getBoolean("larva.scenarioPropertyOverridesIncluded", false);
 	private @Getter @Setter boolean multiThreaded = false;
 	private @Getter @Setter LarvaLogLevel logLevel = LarvaLogLevel.WRONG_PIPELINE_MESSAGES;
-	private @Getter @Setter boolean autoSaveDiffs = AppConstants.getInstance().getBoolean("larva.diffs.autosave", false);
+	private @Getter @Setter boolean enableSaving = AppConstants.getInstance().getBoolean("servlet.LarvaServlet.allowFileSave", false);
+	private @Getter @Setter boolean autoSaveDiffs = enableSaving && AppConstants.getInstance().getBoolean("larva.diffs.autosave", false);
 
 	/**
 	 * if allowReadlineSteps is set to true, actual results can be compared in line by using .readline steps.
 	 * Those results cannot be saved to the expected value defined inline, however.
 	 */
-	private @Getter @Setter boolean allowReadlineSteps = false;
+	private @Getter @Setter boolean allowReadlineSteps = true;
 
 	private @Getter @Setter String activeScenariosDirectory;
 }

--- a/larva/src/main/java/org/frankframework/larva/LarvaServlet.java
+++ b/larva/src/main/java/org/frankframework/larva/LarvaServlet.java
@@ -15,6 +15,8 @@
 */
 package org.frankframework.larva;
 
+import static org.frankframework.larva.output.LarvaHtmlWriter.encodeForHtml;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
@@ -181,7 +183,11 @@ public class LarvaServlet extends AbstractHttpServlet {
 					larvaTool.windiff(request.getParameter("expectedFileName"), request.getParameter("expectedBox"), request.getParameter("resultBox"));
 				} catch (IOException e) {
 					log.warn("unable to write tempFile", e);
-					resp.sendError(500, "unable to write tempFile");
+					writer.append("<h2 class='warning'>Unable to write tempFile or invoke Windiff command: ")
+							.append(encodeForHtml(e.getMessage()))
+							.append("</h2>")
+							.flush();
+					return;
 				}
 			} else {
 				writer.append("<p>Overwriting expected result with actual result...</p>");

--- a/larva/src/main/java/org/frankframework/larva/output/LarvaHtmlWriter.java
+++ b/larva/src/main/java/org/frankframework/larva/output/LarvaHtmlWriter.java
@@ -151,6 +151,7 @@ public class LarvaHtmlWriter extends LarvaWriter {
 				    <input type='hidden' name='iehack' value='&#9760;' />
 				    <h4>Step '%s'</h4>
 				    <hr/>
+				    %s
 				    <div class='resultContainer'>
 				      %s
 				      <h5>Result (%s):</h5>
@@ -174,10 +175,19 @@ public class LarvaHtmlWriter extends LarvaWriter {
 				  </form>
 				</div>
 				""";
+		String savingDisabledMessage;
+		if (!getLarvaConfig().isEnableSaving()) {
+			savingDisabledMessage = "Saving and Windiff are disabled on this environment. Set property 'servlet.LarvaServlet.allowFileSave' to 'true' for this environment to enable saving of results.<hr/>";
+		} else if (stepOutputFilename == null) {
+			savingDisabledMessage = "Saving and Windiff are disabled for this result because this was a step with inline data<hr/>";
+		} else {
+			savingDisabledMessage = "";
+		}
+		boolean canSaveResult = getLarvaConfig().isEnableSaving() && stepOutputFilename != null;
 		String btn1 = "<a class=\"['" + resultBoxId + "','" + expectedBoxId + "']|indentCompare|" + diffBoxId + "\" href=\"javascript:void(0)\">compare</a>";
-		String btn2 = "<a href='javascript:void(0);' class='" + formName + "|indentWindiff'>windiff</a>";
-		String saveCommand = stepOutputFilename != null ? "<a href='javascript:void(0);' class='" + formName + "|saveResults'>save</a>" : null;
-		writeHtml(logLevel, template.formatted(cssClass, formName, encodeForHtml(stepName),
+		String btn2 = canSaveResult ? "<a href='javascript:void(0);' class='" + formName + "|indentWindiff'>windiff</a>" : "";
+		String saveCommand = canSaveResult ? "<a href='javascript:void(0);' class='" + formName + "|saveResults'>save</a>" : null;
+		writeHtml(logLevel, template.formatted(cssClass, formName, encodeForHtml(stepName), savingDisabledMessage,
 				writeCommands(resultBoxId, true, saveCommand),
 				encodeForHtml(headerExtra), resultBoxId, encodeForHtml(actualMessage),
 				writeCommands(expectedBoxId, true, null),


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
When saving the actual results of a step in a Larva is not possible on the environment, or because the step is an inline step, do not show the Save / Windiff buttons and instead show a text message explaining why.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Closes #7720

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [x] N/A

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [x] FF! Doc updated (user-facing behavior/config) (N/A)
- [x] FF! Manual updated (if applicable) (N/A)
- [x] Javadoc updated/generated (developer-facing APIs) (N/A)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [x] E2E/Integration tests added/updated (if applicable) (N/A)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [x] Breaking change recorded in markdown file
- [x] Migration notes included (if needed)
</details>
