### PR TITLE
Add Kodiak config for auto approving dependency bots

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,10 @@
+version = 1
+
+[merge]
+method = "squash"
+delete_branch_on_merge = true
+notify_on_conflict = false
+show_missing_automerge_label_message = false
+
+[approve]
+auto_approve_usernames = ["dependabot", "renovate"]


### PR DESCRIPTION
This config enables Kodiak (https://kodiakhq.com/) which will auto approve dependabot and renovate PRs.

Also:
Set merge method and approval settings in config

## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked → Is there an issue?
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
