### PR TITLE
Use OkHTTP which is already present instead of Netty

### DIFF
--- a/filesystem/pom.xml
+++ b/filesystem/pom.xml
@@ -73,6 +73,18 @@
 			<artifactId>azure-identity</artifactId>
 			<version>1.18.2</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.azure</groupId>
+					<artifactId>azure-core-http-netty</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-core-http-okhttp</artifactId>
+			<version>1.13.3</version>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- Test scoped and provided dependencies -->

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
@@ -250,7 +250,7 @@ public class ExchangeFileSystem extends AbstractFileSystem<MailItemId> implement
 	@Override
 	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		MailFolder f = findSubFolder(mailFolder, folder);
-		return f == null ? 0 : f.getTotalItemCount();
+		return f == null ? 0 : (int) f.getTotalItemCount();
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/MailFolder.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/MailFolder.java
@@ -27,10 +27,10 @@ public class MailFolder extends MailItemId {
 	@JsonProperty("displayName")
 	private String name;
 
-	private int childFolderCount;
-	private int unreadItemCount;
-	private int totalItemCount;
-	private int sizeInBytes;
+	private long childFolderCount;
+	private long unreadItemCount;
+	private long totalItemCount;
+	private long sizeInBytes;
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
Both are test scoped dependencies.

Fixes:
```txt
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/home/runner/.m2/repository/io/netty/netty-common/4.2.10.Final/netty-common-4.2.10.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```