### PR TITLE
Change appender log pattern to use the normal exception format

### DIFF
--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -5,12 +5,12 @@
 	<Appenders>
 		<Appender name="stdout" type="Console">
 			<Layout type="IbisPatternLayout">
-				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %c{2} - %m%n%xEx{short}</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %c{2} - %m%n%ex{short}</Pattern>
 			</Layout>
 		</Appender>
 		<Appender name="application-log-appender" type="Console">
 			<Layout type="PatternLayout">
-				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} - %m%n%xEx{short}</Pattern>
+				<Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} - %m%n%ex{short}</Pattern>
 			</Layout>
 		</Appender>
 		<Appender name="log-all-errors-to-application-log" type="Routing">


### PR DESCRIPTION
Hides the problem described in https://github.com/frankframework/frankframework/issues/10312
Which now triggers 2 'log4j2 cannot log this message stacktraces', and after this merge will only throw once such exception.