### PR TITLE
Enable directory scanning in containers by default

### DIFF
--- a/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
+++ b/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
@@ -12,6 +12,9 @@ common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.ho
 # The configurations directory should be available, may contain custom code, but should not be part of the classpath.
 configurations.directory=/opt/frank/configurations
 
+# Automatically find configuration directories and jar files and load them accordingly.
+configurations.directory.autoLoad=true
+
 # The plugins directory, should not be part of the classpath.
 plugins.directory=/opt/frank/plugins
 


### PR DESCRIPTION
I thought the default was true, but alas... 