### PR TITLE
Fix AOP config for ladybug

### DIFF
--- a/core/src/main/java/org/frankframework/core/IBlockEnabledSender.java
+++ b/core/src/main/java/org/frankframework/core/IBlockEnabledSender.java
@@ -33,5 +33,6 @@ public interface IBlockEnabledSender<H> extends ISenderWithParameters {
 	 * after processing with the blockHandle ends. It should effectively be called in a finally clause of a try around the openBlock.
 	 */
 	void closeBlock(H blockHandle, PipeLineSession session) throws SenderException;
+
 	SenderResult sendMessage(H blockHandle, Message message, PipeLineSession session) throws SenderException, TimeoutException;
 }

--- a/core/src/main/java/org/frankframework/core/PipeLine.java
+++ b/core/src/main/java/org/frankframework/core/PipeLine.java
@@ -43,6 +43,7 @@ import lombok.extern.log4j.Log4j2;
 import org.frankframework.cache.ICache;
 import org.frankframework.cache.ICacheEnabled;
 import org.frankframework.configuration.AdapterAwareBeanPostProcessor;
+import org.frankframework.configuration.AopProxyBeanFactoryPostProcessor;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.configuration.ConfigurationWarnings;
@@ -172,6 +173,11 @@ public class PipeLine extends ConfigurableApplicationContext implements ICacheEn
 			adapter = contextAdapter;
 		} else {
 			throw new IllegalArgumentException("ApplicationContext must always be of type Adapter");
+		}
+
+		// AOP is required for the Ladybug to function.
+		if (getEnvironment().matchesProfiles("aop")) {
+			addBeanFactoryPostProcessor(new AopProxyBeanFactoryPostProcessor());
 		}
 
 		super.afterPropertiesSet();

--- a/core/src/main/java/org/frankframework/processors/CoreListenerProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CoreListenerProcessor.java
@@ -35,14 +35,14 @@ public class CoreListenerProcessor<M> implements ListenerProcessor<M> {
 	private final Logger log = LogUtil.getLogger(this);
 
 	@Override
-	public Message getMessage(ICorrelatedPullingListener<M> listener, String correlationID, PipeLineSession pipeLineSession) throws ListenerException, TimeoutException {
+	public Message getMessage(ICorrelatedPullingListener<M> listener, String correlationId, PipeLineSession pipeLineSession) throws ListenerException, TimeoutException {
 		if (log.isDebugEnabled())
-			log.debug("{}starts listening for return message with correlationID [{}]", getLogPrefix(listener, pipeLineSession), correlationID);
+			log.debug("{}starts listening for return message with correlationID [{}]", getLogPrefix(listener, pipeLineSession), correlationId);
 		Message result;
 		Map<String,Object> threadContext = new HashMap<>();
 		try {
 			threadContext = listener.openThread();
-			RawMessageWrapper<M> msg = listener.getRawMessage(correlationID, threadContext);
+			RawMessageWrapper<M> msg = listener.getRawMessage(correlationId, threadContext);
 			// TODO: Add a method to check if it is an empty / null RawMessageWrapper?
 			if (msg==null) {
 				log.info("{}received null reply message", getLogPrefix(listener, pipeLineSession));

--- a/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/CorePipeLineProcessor.java
@@ -62,7 +62,6 @@ public class CorePipeLineProcessor implements PipeLineProcessor, ApplicationCont
 
 	@Override
 	public PipeLineResult processPipeLine(PipeLine pipeLine, String messageId, @NonNull Message message, PipeLineSession pipeLineSession, String firstPipe) throws PipeRunException {
-
 		if (message.isEmpty() && StringUtils.isNotEmpty(pipeLine.getAdapterToRunBeforeOnEmptyInput())) {
 			log.debug("running adapterBeforeOnEmptyInput");
 			Adapter adapter = configuration.getRegisteredAdapter(pipeLine.getAdapterToRunBeforeOnEmptyInput());

--- a/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/InputOutputPipeProcessor.java
@@ -72,7 +72,7 @@ public class InputOutputPipeProcessor extends AbstractPipeProcessor {
 	// Should the skipPipe be handled before getInputFrom?
 	@NonNull
 	@Override
-	protected PipeRunResult processPipe(@NonNull PipeLine pipeLine, @NonNull IPipe pipe, @NonNull final Message inputMessage, @NonNull PipeLineSession pipeLineSession, @NonNull ThrowingFunction<Message, PipeRunResult,PipeRunException> chain) throws PipeRunException {
+	protected PipeRunResult processPipe(@NonNull PipeLine pipeLine, @NonNull IPipe pipe, @NonNull final Message inputMessage, @NonNull PipeLineSession pipeLineSession, @NonNull ThrowingFunction<Message, PipeRunResult, PipeRunException> chain) throws PipeRunException {
 		Message originalMessage = inputMessage;
 
 		// Get the input message for the pipe to be processed, does not return null.

--- a/core/src/main/java/org/frankframework/processors/ListenerProcessor.java
+++ b/core/src/main/java/org/frankframework/processors/ListenerProcessor.java
@@ -26,6 +26,6 @@ import org.frankframework.stream.Message;
  */
 public interface ListenerProcessor<M> {
 
-	Message getMessage(ICorrelatedPullingListener<M> listener, String correlationID, PipeLineSession pipeLineSession) throws ListenerException, TimeoutException;
+	Message getMessage(ICorrelatedPullingListener<M> listener, String correlationId, PipeLineSession pipeLineSession) throws ListenerException, TimeoutException;
 
 }

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -175,9 +175,6 @@
 		<!-- Logger name="org.springframework.aop" level="DEBUG" additivity="false">
 			<AppenderRef ref="stdout"/>
 		</Logger -->
-		<!-- Logger name="bitronix.tm" level="DEBUG" additivity="false">
-			<AppenderRef ref="stdout"/>
-		</Logger -->
 		<!-- Logger name="org.quartz" level="DEBUG" additivity="false">
 			<AppenderRef ref="stdout"/>
 		</Logger -->

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/IbisDebuggerAdvice.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/IbisDebuggerAdvice.java
@@ -267,29 +267,29 @@ public class IbisDebuggerAdvice implements InitializingBean, ThreadLifeCycleEven
 	}
 
 	/**
+	 * Provides advice for {@link ISender#sendMessage(Message message, PipeLineSession session)}
+	 */
+	public SenderResult debugSenderSendMessage(ProceedingJoinPoint proceedingJoinPoint, Message message, PipeLineSession session) throws Throwable {
+		return debugSenderInputOutputAbort(proceedingJoinPoint, message, session, 0);
+	}
+
+	/**
 	 * Provides advice for {@link ISender#sendMessageOrThrow(Message message, PipeLineSession session)}
 	 */
-	public Message debugSenderSendMessageOrThrow(ProceedingJoinPoint proceedingJoinPoint, Message message, PipeLineSession pipeLineSession) throws Throwable {
+	public Message debugSenderSendMessageOrThrow(ProceedingJoinPoint proceedingJoinPoint, Message message, PipeLineSession session) throws Throwable {
 		if (!isEnabled() || proceedingJoinPoint.getTarget() instanceof SendMessageJobSender) {
 			return (Message) proceedingJoinPoint.proceed();
 		}
 
-		SenderResult result = debugSenderInputOutputAbort(proceedingJoinPoint, message, pipeLineSession, 0);
+		SenderResult result = debugSenderInputOutputAbort(proceedingJoinPoint, message, session, 0);
 		return result.getResult();
-	}
-
-	/**
-	 * Provides advice for {@link ISender#sendMessage(Message message, PipeLineSession session)}
-	 */
-	public SenderResult debugSenderSendMessage(ProceedingJoinPoint proceedingJoinPoint, Message message, PipeLineSession pipeLineSession) throws Throwable {
-		return debugSenderInputOutputAbort(proceedingJoinPoint, message, pipeLineSession, 0);
 	}
 
 	/**
 	 * Provides advice for {@link IBlockEnabledSender#sendMessage(Object blockHandle, Message message, PipeLineSession session)}
 	 */
-	public SenderResult debugBlockEnabledSenderInputOutputAbort(ProceedingJoinPoint proceedingJoinPoint, Object blockHandle, Message message, PipeLineSession pipeLineSession) throws Throwable {
-		return debugSenderInputOutputAbort(proceedingJoinPoint, message, pipeLineSession, 1);
+	public SenderResult debugBlockEnabledSenderInputOutputAbort(ProceedingJoinPoint proceedingJoinPoint, Object blockHandle, Message message, PipeLineSession session) throws Throwable {
+		return debugSenderInputOutputAbort(proceedingJoinPoint, message, session, 1);
 	}
 
 	@Override
@@ -340,19 +340,19 @@ public class IbisDebuggerAdvice implements InitializingBean, ThreadLifeCycleEven
 
 
 	/**
-	 * Provides advice for {@link CacheSenderWrapperProcessor#sendMessage(AbstractSenderWrapper senderWrapperBase, Message message, PipeLineSession session)}
+	 * Provides advice for {@link CacheSenderWrapperProcessor#sendMessage(AbstractSenderWrapper abstractSenderWrapper, Message message, PipeLineSession session)}
 	 */
-	public SenderResult debugSenderGetInputFrom(ProceedingJoinPoint proceedingJoinPoint, AbstractSenderWrapper senderWrapperBase, Message message, PipeLineSession pipeLineSession) throws Throwable {
+	public SenderResult debugSenderGetInputFrom(ProceedingJoinPoint proceedingJoinPoint, AbstractSenderWrapper abstractSenderWrapper, Message message, PipeLineSession session) throws Throwable {
 		if (!isEnabled()) {
 			return (SenderResult)proceedingJoinPoint.proceed();
 		}
-		String correlationId = getCorrelationId(pipeLineSession);
+		String correlationId = getCorrelationId(session);
 		Message result = debugGetInputFrom(
-				pipeLineSession, correlationId, message,
-				senderWrapperBase.getGetInputFromSessionKey(),
-				senderWrapperBase.getGetInputFromFixedValue(),
+				session, correlationId, message,
+				abstractSenderWrapper.getGetInputFromSessionKey(),
+				abstractSenderWrapper.getGetInputFromFixedValue(),
 				null);
-		if (debugger.stubSender(senderWrapperBase, correlationId)) {
+		if (debugger.stubSender(abstractSenderWrapper, correlationId)) {
 			return null;
 		}
 		Object[] args = proceedingJoinPoint.getArgs();

--- a/ladybug/debugger/src/main/resources/springIbisDebuggerAdvice.xml
+++ b/ladybug/debugger/src/main/resources/springIbisDebuggerAdvice.xml
@@ -102,10 +102,10 @@
 						)
 					)
 					and
-					args(message, pipeLineSession)
+					args(message, session)
 					"
 				method="debugSenderSendMessage"
-				arg-names="proceedingJoinPoint, message, pipeLineSession"
+				arg-names="proceedingJoinPoint, message, session"
 			/>
 			<aop:around
 				pointcut=
@@ -118,10 +118,10 @@
 						)
 					)
 					and
-					args(message, pipeLineSession)
+					args(message, session)
 					"
 				method="debugSenderSendMessageOrThrow"
-				arg-names="proceedingJoinPoint, message, pipeLineSession"
+				arg-names="proceedingJoinPoint, message, session"
 			/>
 			<aop:around
 				pointcut=
@@ -135,10 +135,10 @@
 						)
 					)
 					and
-					args(blockHandle, message, pipeLineSession)
+					args(blockHandle, message, session)
 					"
 				method="debugBlockEnabledSenderInputOutputAbort"
-				arg-names="proceedingJoinPoint, blockHandle, message, pipeLineSession"
+				arg-names="proceedingJoinPoint, blockHandle, message, session"
 			/>
 			<aop:around
 				pointcut=
@@ -152,10 +152,10 @@
 						)
 					)
 					and
-					args(senderWrapperBase, message, pipeLineSession)
+					args(abstractSenderWrapper, message, session)
 					"
 				method="debugSenderGetInputFrom"
-				arg-names="proceedingJoinPoint, senderWrapperBase, message, pipeLineSession"
+				arg-names="proceedingJoinPoint, abstractSenderWrapper, message, session"
 			/>
 			<aop:around
 				pointcut=

--- a/test/src/test/java/org/frankframework/core/TestAopConfiguration.java
+++ b/test/src/test/java/org/frankframework/core/TestAopConfiguration.java
@@ -1,0 +1,30 @@
+package org.frankframework.core;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+
+import org.frankframework.runner.FrankApplication;
+
+public class TestAopConfiguration {
+
+	@Test
+	@DisplayName("Verify https://github.com/frankframework/frankframework/issues/10734 does not occur.")
+	void validateThereAreNoAopErrors() throws Exception {
+		FrankApplication frankApplication;
+		try (TestAppender testAppender = TestAppender.newBuilder().minLogLevel(Level.DEBUG).build(AspectJExpressionPointcut.class)) {
+			frankApplication = new FrankApplication();
+			frankApplication.run();
+
+			assertTrue(frankApplication.isRunning());
+
+			assertTrue(testAppender.getLogEvents().isEmpty(), "FOUND AOP ERRORS! >> " + testAppender.getLogEvents());
+		}
+
+		FrankApplication.exit(frankApplication);
+	}
+
+}

--- a/test/src/test/java/org/frankframework/core/TestAppender.java
+++ b/test/src/test/java/org/frankframework/core/TestAppender.java
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package org.frankframework.console.util;
+package org.frankframework.core;
 
 import java.io.Serializable;
 import java.util.ArrayList;


### PR DESCRIPTION
Unfortunatelly I had to duplicate (and improve) the TestAppender code. But we now have a test to prevent this from happening again 😄.

It is still possible some classes are not pointcut due to AOP being disabled for example. I had to explicitly enable it in the pipeline config... At least right now we will know when the arguments don't match.