### PR TITLE
Fix eslint conflicting rules

### DIFF
--- a/console/frontend/src/main/frontend/eslint.config.mjs
+++ b/console/frontend/src/main/frontend/eslint.config.mjs
@@ -119,13 +119,14 @@ export default [
               ['private-static-get', 'private-static-set'],
               ['#private-static-get', '#private-static-set'],
 
-              ['public-decorated-get', 'public-decorated-set'],
-              ['protected-decorated-get', 'protected-decorated-set'],
-              ['private-decorated-get', 'private-decorated-set'],
-
-              ['public-instance-get', 'public-instance-set'],
-              ['protected-instance-get', 'protected-instance-set'],
-              ['private-instance-get', 'private-instance-set'],
+              ['public-decorated-get', 'public-decorated-set', 'public-instance-get', 'public-instance-set'],
+              [
+                'protected-decorated-get',
+                'protected-decorated-set',
+                'protected-instance-get',
+                'protected-instance-set',
+              ],
+              ['private-decorated-get', 'private-decorated-set', 'private-instance-get', 'private-instance-set'],
               ['#private-instance-get', '#private-instance-set'],
 
               ['public-abstract-get', 'public-abstract-set'],


### PR DESCRIPTION
The current eslint config had a possible conflict in the member ordering, specifically when this example occurs:

Lets say we have this:
```ts
@Input()
set value(value: string) {
  this.writeValue(value);
}

get value(): string {
  return this.internalValue;
}

@Input()
set pattern(pattern: string | undefined) {
  this.patternExpression = pattern ?? '';
  this.onValidatorChange();
  this.emitValidity();
}

get pattern(): string | undefined {
  return this.patternExpression || undefined;
}
```

Currently the member ordering will complain about:
`ESLint: Member pattern should be declared before all public instance get, public instance set definitions. (@typescript-eslint/member-ordering)` Meaning it wants the `set pattern` to be declared before the `get value` because of the `@Input` annotation. However if we do, we get another conflict, so considering
```ts
@Input()
set value(value: string) {
  this.writeValue(value);
}

@Input()
set pattern(pattern: string | undefined) {
  this.patternExpression = pattern ?? '';
  this.onValidatorChange();
  this.emitValidity();
}

get value(): string {
  return this.internalValue;
}

get pattern(): string | undefined {
  return this.patternExpression || undefined;
}

```
And then we get the following:
`ESLint: All value signatures should be adjacent. (@typescript-eslint/adjacent-overload-signatures)` Meaning it wants all getters and setters to be paired together.

These two obviously work against each other so I've changed the member ordering setup in the eslint config to fix this.