### PR TITLE
Implement WS Addressing to determine MessageID

### DIFF
--- a/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
+++ b/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
@@ -203,7 +203,7 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 			SOAPHeader header = request.getSOAPHeader();
 			// Verify we have a SOAPHeader. Possibly also that the Addressing namespace is present?
 			if (header != null) {
-				NodeList nodes = header.getElementsByTagName("MessageID");
+				NodeList nodes = header.getElementsByTagNameNS("*", "MessageID");
 				if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
 					String messageId = nodes.item(0).getTextContent();
 					if (StringUtils.isNotBlank(messageId)) {

--- a/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
+++ b/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
@@ -26,6 +26,7 @@ import jakarta.xml.soap.AttachmentPart;
 import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.MimeHeader;
 import jakarta.xml.soap.SOAPConstants;
+import jakarta.xml.soap.SOAPElement;
 import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPHeader;
 import jakarta.xml.soap.SOAPMessage;
@@ -76,6 +77,7 @@ import org.frankframework.util.XmlUtils;
 @ServiceMode(value=jakarta.xml.ws.Service.Mode.MESSAGE)
 @BindingType(jakarta.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
 public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
+	private static final String WS_ADDR_NS = "https://www.w3.org/2006/03/addressing/ws-addr.xsd";
 
 	private String attachmentXmlSessionKey = null;
 	private Map<String, MessageFactory> factory = new HashMap<>();
@@ -129,62 +131,79 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 			String soapProtocol = pipelineSession.get(SOAP_PROTOCOL_KEY, SOAPConstants.SOAP_1_1_PROTOCOL);
 			SOAPMessage soapMessage = convertResponseToSoapMessage(response, soapProtocol);
 
-			String multipartXml = pipelineSession.getString(attachmentXmlSessionKey);
-			log.debug("building multipart message with MultipartXmlSessionKey [{}]", multipartXml);
-			if (StringUtils.isNotEmpty(multipartXml)) {
-				Element partsElement;
-				try {
-					partsElement = XmlUtils.buildElement(multipartXml);
-				}
-				catch (DomBuilderException e) {
-					String m = "error building multipart xml";
-					log.error(m, e);
-					throw new WebServiceException(m, e);
-				}
-				List<Node> parts = XmlUtils.getChildTags(partsElement, "part");
-				if (parts.isEmpty()) {
-					log.warn("no part(s) in multipart xml [{}]", multipartXml);
-				} else {
-					for (final Node part : parts) {
-						Element partElement = (Element) part;
-
-						String partSessionKey = partElement.getAttribute("sessionKey");
-						String name = partElement.getAttribute("name");
-						Message partObject = pipelineSession.getMessage(partSessionKey);
-
-						if (!partObject.isNull()) {
-							String mimeType = partElement.getAttribute("mimeType"); // Optional, auto-detected if not set
-							MessageDataSource ds = new MessageDataSource(partObject, mimeType);
-							SourceClosingDataHandler dataHander = new SourceClosingDataHandler(ds);
-							AttachmentPart attachmentPart = soapMessage.createAttachmentPart(dataHander);
-							attachmentPart.setContentId(partSessionKey); // ContentID is URLDecoded, it may not contain special characters, see #4661
-
-							String filename = StringUtils.isNotBlank(name) ? name : ds.getName();
-							attachmentPart.addMimeHeader("Content-Disposition", "attachment; name=\""+filename+"\"; filename=\""+filename+"\"");
-							soapMessage.addAttachmentPart(attachmentPart);
-
-							log.debug("appended filepart [{}] key [{}]", filename, partSessionKey);
-						} else {
-							log.debug("skipping filepart [{}] key [{}], content is <NULL>", name, partSessionKey);
-						}
-					}
-				}
+			if (StringUtils.isNotEmpty(attachmentXmlSessionKey) && pipelineSession.containsKey(attachmentXmlSessionKey)) {
+				log.debug("building multipart message with MultipartXmlSessionKey [{}]", attachmentXmlSessionKey);
+				addAttachments(soapMessage, pipelineSession);
 			}
+
+			setMessageId(soapMessage, messageId);
 
 			return soapMessage;
 		}
 	}
 
+	private void addAttachments(SOAPMessage soapMessage, PipeLineSession pipelineSession) {
+		String multipartXml = pipelineSession.getString(attachmentXmlSessionKey);
+
+		Element partsElement;
+		try {
+			partsElement = XmlUtils.buildElement(multipartXml);
+		}
+		catch (DomBuilderException e) {
+			String m = "error building multipart xml";
+			log.error(m, e);
+			throw new WebServiceException(m, e);
+		}
+		List<Node> parts = XmlUtils.getChildTags(partsElement, "part");
+		if (parts.isEmpty()) {
+			log.warn("no part(s) in multipart xml [{}]", multipartXml);
+		} else {
+			log.debug("found [{}] part(s) in multipart xml [{}]", parts::size, () -> multipartXml);
+
+			for (final Node part : parts) {
+				Element partElement = (Element) part;
+
+				String partSessionKey = partElement.getAttribute("sessionKey");
+				String name = partElement.getAttribute("name");
+				Message partObject = pipelineSession.getMessage(partSessionKey);
+
+				if (!partObject.isNull()) {
+					String mimeType = partElement.getAttribute("mimeType"); // Optional, auto-detected if not set
+					MessageDataSource ds = new MessageDataSource(partObject, mimeType);
+					SourceClosingDataHandler dataHander = new SourceClosingDataHandler(ds);
+					AttachmentPart attachmentPart = soapMessage.createAttachmentPart(dataHander);
+					attachmentPart.setContentId(partSessionKey); // ContentID is URLDecoded, it may not contain special characters, see #4661
+
+					String filename = StringUtils.isNotBlank(name) ? name : ds.getName();
+					attachmentPart.addMimeHeader("Content-Disposition", "attachment; name=\""+filename+"\"; filename=\""+filename+"\"");
+					soapMessage.addAttachmentPart(attachmentPart);
+
+					log.debug("appended filepart [{}] key [{}]", filename, partSessionKey);
+				} else {
+					log.debug("skipping filepart [{}] key [{}], content is <NULL>", name, partSessionKey);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get or generate a MessageID.
+	 * Inherits the WSA MessageID if present or generates one.
+	 * 
+	 * Ideally we should ensure the MessageID element uses the {@value #WS_ADDR_NS} namespace,
+	 * but some people use http vs https or an older version of the spec...
+	 */
 	private String getMessageId(@Nullable SOAPMessage request) {
 		if (request == null) {
+			// We're not going to process the message, but require an identifier for traceability.
 			return MessageUtils.generateFallbackMessageId();
 		}
 
 		try {
 			SOAPHeader header = request.getSOAPHeader();
-			// Verify we have a SOAPHeader and the Addressing namespace is present.
-			if (header != null && header.lookupPrefix("http://www.w3.org/2005/08/addressing") != null) {
-				NodeList nodes = header.getElementsByTagNameNS("http://www.w3.org/2005/08/addressing", "MessageID");
+			// Verify we have a SOAPHeader. Possibly also that the Addressing namespace is present?
+			if (header != null) {
+				NodeList nodes = header.getElementsByTagName("MessageID");
 				if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
 					String messageId = nodes.item(0).getTextContent();
 					if (StringUtils.isNotBlank(messageId)) {
@@ -193,10 +212,29 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 				}
 			}
 		} catch (SOAPException e) {
-			// Perhaps there is no header?
+			log.warn("determined we should read the WSA [MessageID] element but was unable to", e);
 		}
 
 		return MessageUtils.generateMessageId();
+	}
+
+	/**
+	 * If a MessageID was provided, ensure we return a 'RelatesTo' header conform the ws-addr specification.
+	 */
+	private void setMessageId(SOAPMessage soapMessage, String messageId) {
+		if (MessageUtils.isFallbackMessageId(messageId) || messageId.startsWith(MessageUtils.DEFAULT_MESSAGE_ID_PREFIX)) {
+			return;
+		}
+
+		try {
+			SOAPHeader header = soapMessage.getSOAPHeader();
+			if (header != null) {
+				SOAPElement relatesTo = header.addChildElement("RelatesTo", "wsa", WS_ADDR_NS);
+				relatesTo.addTextNode(messageId);
+			}
+		} catch (SOAPException e) {
+			log.warn("determined we should add a WSA [RelatesTo] element but was unable to", e);
+		}
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
+++ b/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
@@ -27,6 +27,7 @@ import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.MimeHeader;
 import jakarta.xml.soap.SOAPConstants;
 import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPHeader;
 import jakarta.xml.soap.SOAPMessage;
 import jakarta.xml.soap.SOAPPart;
 import jakarta.xml.ws.BindingType;
@@ -40,9 +41,11 @@ import jakarta.xml.ws.handler.MessageContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.logging.log4j.CloseableThreadContext;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.MimeType;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import lombok.extern.log4j.Log4j2;
@@ -111,8 +114,8 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 	}
 
 	@Override
-	public SOAPMessage invoke(SOAPMessage request) {
-		String messageId = MessageUtils.generateFallbackMessageId();
+	public SOAPMessage invoke(@Nullable SOAPMessage request) {
+		String messageId = getMessageId(request);
 		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put(LogUtil.MDC_MESSAGE_ID_KEY, messageId);
 				PipeLineSession pipelineSession = new PipeLineSession()) {
 
@@ -170,6 +173,30 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 
 			return soapMessage;
 		}
+	}
+
+	private String getMessageId(@Nullable SOAPMessage request) {
+		if (request == null) {
+			return MessageUtils.generateFallbackMessageId();
+		}
+
+		try {
+			SOAPHeader header = request.getSOAPHeader();
+			// Verify we have a SOAPHeader and the Addressing namespace is present.
+			if (header != null && header.lookupPrefix("http://www.w3.org/2005/08/addressing") != null) {
+				NodeList nodes = header.getElementsByTagNameNS("http://www.w3.org/2005/08/addressing", "MessageID");
+				if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
+					String messageId = nodes.item(0).getTextContent();
+					if (StringUtils.isNotBlank(messageId)) {
+						return messageId;
+					}
+				}
+			}
+		} catch (SOAPException e) {
+			// Perhaps there is no header?
+		}
+
+		return MessageUtils.generateMessageId();
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
+++ b/core/src/main/java/org/frankframework/http/cxf/AbstractSOAPProvider.java
@@ -189,7 +189,7 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 	/**
 	 * Get or generate a MessageID.
 	 * Inherits the WSA MessageID if present or generates one.
-	 * 
+	 *
 	 * Ideally we should ensure the MessageID element uses the {@value #WS_ADDR_NS} namespace,
 	 * but some people use http vs https or an older version of the spec...
 	 */
@@ -228,7 +228,7 @@ public abstract class AbstractSOAPProvider implements Provider<SOAPMessage> {
 
 		try {
 			SOAPHeader header = soapMessage.getSOAPHeader();
-			if (header != null) {
+			if (header != null && header.getElementsByTagNameNS("*", "RelatesTo").getLength() == 0) {
 				SOAPElement relatesTo = header.addChildElement("RelatesTo", "wsa", WS_ADDR_NS);
 				relatesTo.addTextNode(messageId);
 			}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -2034,9 +2034,9 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	}
 
 	/**
-	 * Sender to which the response (output of {@link PipeLine}) should be sent. Applies if the receiver
-	 * has an asynchronous listener.
-	 * N.B. Sending correlated responses via this sender is not supported.
+	 * Sender to which the response (output of {@link PipeLine}) should be sent. Applies <i>only</i> if the receiver
+	 * has an asynchronous listener. <br/>
+	 * If possible, please use the replyDestinationName attribute on the JmsListener instead.
 	 */
 	public void setSender(ICorrelatedSender sender) {
 		this.sender = sender;

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
@@ -19,7 +19,6 @@ public class SoapProviderStub extends AbstractSOAPProvider {
 	Message processRequest(SOAPMessage message, PipeLineSession pipelineSession) {
 		pipelineSession.putAll(session);
 
-//		pipelineSession.mergeToParentSession("*", session);
 		session.putAll(pipelineSession);
 		return parseSOAPMessage(message);
 	}

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderStub.java
@@ -19,7 +19,8 @@ public class SoapProviderStub extends AbstractSOAPProvider {
 	Message processRequest(SOAPMessage message, PipeLineSession pipelineSession) {
 		pipelineSession.putAll(session);
 
-		pipelineSession.mergeToParentSession("*", session);
+//		pipelineSession.mergeToParentSession("*", session);
+		session.putAll(pipelineSession);
 		return parseSOAPMessage(message);
 	}
 

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
@@ -566,8 +566,8 @@ public class SoapProviderTest {
 
 		NodeList nodes = response.getSOAPHeader().getElementsByTagNameNS("https://www.w3.org/2006/03/addressing/ws-addr.xsd", "RelatesTo");
 		if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
-			String messageId = nodes.item(0).getTextContent();
-			assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", messageId);
+			String relatesTo = nodes.item(0).getTextContent();
+			assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", relatesTo);
 		} else {
 			fail("no message id found in response: " + XmlUtils.nodeToString(response.getSOAPPart()));
 		}
@@ -584,5 +584,24 @@ public class SoapProviderTest {
 
 		NodeList nodes = response.getSOAPHeader().getElementsByTagNameNS("https://www.w3.org/2006/03/addressing/ws-addr.xsd", "RelatesTo");
 		assertEquals(0, nodes.getLength());
+	}
+
+	@Test
+	/**
+	 * We want to ensure that when somebody has manually set a relatesTo (although I cannot imaging why) we don't overwrite it.
+	 */
+	public void soapWithManualRelatesTo() throws Throwable {
+		SOAPMessage request = createMessage("soap-addressing-with-relatesto.xml");
+		SOAPMessage response = SOAPProvider.invoke(request);
+
+		assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", SOAPProvider.getSession().getMessageId());
+
+		NodeList nodes = response.getSOAPHeader().getElementsByTagNameNS("*", "RelatesTo");
+		if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
+			String relatesTo = nodes.item(0).getTextContent();
+			assertEquals("test123", relatesTo);
+		} else {
+			fail("no message id found in response: " + XmlUtils.nodeToString(response.getSOAPPart()));
+		}
 	}
 }

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
@@ -55,6 +55,7 @@ import org.frankframework.stream.Message;
 import org.frankframework.stream.MessageContext;
 import org.frankframework.stream.UrlMessage;
 import org.frankframework.testutil.MatchUtils;
+import org.frankframework.util.MessageUtils;
 import org.frankframework.util.StreamUtil;
 import org.frankframework.util.XmlUtils;
 
@@ -547,5 +548,28 @@ public class SoapProviderTest {
 	@Test
 	public void nullAction() {
 		assertNull(SOAPProvider.findAction("application/soap+xml;charset=UTF-8;action"));
+	}
+
+	/**
+	 * Since we have plenty of tests that verify request / responses,
+	 * we just focus on the messageId here.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = {"soap-addressing.xml", "soap-addressing-ns-on-header.xml"})
+	public void soapAddressing(String input) throws Throwable {
+		SOAPMessage request = createMessage(input);
+		SOAPProvider.invoke(request);
+
+		assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", SOAPProvider.getSession().getMessageId());
+	}
+
+	@Test
+	public void soapAddresNoMid() throws Throwable {
+		SOAPMessage request = createMessage("soap-addressing-ns-but-no-mid.xml");
+		SOAPProvider.invoke(request);
+
+		String mid = SOAPProvider.getSession().getMessageId();
+		assertNotNull(mid);
+		assertTrue(mid.startsWith(MessageUtils.DEFAULT_MESSAGE_ID_PREFIX));
 	}
 }

--- a/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
+++ b/core/src/test/java/org/frankframework/http/cxf/SoapProviderTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineSession;
@@ -555,21 +557,32 @@ public class SoapProviderTest {
 	 * we just focus on the messageId here.
 	 */
 	@ParameterizedTest
-	@ValueSource(strings = {"soap-addressing.xml", "soap-addressing-ns-on-header.xml"})
+	@ValueSource(strings = {"soap-addressing.xml", "soap-addressing-ns.xml", "soap-addressing-minimal.xml", "soap-addressing-ns-on-header.xml"})
 	public void soapAddressing(String input) throws Throwable {
 		SOAPMessage request = createMessage(input);
-		SOAPProvider.invoke(request);
+		SOAPMessage response = SOAPProvider.invoke(request);
 
 		assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", SOAPProvider.getSession().getMessageId());
+
+		NodeList nodes = response.getSOAPHeader().getElementsByTagNameNS("https://www.w3.org/2006/03/addressing/ws-addr.xsd", "RelatesTo");
+		if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
+			String messageId = nodes.item(0).getTextContent();
+			assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", messageId);
+		} else {
+			fail("no message id found in response: " + XmlUtils.nodeToString(response.getSOAPPart()));
+		}
 	}
 
 	@Test
 	public void soapAddresNoMid() throws Throwable {
 		SOAPMessage request = createMessage("soap-addressing-ns-but-no-mid.xml");
-		SOAPProvider.invoke(request);
+		SOAPMessage response = SOAPProvider.invoke(request);
 
 		String mid = SOAPProvider.getSession().getMessageId();
 		assertNotNull(mid);
 		assertTrue(mid.startsWith(MessageUtils.DEFAULT_MESSAGE_ID_PREFIX));
+
+		NodeList nodes = response.getSOAPHeader().getElementsByTagNameNS("https://www.w3.org/2006/03/addressing/ws-addr.xsd", "RelatesTo");
+		assertEquals(0, nodes.getLength());
 	}
 }

--- a/core/src/test/resources/Soap/soap-addressing-minimal.xml
+++ b/core/src/test/resources/Soap/soap-addressing-minimal.xml
@@ -1,0 +1,8 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header>
+		<wsa:MessageID xmlns:wsa="https://www.w3.org/2006/03/addressing/ws-addr.xsd">6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>

--- a/core/src/test/resources/Soap/soap-addressing-ns-but-no-mid.xml
+++ b/core/src/test/resources/Soap/soap-addressing-ns-but-no-mid.xml
@@ -1,0 +1,8 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+		<wsa:MessageID />
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>

--- a/core/src/test/resources/Soap/soap-addressing-ns-on-header.xml
+++ b/core/src/test/resources/Soap/soap-addressing-ns-on-header.xml
@@ -1,0 +1,8 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>

--- a/core/src/test/resources/Soap/soap-addressing-ns.xml
+++ b/core/src/test/resources/Soap/soap-addressing-ns.xml
@@ -1,5 +1,7 @@
 <Envelope xmlns="http://www.w3.org/2003/05/soap-envelope"
-	xmlns:wsa="http://www.w3.org/2006/03/addressing/ws-addr.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.w3.org/2005/08/addressing https://www.w3.org/2006/03/addressing/ws-addr.xsd"
+	xmlns:wsa="http://www.w3.org/2005/08/addressing">
 	<Header>
 		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
 		<wsa:ReplyTo>

--- a/core/src/test/resources/Soap/soap-addressing-with-relatesto.xml
+++ b/core/src/test/resources/Soap/soap-addressing-with-relatesto.xml
@@ -1,0 +1,10 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+		<!-- We can do this because the input is the output (of our SoapProviderStub), and the input ignores this field. -->
+		<wsa:RelatesTo>test123</wsa:RelatesTo>
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>

--- a/core/src/test/resources/Soap/soap-addressing.xml
+++ b/core/src/test/resources/Soap/soap-addressing.xml
@@ -1,0 +1,14 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope"
+	xmlns:wsa="http://www.w3.org/2005/08/addressing">
+	<Header>
+		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+		<wsa:ReplyTo>
+			<wsa:Address>http://example.com/business/client</wsa:Address>
+		</wsa:ReplyTo>
+		<wsa:To>http://example.com/fabrikam/Purchasing</wsa:To>
+		<wsa:Action>http://example.com/fabrikam/SubmitPO</wsa:Action>
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

In order to reduce the use of a fallback-MessageID, I've implemented a way to retrieve it from the message it self using the soap-addressing spec.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [iks] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [iks] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
