### PR TITLE
Validate user authorities in bearer only flow

### DIFF
--- a/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractServletAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractServletAuthenticator.java
@@ -17,6 +17,7 @@ package org.frankframework.lifecycle.servlets;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +47,8 @@ import org.springframework.security.config.annotation.web.configurers.FormLoginC
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
@@ -114,6 +117,15 @@ public abstract class AbstractServletAuthenticator implements IAuthenticator, Ap
 		} else {
 			this.securityRoles.addAll(securityRoles);
 		}
+	}
+
+	final List<GrantedAuthority> getAuthorities() {
+		Set<String> securityRoles = getSecurityRoles();
+		List<GrantedAuthority> grantedAuthorities = new ArrayList<>(securityRoles.size());
+		for (String role : securityRoles) {
+			grantedAuthorities.add(new SimpleGrantedAuthority(DEFAULT_ROLE_PREFIX + role));
+		}
+		return grantedAuthorities;
 	}
 
 	/**

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/BearerOnlyAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/BearerOnlyAuthenticator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2025 WeAreFrank!
+   Copyright 2025-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package org.frankframework.lifecycle.servlets;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,16 +28,21 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 import lombok.Setter;
@@ -81,7 +88,7 @@ public class BearerOnlyAuthenticator extends AbstractServletAuthenticator {
 	 * @see "JwtAuthenticationConverter#principalClaimName"
 	 */
 	@Setter
-	private String userNameAttributeName;
+	private String userNameAttributeName = JwtClaimNames.SUB;
 
 	/**
 	 * <p>The claim name in the JWT token that contains the authorities of the user.
@@ -106,23 +113,31 @@ public class BearerOnlyAuthenticator extends AbstractServletAuthenticator {
 
 		http.oauth2ResourceServer(oauth2 -> oauth2
 				.jwt(jwt -> jwt.decoder(getJwtDecoder())
-						.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+						.jwtAuthenticationConverter(new RoleBasedJwtAuthenticationConverter())));
 
 		return http.build();
 	}
 
-	public JwtAuthenticationConverter jwtAuthenticationConverter() {
-		Converter<Jwt, Collection<GrantedAuthority>> jwtGrantedAuthoritiesConverter = getJwtCollectionConverter();
+	/**
+	 * {@link JwtAuthenticationConverter}
+	 */
+	private class RoleBasedJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
-		JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+		@Override
+		public final AbstractAuthenticationToken convert(Jwt jwt) {
+			Collection<GrantedAuthority> authorities = new HashSet<>(getJwtCollectionConverter().convert(jwt));
+			authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.BEARER_AUTHORITY));
+			String principalClaimValue = jwt.getClaimAsString(userNameAttributeName);
+			AbstractAuthenticationToken token = new JwtAuthenticationToken(jwt, authorities, principalClaimValue);
 
-		if (StringUtils.isNotBlank(userNameAttributeName)) {
-			log.debug("Using principalClaimName [{}]", userNameAttributeName);
-			jwtAuthenticationConverter.setPrincipalClaimName(userNameAttributeName);
+			if (!getAuthorities().isEmpty()) {
+				token.setAuthenticated(!Collections.disjoint(getAuthorities(), token.getAuthorities()));
+				log.info("Checking if user contains required role(s) [{}]", getAuthorities());
+			}
+
+			return token;
 		}
 
-		jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter);
-		return jwtAuthenticationConverter;
 	}
 
 	/**
@@ -171,13 +186,19 @@ public class BearerOnlyAuthenticator extends AbstractServletAuthenticator {
 	}
 
 	List<String> getRolesFromUserInfoUri(String accessToken) {
-		Map<String, Object> userInfo = RestClient.create()
+		final Map<String, Object> userInfo;
+		try {
+			userInfo = RestClient.create()
 				.get()
 				.uri(userInfoUri)
 				.accept(MediaType.APPLICATION_JSON)
 				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
 				.retrieve()
 				.body(new ParameterizedTypeReference<>() {});
+		} catch (HttpClientErrorException e) {
+			log.debug("userInfo endpoint exception, status code [{}]", () -> e.getStatusCode().value(), () -> e);
+			return List.of();
+		}
 
 		log.debug("Fetched user info: {}", userInfo);
 

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/NoOpAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/NoOpAuthenticator.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2024 WeAreFrank!
+   Copyright 2022-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
 */
 package org.frankframework.lifecycle.servlets;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 
@@ -53,14 +47,5 @@ public class NoOpAuthenticator extends AbstractServletAuthenticator {
 	@Override
 	protected AuthorizationManager<RequestAuthorizationContext> getAuthorizationManager() {
 		return AuthenticatedAuthorizationManager.anonymous();
-	}
-
-	private List<GrantedAuthority> getAuthorities() {
-		Set<String> securityRoles = getSecurityRoles();
-		List<GrantedAuthority> grantedAuthorities = new ArrayList<>(securityRoles.size());
-		for (String role : securityRoles) {
-			grantedAuthorities.add(new SimpleGrantedAuthority(DEFAULT_ROLE_PREFIX + role));
-		}
-		return grantedAuthorities;
 	}
 }


### PR DESCRIPTION
`BearerOnlyAuthenticator` is authentication only (you may enter or you may not). In some cases, we have access to user roles as well and want to do authorization as well (you may enter and have the correct role to access a certain resource). This change checks for the required role