### PR TITLE
Add documentation on limitations to credential factories

### DIFF
--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialResolver.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialResolver.java
@@ -30,6 +30,12 @@ import org.frankframework.util.StringUtil;
 /**
  * Implementation of {@link AdditionalStringResolver} for resolving user credentials using
  * the {@link CredentialFactory}.
+ * <br/>
+ * Only supports username and password resolution with the following syntax:
+ * <ul>
+ *   <li>credential:username:authAlias</li>
+ *   <li>credential:password:authAlias</li>
+ * </ul>
  * This class is loaded via the ServiceLoader.
  */
 public class CredentialResolver implements AdditionalStringResolver {

--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/FileSystemCredentialFactory.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/FileSystemCredentialFactory.java
@@ -39,6 +39,8 @@ import org.frankframework.credentialprovider.util.CredentialConstants;
  *
  * <p>By default, the default values {@code username} and {@code password} are used for these files.</p>
  *
+ * @ff.info Please note that file system specific limitations and permissions apply when using this CredentialFactory. See <a
+ * href="https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations">Comparison of filename limitations</a> for more information.
  * @ff.info It's required to set the property {@value FileSystemCredentialFactory#FILESYSTEM_ROOT_PROPERTY} to the directory you wish to read credentials from.
  *
  */

--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/delinea/DelineaCredentialFactory.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/delinea/DelineaCredentialFactory.java
@@ -79,11 +79,14 @@ import org.frankframework.credentialprovider.util.CredentialConstants;
  *
  * @see <a href="https://github.com/DelineaXPM/tss-sdk-java">tss-sdk-java</a> for the reference java implementation
  * @see <a href="https://updates.thycotic.net/secretserver/restapiguide/">Delinea API documentation</a>
+ *
+ * @ff.info Please note that referenced secrets need to be numeric, since they reference the internal Delinea secret ID.
  */
 @Log4j2
 public class DelineaCredentialFactory implements ISecretProvider {
 
 	private static final String BASE_KEY = "credentialFactory.delinea.";
+
 	// Leave empty to not use autocomment
 	static final String USE_AUTO_COMMENT_VALUE = BASE_KEY + "autocomment.value";
 	static final String TENANT_KEY = BASE_KEY + "tenant";

--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesCredentialFactory.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesCredentialFactory.java
@@ -63,6 +63,9 @@ import org.frankframework.credentialprovider.util.CredentialConstants;
  * }</pre>
  * </p>
  *
+ * @ff.info Please note that the namespace value requires to be valid according to the rules defined in
+ * <a href="https://tools.ietf.org/html/rfc1123">RFC 1123</a>. This means the namespace must consist of lower case alphanumeric characters, '-' or '.',
+ * and must start and end with an alphanumeric character
  * @ff.info The credentials are cached for 60 seconds, to prevent unnecessary calls to the Kubernetes API.
  */
 @Log


### PR DESCRIPTION
## Changes
Added ff.info annotations which will be picked up in the frank doc to document limitations for specific credential factory implementations.

Also modified the generic description on credential factories. See: https://github.com/frankframework/frank-doc/pull/448


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issues linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [x] FF! Doc updated (user-facing behavior/config)
- [x] Javadoc updated/generated (developer-facing APIs)
</details>
