### PR TITLE
Downgrade rabbitmq test container image to 4.2

### DIFF
--- a/messaging/src/test/java/org/frankframework/messaging/amqp/RabbitMQ4AmqpListenerTest.java
+++ b/messaging/src/test/java/org/frankframework/messaging/amqp/RabbitMQ4AmqpListenerTest.java
@@ -11,7 +11,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 class RabbitMQ4AmqpListenerTest extends AmqpListenerTest {
 
-	private static final String RABBIT_MQ_DOCKER_TAG = "rabbitmq:4-alpine";
+	private static final String RABBIT_MQ_DOCKER_TAG = "rabbitmq:4.2-alpine";
 
 	@Container
 	private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(RABBIT_MQ_DOCKER_TAG)

--- a/messaging/src/test/java/org/frankframework/messaging/amqp/RabbitMQ4AmqpSenderTest.java
+++ b/messaging/src/test/java/org/frankframework/messaging/amqp/RabbitMQ4AmqpSenderTest.java
@@ -12,7 +12,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 class RabbitMQ4AmqpSenderTest extends AmqpSenderTest {
 
-	private static final String RABBIT_MQ_DOCKER_TAG = "rabbitmq:4-alpine";
+	private static final String RABBIT_MQ_DOCKER_TAG = "rabbitmq:4.2-alpine";
 
 	@Container
 	private static final RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(RABBIT_MQ_DOCKER_TAG)


### PR DESCRIPTION
RabbitMQ4AmqpListenerTest is failing because of a new [4.3 release](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0), deprecating amqp_address_v1. Pinning the docker image use in the test to 4.2 solves the issue.