### PR TITLE
Replace [emptyInputReplacement] with [defaultValue] in EchoPipe usages

### DIFF
--- a/example/src/main/resources/ConfigurationHelloWorlds.xml
+++ b/example/src/main/resources/ConfigurationHelloWorlds.xml
@@ -31,7 +31,7 @@
 			<pipe
 				name="ConvertEmptyMessageToDummyMessage"
 				className="org.frankframework.pipes.EchoPipe"
-				emptyInputReplacement="Dummy"
+				defaultValue="Dummy"
 			/>
 			<pipe
 				name="Text2Xml"

--- a/test/src/main/configurations/MainConfig/ConfigurationReplaceInputAndPreserve.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationReplaceInputAndPreserve.xml
@@ -47,7 +47,7 @@
 			</Exits>
 
 			<PutInSessionPipe name="PutValueInSession" sessionKey="requestKey" value="&lt;abc/&gt;" />
-			<EchoPipe name="TestMissingKeyInputReplacement" emptyInputReplacement="" getInputFromSessionKey="missingKey"/>
+			<EchoPipe name="TestMissingKeyInputReplacement" defaultValue="" getInputFromSessionKey="missingKey"/>
 		</Pipeline>
 	</Adapter>
 </Module>


### PR DESCRIPTION
## Changes
"attribute [emptyInputReplacement] is deprecated: Attribute has been renamed to 'defaultValue'"

Changed test and example configurations which still used the deprecated value