### PR TITLE
Merge dependency pull-requests from Renovate automatically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,11 @@
     "commitMessageSuffix": "",
     "packageRules": [
         {
+          "description": "Automerge non-major updates",
+          "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+          "automerge": true
+        },
+        {
             "description": "Maven dependencies - daily at 6 AM, ignore major updates",
             "matchManagers": [
                 "maven"


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Enable auto-merge for non-major dependency updates.

Relevant: #10519 

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>

## Also

Ladybug does get updates: https://github.com/frankframework/frankframework/pull/10335/changes

The variable is set in the ladybug/pom.xml.
The only place it is used is in ladybug/common/pom.xml.

Is that the best place for the variable?