### PR TITLE
Disable dependency dashboard approval in renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
         ":configMigration",
         "security:minimumReleaseAgeNpm"
     ],
-    "dependencyDashboardApproval": true,
+    "dependencyDashboardApproval": false,
     "baseBranchPatterns": [
         "master",
         "/^release\\/9\\./",


### PR DESCRIPTION
## Changes
Renovate was not creating pull requests automatically like we'd expect. Changed the dashboard approval setting to false.