### PR TITLE
Load AMDLoader only when intializing Console

### DIFF
--- a/console/frontend/src/main/frontend/src/app/app.component.ts
+++ b/console/frontend/src/main/frontend/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, OnDestroy, OnInit, Renderer2, Signal, WritableSignal
 import { filter, first, Subscription } from 'rxjs';
 import {
   Adapter,
+  AMDRequire,
   AppInitState,
   appInitState,
   AppService,
@@ -228,6 +229,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
         this.initializeWarnings();
         this.checkIafVersions();
+        this.initializeAmdLoader();
       },
       error: (error: HttpErrorResponse) => {
         this.appService.loading.set(false);
@@ -249,7 +251,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   checkIafVersions(): void {
-    /* Check FF version */
     console.log('Checking FF version with remote...');
     this.appService.getIafVersions(this.miscService.getUID(this.serverInfo!)).subscribe((response) => {
       this.serverInfo = null;
@@ -308,11 +309,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   initializeWarnings(): void {
-    /*const startupErrorSubscription = this.appService.startupError$.subscribe(() => {
-      this.startupError = this.appService.startupError();
-    });
-    this._subscriptionsReloadable.add(startupErrorSubscription);*/
-
     this.http
       .get<Record<string, MessageLog>>(`${this.appService.absoluteApiPath}server/warnings`)
       .subscribe((data) => this.processWarnings(data));
@@ -530,6 +526,15 @@ export class AppComponent implements OnInit, OnDestroy {
 
   openInfoModel(): void {
     this.modalService.open(InformationModalComponent, this.MODAL_OPTIONS_CLASSES);
+  }
+
+  private initializeAmdLoader(): void {
+    if ((globalThis as unknown as AMDRequire).require) return;
+    const loaderScript: HTMLScriptElement = document.createElement('script');
+    loaderScript.type = 'text/javascript';
+    loaderScript.src = 'assets/monaco/vs/loader.js';
+    loaderScript.addEventListener('load', () => this.appService.triggerAMDLoaderReady());
+    document.body.append(loaderScript);
   }
 
   private updateClusterMembers(member: ClusterMember, action: ClusterMemberEventType): void {

--- a/console/frontend/src/main/frontend/src/app/app.service.ts
+++ b/console/frontend/src/main/frontend/src/app/app.service.ts
@@ -226,6 +226,13 @@ export const appInitState = {
 } as const;
 export type AppInitState = (typeof appInitState)[keyof typeof appInitState];
 
+export type AMDRequire = {
+  require: {
+    (imports: string[], callback: () => void): void;
+    config(config: { paths: Record<string, string> }): void;
+  };
+};
+
 @Injectable({
   providedIn: 'root',
 })
@@ -241,11 +248,13 @@ export class AppService {
   public reload$: Observable<void>;
   public toggleSidebar$: Observable<void>;
   public customBreadcrumbs$: Observable<string>;
+  public amdLoaderReady$: Observable<void>;
   public consoleState: WritableSignal<AppInitState> = signal(appInitState.UN_INIT);
 
   private reloadSubject = new Subject<void>();
   private toggleSidebarSubject = new Subject<void>();
   private customBreadcrumbsSubject = new Subject<string>();
+  private amdLoaderReadySubject = new Subject<void>();
 
   private _adapters: WritableSignal<Record<string, Adapter>> = signal({});
   private _configurations: WritableSignal<Configuration[]> = signal([]);
@@ -289,6 +298,7 @@ export class AppService {
     this.reload$ = this.reloadSubject.asObservable();
     this.toggleSidebar$ = this.toggleSidebarSubject.asObservable();
     this.customBreadcrumbs$ = this.customBreadcrumbsSubject.asObservable();
+    this.amdLoaderReady$ = this.amdLoaderReadySubject.asObservable();
   }
 
   get adapters(): Signal<Record<string, Adapter>> {
@@ -441,6 +451,11 @@ export class AppService {
 
   toggleSidebar(): void {
     this.toggleSidebarSubject.next();
+  }
+
+  triggerAMDLoaderReady(): void {
+    this.amdLoaderReadySubject.next();
+    this.amdLoaderReadySubject.complete();
   }
 
   updateTitle(title: string): void {

--- a/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/monaco-editor/monaco-editor.component.ts
@@ -16,13 +16,7 @@ import {
 } from '@angular/core';
 import { first, Observable, ReplaySubject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-
-type AMDRequire = {
-  require: {
-    (imports: string[], callback: () => void): void;
-    config(config: { paths: Record<string, string> }): void;
-  };
-};
+import { AMDRequire, AppService } from '../../app.service';
 
 @Component({
   selector: 'app-monaco-editor',
@@ -47,9 +41,10 @@ export class MonacoEditorComponent implements AfterViewInit, OnChanges, OnDestro
 
   editor$: Observable<monaco.editor.IStandaloneCodeEditor>;
 
-  private router = inject(Router);
-  private route = inject(ActivatedRoute);
-  private zone = inject(NgZone);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly zone = inject(NgZone);
+  private readonly appService = inject(AppService);
 
   private editorSubject = new ReplaySubject<monaco.editor.IStandaloneCodeEditor>(1);
 
@@ -111,21 +106,18 @@ export class MonacoEditorComponent implements AfterViewInit, OnChanges, OnDestro
       return;
     }
 
-    if ((globalThis as unknown as AMDRequire).require) {
-      this.onAmdLoader();
-    } else {
-      const loaderScript: HTMLScriptElement = document.createElement('script');
-      loaderScript.type = 'text/javascript';
-      loaderScript.src = 'assets/monaco/vs/loader.js';
-      loaderScript.addEventListener('load', () => this.onAmdLoader());
-      document.body.append(loaderScript);
+    const amdWindow = globalThis as unknown as AMDRequire;
+    const amdLoaderSubscription = this.appService.amdLoaderReady$.subscribe(() => this.onAmdLoader(amdWindow));
+    if ((amdWindow as Partial<AMDRequire>).require) {
+      amdLoaderSubscription.unsubscribe();
+      this.onAmdLoader(amdWindow as AMDRequire);
     }
   }
 
-  private onAmdLoader(): void {
-    const windowRequire = (globalThis as unknown as AMDRequire).require;
-    windowRequire.config({ paths: { vs: 'assets/monaco/vs' } });
-    windowRequire(['vs/editor/editor.main'], () => {
+  private onAmdLoader(amdWindow: AMDRequire): void {
+    const { require } = amdWindow;
+    require.config({ paths: { vs: 'assets/monaco/vs' } });
+    require(['vs/editor/editor.main'], () => {
       this.initializeMonaco();
     });
   }


### PR DESCRIPTION
AMDLoader now only gets initialized during Console intialization and only once
Monaco editor has checks to wait for AMDLoader to be available