### PR TITLE
Do not group patch versions in renovate pr's

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,7 +58,7 @@
             "separateMajorMinor": true,
             "separateMultipleMinor": true,
             "separateMultipleMajor": true,
-            "separateMinorPatch": false
+            "separateMinorPatch": true
         },
         {
             "description": "Aspose Dependencies",


### PR DESCRIPTION
## Changes
Enable separateMinorPatch to true for dependencies in renovate configuration so patch version updates are not grouped in one PR