### PR TITLE
Remove hostname from MessageUtils.generateMessageID

### DIFF
--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -83,7 +83,6 @@ import org.frankframework.stream.MessageContext;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.DateFormatUtils;
 import org.frankframework.util.LogUtil;
-import org.frankframework.util.MessageUtils;
 import org.frankframework.util.Misc;
 import org.frankframework.util.RunState;
 import org.frankframework.util.RunStateManager;
@@ -759,12 +758,7 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 	 * @param pipeLineSession {@link PipeLineSession} session in which message is to be processed
 	 * @return The {@link PipeLineResult} from processing the message, or indicating what error occurred.
 	 */
-	public PipeLineResult processMessageDirect(String messageId, Message message, PipeLineSession pipeLineSession) {
-		if (StringUtils.isEmpty(messageId)) {
-			messageId = MessageUtils.generateFallbackMessageId();
-			log.info("messageId not set, creating synthetic id [{}]", messageId);
-			pipeLineSession.put(PipeLineSession.MESSAGE_ID_KEY, messageId);
-		}
+	public PipeLineResult processMessageDirect(@NonNull String messageId, @NonNull Message message, PipeLineSession pipeLineSession) {
 		try (final CloseableThreadContext.Instance ignored = LogUtil.getThreadContext(this, messageId, pipeLineSession);
 			IbisMaskingLayout.HideRegexContext ignored2 = IbisMaskingLayout.pushToThreadLocalReplace(composedHideRegexPattern)
 		) {

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -472,17 +472,13 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 		return dm;
 	}
 
+	/**
+	 * The MessageID is never null as it's set in {@link #setupChildSession(PipeLineSession, ParameterValueList, PipeLineSession)}.
+	 */
 	private ServiceClient getAdapterServiceClient(String target) throws SenderException {
 		Adapter adapter = findAdapter(target);
 		return (message, session) -> {
-			String messageId = session.getMessageId();
-			if (StringUtils.isEmpty(messageId)) {
-				// TODO figure out if this can actually happen
-				messageId = MessageUtils.generateFallbackMessageId();
-				log.info("messageId not set, creating synthetic id [{}]", messageId);
-			}
-
-			PipeLineResult plr = adapter.processMessageDirect(messageId, message, session);
+			PipeLineResult plr = adapter.processMessageDirect(session.getMessageId(), message, session);
 			session.setExitState(plr);
 			// TODO: The code here seems rather dubious actually. Check if we really want to keep this special behaviour on having the text "ListenerException" in our error message.
 			if (plr.getState() == PipeLine.ExitState.ERROR) {

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -475,7 +475,14 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	private ServiceClient getAdapterServiceClient(String target) throws SenderException {
 		Adapter adapter = findAdapter(target);
 		return (message, session) -> {
-			PipeLineResult plr = adapter.processMessageDirect(session.getMessageId(), message, session);
+			String messageId = session.getMessageId();
+			if (StringUtils.isEmpty(messageId)) {
+				// TODO figure out if this can actually happen
+				messageId = MessageUtils.generateFallbackMessageId();
+				log.info("messageId not set, creating synthetic id [{}]", messageId);
+			}
+
+			PipeLineResult plr = adapter.processMessageDirect(messageId, message, session);
 			session.setExitState(plr);
 			// TODO: The code here seems rather dubious actually. Check if we really want to keep this special behaviour on having the text "ListenerException" in our error message.
 			if (plr.getState() == PipeLine.ExitState.ERROR) {

--- a/core/src/main/java/org/frankframework/util/MessageUtils.java
+++ b/core/src/main/java/org/frankframework/util/MessageUtils.java
@@ -505,7 +505,7 @@ public class MessageUtils {
 	}
 
 	public static @NonNull String generateMessageId(String prefix) {
-		return prefix + "-" + Misc.getHostname() + "-" + UUIDUtil.createSimpleUUID();
+		return prefix + "-" + UUIDUtil.createSimpleUUID();
 	}
 
 	public static @NonNull String generateFallbackMessageId() {


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

I'm unsure why we included the hostname, but I don't think it's useful? The ID is unique enough as it is...

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
