### PR TITLE
Fix overflow in navigation sidebar

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.scss
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-navigation/pages-navigation.component.scss
@@ -17,10 +17,9 @@
 
 li > a {
   cursor: pointer;
-}
-
-fa-icon + span {
-  margin-left: 6px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .fa-green {

--- a/console/frontend/src/main/frontend/src/styles.scss
+++ b/console/frontend/src/main/frontend/src/styles.scss
@@ -33,7 +33,7 @@ fa-icon + span {
 
 .nav > li > a fa-icon,
 .scroll-to-top a fa-icon {
-  margin-right: 6px;
+  margin-right: 3px;
   width: 16px;
   text-align: center;
 }


### PR DESCRIPTION
<img width="488" height="314" alt="image" src="https://github.com/user-attachments/assets/cd553e3e-48e6-46bb-a508-08d445e0142d" />
<img width="497" height="339" alt="image" src="https://github.com/user-attachments/assets/774ab9ae-18f4-47e9-ae53-5cab5e2504b1" />

Less padding + no text overflow with ellipsis on zoomed in screens