### PR TITLE
Treat custom view URLs starting with '/' as server-root-relative paths

### DIFF
--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-custom-view/iframe-custom-view.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-custom-view/iframe-custom-view.component.ts
@@ -44,6 +44,8 @@ export class IframeCustomViewComponent extends BaseIframeComponent implements On
       this.window.open(view['url'], view['name']);
       this.redirectURL = view['url'];
       this.url = '';
+    } else if (view['url'].startsWith('/')) {
+      this.url = view['url'];
     } else {
       this.url = this.appService.getServerPath() + view['url'];
     }


### PR DESCRIPTION
Custom view URLs starting with / are now used as-is instead of being prefixed with the application's server path. This allows operators to configure links to sibling applications deployed on the same server (e.g. /other-app/) without them resolving incorrectly to /current-app//other-app/.                                                                                                                                 
                                                                                                                                                                                                                     
When Frank!Framework is deployed alongside other web applications in the same servlet container, it is common to want custom view links that point to those sibling applications. Until now, any URL that did not contain http was unconditionally prefixed with the server path, making it impossible to express a server-root-relative link without resorting to a full absolute URL including hostname and port.
                                                                                                                                                                                                                     The fix adds a simple guard: if the configured URL already starts with /, it is used directly and the server path prefix is skipped. Relative URLs (no leading slash, no protocol) continue to behave exactly as before, so existing configurations are unaffected. Absolute URLs containing http also continue to open in a new window as before. The change is a strict extension of the existing branching logic with no modifications to either of the two existing code paths.   