### PR TITLE
Configure automerge to be done by Kodiak instead of Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,11 +29,6 @@
     "commitMessageSuffix": "",
     "packageRules": [
         {
-          "description": "Automerge non-major updates",
-          "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-          "automerge": true
-        },
-        {
             "description": "Maven dependencies - daily at 6 AM, ignore major updates",
             "matchManagers": [
                 "maven"

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -6,5 +6,9 @@ delete_branch_on_merge = true
 notify_on_conflict = false
 show_missing_automerge_label_message = false
 
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot", "renovate"]
+
 [approve]
 auto_approve_usernames = ["dependabot", "renovate"]


### PR DESCRIPTION
There is a possibility that this won't work for us. But I thought that it is worth the try. If it doesn't work I can make Renovate add a label when PR is patch/minor.

Here are the docs:

<span><p>Dependency upgrade types are parsed from the pull request title
 and body. The following table shows version upgrade examples for 
Dependabot pull request titles:</p>

title | upgrade
-- | --
Bump lodash from 1.0.0 to 1.0.1 | patch
Bump lodash from 2.5.1 to 2.8.0 | minor
Bump lodash from 4.2.1 to 5.0.0 | major


<p>If Kodiak cannot determine the upgrade type from the pull request title, Kodiak will not automerge the pull request.</p>
<p>See the <a href="https://github.com/chdsbd/kodiak/blob/b1893ee6add4a1533bdac77999aad698e0b2e74c/bot/kodiak/test_dependencies.py#L10-L35">tests file</a> for more examples.