### PR TITLE
Fix race condition in XSD PreparseResult intialization

### DIFF
--- a/core/src/main/java/org/frankframework/validation/XercesXmlValidator.java
+++ b/core/src/main/java/org/frankframework/validation/XercesXmlValidator.java
@@ -19,7 +19,7 @@ package org.frankframework.validation;
 import static org.apache.xerces.parsers.XMLGrammarCachingConfiguration.BIG_PRIME;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -411,11 +411,11 @@ class PreparseResult {
 
 	public List<XSModel> getXsModels() {
 		if (xsModels == null) {
-			xsModels = new ArrayList<>();
 			Grammar[] grammars = grammarPool.retrieveInitialGrammarSet(XMLGrammarDescription.XML_SCHEMA);
-			for (Grammar grammar : grammars) {
-				xsModels.add(((XSGrammar) grammar).toXSModel());
-			}
+			xsModels = Arrays.stream(grammars)
+					.map(XSGrammar.class::cast)
+					.map(XSGrammar::toXSModel)
+					.toList();
 		}
 		return xsModels;
 	}


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
I believe this fixes the race condition, even if the variable might still be initialized twice because I don't want to add locking.
The initialization of the list now happens in each thread independently so different threads don't interfere with each other's work.



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Closes #9958

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
