### PR TITLE
Make ExitState a system key. ENUMs in Session only when they're system-keys, otherwise store the name of the enum.

### DIFF
--- a/core/src/main/java/org/frankframework/core/PipeLineSession.java
+++ b/core/src/main/java/org/frankframework/core/PipeLineSession.java
@@ -74,8 +74,8 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	public static final String HTTP_METHOD_KEY 	   = "HttpMethod";
 
 	public static final String API_PRINCIPAL_KEY   = "apiPrincipal";
-	public static final String EXIT_STATE_CONTEXT_KEY="exitState";
-	public static final String EXIT_CODE_CONTEXT_KEY="exitCode";
+	public static final String EXIT_STATE_CONTEXT_KEY= SYSTEM_MANAGED_RESOURCE_PREFIX + "exitState";
+	public static final String EXIT_CODE_CONTEXT_KEY= "exitCode";
 
 	private transient @Nullable ISecurityHandler securityHandler = null;
 	private transient Cleaner.@Nullable Cleanable cleanable;
@@ -171,6 +171,9 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	public Object put(String key, @Nullable Object value) {
 		if (shouldCloseSessionResource(key, value)) {
 			closeables.add((AutoCloseable) value);
+		}
+		if (value instanceof Enum<?> enumValue && !key.startsWith(SYSTEM_MANAGED_RESOURCE_PREFIX)) {
+			super.put(key, enumValue.name());
 		}
 		return super.put(key, value);
 	}

--- a/nn-specials/src/main/java/org/frankframework/extensions/svn/ScanTibcoSolutionPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/svn/ScanTibcoSolutionPipe.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
-import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Vector;

--- a/test/src/main/configurations/MainConfig/ConfigurationReturnedSessionKeys.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationReturnedSessionKeys.xml
@@ -54,7 +54,6 @@
 				<param name="reasonCode" sessionKey="reasonCode"/>
 				<param name="dataStream" sessionKey="dataStream"/>
 				<param name="localValue" sessionKey="localValue"/>
-				<param name="exitState" sessionKey="exitState"/>
 				<param name="forward" value="success"/>
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -63,7 +62,6 @@
 				<param name="reasonCode" sessionKey="reasonCode"/>
 				<param name="dataStream" sessionKey="dataStream"/>
 				<param name="localValue" sessionKey="localValue"/>
-				<param name="exitState" sessionKey="exitState"/>
 				<param name="forward" value="400"/>
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -72,7 +70,6 @@
 				<param name="reasonCode" sessionKey="reasonCode"/>
 				<param name="dataStream" sessionKey="dataStream"/>
 				<param name="localValue" sessionKey="localValue"/>
-				<param name="exitState" sessionKey="exitState"/>
 				<param name="forward" value="exception"/>
 				<forward name="success" path="EXIT" />
 			</pipe>

--- a/test/src/main/configurations/MainConfig/ReturnedSessionKeys/Reply.xsl
+++ b/test/src/main/configurations/MainConfig/ReturnedSessionKeys/Reply.xsl
@@ -24,9 +24,6 @@
 			<pipelineResult>
 				<xsl:value-of select="." />
 			</pipelineResult>
-			<exitState>
-				<xsl:value-of select="$exitState" />
-			</exitState>
 			<forward>
 				<xsl:value-of select="$forward" />
 			</forward>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario01/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario01/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>PipeLine result from inputStream</pipelineResult>
-  <exitState>SUCCESS</exitState>
   <forward>success</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario02/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario02/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>PipeLine result from inputStream</pipelineResult>
-  <exitState>ERROR</exitState>
   <forward>400</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario03/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario03/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>Exception caught</pipelineResult>
-  <exitState>ERROR</exitState>
   <forward>exception</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario04/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario04/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>PipeLine result from inputStream</pipelineResult>
-  <exitState>SUCCESS</exitState>
   <forward>success</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario05/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario05/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>PipeLine result from inputStream</pipelineResult>
-  <exitState>ERROR</exitState>
   <forward>400</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario06/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario06/out.xml
@@ -4,6 +4,5 @@
   <dataStream>SessionKey value from inputStream</dataStream>
   <localValue>LocalValueParent</localValue>
   <pipelineResult>Exception caught</pipelineResult>
-  <exitState>ERROR</exitState>
   <forward>exception</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario11/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario11/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>PipeLine result from inputStream</pipelineResult>
-	<exitState>SUCCESS</exitState>
 	<forward>success</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario12/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario12/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>PipeLine result from inputStream</pipelineResult>
-	<exitState>ERROR</exitState>
 	<forward>400</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario13/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario13/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>Exception caught</pipelineResult>
-	<exitState>ERROR</exitState>
 	<forward>exception</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario14/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario14/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>PipeLine result from inputStream</pipelineResult>
-	<exitState>SUCCESS</exitState>
 	<forward>success</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario15/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario15/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>PipeLine result from inputStream</pipelineResult>
-	<exitState>ERROR</exitState>
 	<forward>400</forward>
 </reply>

--- a/test/src/test/testtool/ReturnedSessionKeys/scenario16/out.xml
+++ b/test/src/test/testtool/ReturnedSessionKeys/scenario16/out.xml
@@ -4,6 +4,5 @@
 	<dataStream>SessionKey value from inputStream</dataStream>
 	<localValue>LocalValueParent</localValue>
 	<pipelineResult>Exception caught</pipelineResult>
-	<exitState>ERROR</exitState>
 	<forward>exception</forward>
 </reply>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

ExitState in the Session shouldn't really be used by users, it's a system field.
Update a Larva test which did extract its value.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Related to #10244

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
