### PR TITLE
Allow custom code by default in docker images

### DIFF
--- a/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
+++ b/docker/Tomcat/webapp/src/scripts/catalinaAdditional.properties
@@ -14,6 +14,7 @@ configurations.directory=/opt/frank/configurations
 
 # Automatically find configuration directories and jar files and load them accordingly.
 configurations.directory.autoLoad=true
+configurations.allowCustomClasses=true
 
 # The plugins directory, should not be part of the classpath.
 plugins.directory=/opt/frank/plugins


### PR DESCRIPTION
Unsure if we want this, but to me it seems like a sensible default.