### PR TITLE
Rename MessageBase to AbstractMessage

### DIFF
--- a/bootable-runner/src/main/java/org/frankframework/runner/FrankApplication.java
+++ b/bootable-runner/src/main/java/org/frankframework/runner/FrankApplication.java
@@ -68,7 +68,7 @@ import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.LocalGateway;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.management.bus.message.RequestMessageBuilder;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.ClassUtils;
@@ -256,7 +256,7 @@ public class FrankApplication {
 
 			Message<Object> response = gateway.sendSyncMessage(builder.build(null));
 			// An integer is returned, but just in case it might be something else, convert it to a String.
-			return "200".equals(""+response.getHeaders().get(BusMessageUtils.HEADER_PREFIX+MessageBase.STATUS_KEY));
+			return "200".equals(""+response.getHeaders().get(BusMessageUtils.HEADER_PREFIX+AbstractMessage.STATUS_KEY));
 		} catch (Exception e) {
 			getApplicationLogger().warn("FrankApplication is not yet healthy!", e);
 			return false;

--- a/console/backend/src/main/java/org/frankframework/console/controllers/TestPipeline.java
+++ b/console/backend/src/main/java/org/frankframework/console/controllers/TestPipeline.java
@@ -42,7 +42,7 @@ import org.frankframework.console.util.ResponseUtils;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.management.bus.message.RequestMessageBuilder;
 import org.frankframework.util.CloseUtils;
 import org.frankframework.util.StreamUtil;
@@ -102,7 +102,7 @@ public class TestPipeline {
 
 		builder.setPayload(inputMessage);
 		Message<?> response = frankApiService.sendSyncMessage(builder);
-		String state = BusMessageUtils.getHeader(response, MessageBase.STATE_KEY);
+		String state = BusMessageUtils.getHeader(response, AbstractMessage.STATE_KEY);
 		return testPipelineResponse(ResponseUtils.parseAsString(response), state, inputMessage);
 	}
 
@@ -129,7 +129,7 @@ public class TestPipeline {
 				Message<?> response = frankApiService.sendSyncMessage(builder);
 				result.append(name);
 				result.append(": ");
-				result.append(BusMessageUtils.getHeader(response, MessageBase.STATE_KEY));
+				result.append(BusMessageUtils.getHeader(response, AbstractMessage.STATE_KEY));
 				result.append("\n");
 			}
 		}

--- a/console/backend/src/main/java/org/frankframework/console/controllers/TransactionalStorage.java
+++ b/console/backend/src/main/java/org/frankframework/console/controllers/TransactionalStorage.java
@@ -47,7 +47,7 @@ import org.frankframework.console.util.RequestUtils;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.management.bus.message.RequestMessageBuilder;
 
 @RestController
@@ -102,7 +102,7 @@ public class TransactionalStorage {
 
 					builder.addHeader("messageId", decodedMessageId);
 					Message<?> message = frankApiService.sendSyncMessage(builder);
-					String mimeType = BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY);
+					String mimeType = BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY);
 
 					String filenameExtension = ".txt";
 					if (MediaType.APPLICATION_JSON_VALUE.equals(mimeType)) {

--- a/console/backend/src/main/java/org/frankframework/console/util/ResponseUtils.java
+++ b/console/backend/src/main/java/org/frankframework/console/util/ResponseUtils.java
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
 import org.frankframework.console.ApiException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.message.EmptyMessage;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.util.StreamUtil;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
@@ -57,8 +57,8 @@ public class ResponseUtils {
 	}
 
 	public static ResponseEntity<?> convertToSpringResponse(Message<?> message, StreamingResponseBody response) {
-		int status = BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 200);
-		String mimeType = BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY, null);
+		int status = BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 200);
+		String mimeType = BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY, null);
 		ResponseEntity.BodyBuilder responseEntity = ResponseEntity.status(status);
 		HttpHeaders httpHeaders = new HttpHeaders();
 
@@ -66,7 +66,7 @@ public class ResponseUtils {
 			httpHeaders.setContentType(MediaType.valueOf(mimeType));
 		}
 
-		String contentDisposition = BusMessageUtils.getHeader(message, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(message, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		if (contentDisposition != null) {
 			httpHeaders.setContentDisposition(ContentDisposition.parse(contentDisposition));
 		}
@@ -93,12 +93,12 @@ public class ResponseUtils {
 
 	@Nullable
 	public static String parseAsString(Message<?> message) {
-		int status = BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 200);
+		int status = BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 200);
 		if (!hasPayload(status)) {
 			return null;
 		}
 
-		String mimeType = BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY, null);
+		String mimeType = BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY, null);
 		if (mimeType != null) {
 			MediaType mime = MediaType.valueOf(mimeType);
 			if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(mime) || MediaType.TEXT_PLAIN.equalsTypeAndSubtype(mime)) {

--- a/console/backend/src/test/java/org/frankframework/console/controllers/FrankApiTestBase.java
+++ b/console/backend/src/test/java/org/frankframework/console/controllers/FrankApiTestBase.java
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 
 @WebAppConfiguration
 @ExtendWith(SpringExtension.class)
@@ -86,11 +86,11 @@ public abstract class FrankApiTestBase {
 				Map<String, Object> headers = new HashMap<>(in.getHeaders());
 				headers.put("state", "SUCCESS");
 				headers.put("meta-state", "SUCCESS");
-				headers.put(MessageBase.STATUS_KEY, status);
-				headers.put("meta-" + MessageBase.STATUS_KEY, status);
+				headers.put(AbstractMessage.STATUS_KEY, status);
+				headers.put("meta-" + AbstractMessage.STATUS_KEY, status);
 				if (mediaType != null) {
-					headers.put(MessageBase.MIMETYPE_KEY, mediaType);
-					headers.put("meta-" + MessageBase.MIMETYPE_KEY, mediaType);
+					headers.put(AbstractMessage.MIMETYPE_KEY, mediaType);
+					headers.put("meta-" + AbstractMessage.MIMETYPE_KEY, mediaType);
 				}
 
 				return new MessageHeaders(headers);

--- a/console/backend/src/test/java/org/frankframework/console/controllers/SpringUnitTestLocalGateway.java
+++ b/console/backend/src/test/java/org/frankframework/console/controllers/SpringUnitTestLocalGateway.java
@@ -9,7 +9,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 
 import org.frankframework.management.bus.OutboundGateway;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.util.JacksonUtils;
 
 /**
@@ -40,8 +40,8 @@ public class SpringUnitTestLocalGateway implements OutboundGateway {
 				Map<String, Object> headers = new HashMap<>(in.getHeaders());
 				headers.put("state", "SUCCESS");
 				headers.put("meta-state", "SUCCESS");
-				headers.put(MessageBase.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
-				headers.put("meta-" + MessageBase.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
+				headers.put(AbstractMessage.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
+				headers.put("meta-" + AbstractMessage.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
 
 				// Since I'm too lazy to change all the tests, I've added this.
 				// But this would be a way to verify that we're not sending a payload.

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/FileViewer.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/FileViewer.java
@@ -33,7 +33,7 @@ import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.TopicSelector;
 import org.frankframework.management.bus.message.BinaryMessage;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.FileUtils;
 
@@ -48,7 +48,7 @@ public class FileViewer extends BusEndpointBase {
 	public Message<?> getFileContent(Message<?> message) {
 		String resultType = BusMessageUtils.getHeader(message, "resultType");
 		String fileName = BusMessageUtils.getHeader(message, "fileName");
-		MessageBase<?> response;
+		AbstractMessage<?> response;
 
 		if (fileName == null || resultType == null) {
 			throw new BusException("fileName or type not specified");

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
@@ -49,7 +49,7 @@ import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.TopicSelector;
 import org.frankframework.management.bus.message.BinaryMessage;
 import org.frankframework.management.bus.message.EmptyMessage;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.util.AppConstants;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.MessageUtils;
@@ -89,7 +89,7 @@ public class TestPipeline extends BusEndpointBase {
 
 	@ActionSelector(BusAction.UPLOAD)
 	@RolesAllowed("IbisTester")
-	public MessageBase<?> runTestPipeline(Message<?> message) {
+	public AbstractMessage<?> runTestPipeline(Message<?> message) {
 		String configurationName = BusMessageUtils.getHeader(message, "configuration");
 		String adapterName = BusMessageUtils.getHeader(message, "adapter");
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
@@ -114,7 +114,7 @@ public class TestPipeline extends BusEndpointBase {
 	}
 
 	// Does not support async requests because receiver requests are synchronous
-	private MessageBase<?> processMessage(Adapter adapter, String payload, Map<String, String> threadContext, boolean expectsReply) {
+	private AbstractMessage<?> processMessage(Adapter adapter, String payload, Map<String, String> threadContext, boolean expectsReply) {
 		String messageId = MessageUtils.generateMessageId("testmessage");
 		try (PipeLineSession pls = new PipeLineSession()) {
 			// Make sure the pipeline session has a security handler
@@ -149,15 +149,15 @@ public class TestPipeline extends BusEndpointBase {
 		}
 	}
 
-	private MessageBase<?> convertPipelineResult(PipeLineResult plr) throws IOException {
-		final MessageBase<?> response;
+	private AbstractMessage<?> convertPipelineResult(PipeLineResult plr) throws IOException {
+		final AbstractMessage<?> response;
 		if (org.frankframework.stream.Message.isEmpty(plr.getResult())) {
 			response = EmptyMessage.noContent();
 		} else {
 			response = new BinaryMessage(plr.getResult().asInputStream());
 		}
 
-		response.setHeader(MessageBase.STATE_KEY, plr.getState().name());
+		response.setHeader(AbstractMessage.STATE_KEY, plr.getState().name());
 		return response;
 	}
 

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseMessageBrowsers.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestBrowseMessageBrowsers.java
@@ -61,7 +61,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.pipes.SenderPipe;
 import org.frankframework.receivers.JavaListener;
 import org.frankframework.receivers.RawMessageWrapper;
@@ -155,7 +155,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 
 		Message<?> response = callSyncGateway(request);
 		assertEquals(JSON_MESSAGE, response.getPayload());
-		assertEquals("application/json", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/json", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 
 		Message<?> response = callSyncGateway(request);
 		assertEquals(XML_MESSAGE, response.getPayload());
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 	}
 
 	@Test
@@ -197,7 +197,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 
 		Message<?> response = callSyncGateway(request);
 		assertEquals(JSON_MESSAGE, response.getPayload());
-		assertEquals("application/json", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/json", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 	}
 
 	@Test
@@ -211,7 +211,7 @@ public class TestBrowseMessageBrowsers extends BusTestBase {
 
 		Message<?> response = callSyncGateway(request);
 		assertEquals(XML_MESSAGE, response.getPayload());
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
@@ -3,11 +3,11 @@ package org.frankframework.management.bus.endpoints;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +45,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
 		Message<?> response = callSyncGateway(request);
 		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
-		InputStream resource = (InputStream) response.getPayload();
+		InputStream resource = assertInstanceOf(InputStream.class, response.getPayload());
 		String payload = StreamUtil.streamToString(resource);
 
 		assertThat(payload, Matchers.startsWith("<databaseChangeLog"));
@@ -60,7 +60,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		Object cdk = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY);
 		assertNotNull(cdk);
 		assertThat(""+cdk, Matchers.containsString("DatabaseChangelog.zip"));
-		ByteArrayInputStream bais = (ByteArrayInputStream) response.getPayload();
+		InputStream bais = assertInstanceOf(InputStream.class, response.getPayload());
 		List<Resource> changelogs = new ArrayList<>();
 		try (ZipInputStream is = new ZipInputStream(bais)) {
 			ZipEntry entry;
@@ -106,7 +106,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		String script = TestFileUtils.getTestFile("/Migrator/DatabaseChangelog.xml");
 		MessageBuilder<String> request = createRequestMessage(script, BusTopic.JDBC_MIGRATION, BusAction.UPLOAD);
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
-		MessageHandlingException mhe = assertThrows(MessageHandlingException.class, () -> { callSyncGateway(request); }, "expected: filename not provided exception");
+		MessageHandlingException mhe = assertThrows(MessageHandlingException.class, () -> callSyncGateway(request), "expected: filename not provided exception");
 		assertTrue(mhe.getCause() instanceof BusException);
 	}
 
@@ -116,7 +116,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage(script, BusTopic.JDBC_MIGRATION, BusAction.UPLOAD);
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
 		request.setHeader("filename", "wrong-name.xml");
-		MessageHandlingException mhe = assertThrows(MessageHandlingException.class, () -> { callSyncGateway(request); }, "expected: filename not provided exception");
+		MessageHandlingException mhe = assertThrows(MessageHandlingException.class, () -> callSyncGateway(request), "expected: filename not provided exception");
 		assertTrue(mhe.getCause() instanceof BusException);
 	}
 }

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestDatabaseMigrator.java
@@ -28,7 +28,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.testutil.SpringRootInitializer;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.testutil.TestScopeProvider;
@@ -44,7 +44,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.JDBC_MIGRATION, BusAction.DOWNLOAD);
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 		InputStream resource = (InputStream) response.getPayload();
 		String payload = StreamUtil.streamToString(resource);
 
@@ -56,8 +56,8 @@ public class TestDatabaseMigrator extends BusTestBase {
 		MessageBuilder<String> request = createRequestMessage("NONE", BusTopic.JDBC_MIGRATION, BusAction.DOWNLOAD);
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, BusMessageUtils.ALL_CONFIGS_KEY);
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/octet-stream", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
-		Object cdk = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY);
+		assertEquals("application/octet-stream", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
+		Object cdk = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY);
 		assertNotNull(cdk);
 		assertThat(""+cdk, Matchers.containsString("DatabaseChangelog.zip"));
 		ByteArrayInputStream bais = (ByteArrayInputStream) response.getPayload();
@@ -82,7 +82,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
 		request.setHeader("filename", "DatabaseChangelog.xml");
 		Message<?> response = callSyncGateway(request);
-		assertEquals("text/plain", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("text/plain", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 		String payload = (String) response.getPayload();
 
 		assertEquals(script, payload);
@@ -95,7 +95,7 @@ public class TestDatabaseMigrator extends BusTestBase {
 		request.setHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, getConfiguration().getName());
 		request.setHeader("filename", getConfiguration().getName()+"-DatabaseChangelog.xml");
 		Message<?> response = callSyncGateway(request);
-		assertEquals("text/plain", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("text/plain", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 		String payload = (String) response.getPayload();
 
 		assertEquals(script, payload);

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestFileViewer.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestFileViewer.java
@@ -15,7 +15,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.testutil.SpringRootInitializer;
 import org.frankframework.testutil.TestFileUtils;
 import org.frankframework.util.StreamUtil;
@@ -46,8 +46,8 @@ public class TestFileViewer extends BusTestBase {
 		request.setHeader("fileName", TestFileUtils.getTestFilePath(TestFilePath));
 
 		Message<?> response = callSyncGateway(request);
-		String contentType = BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY, null);
-		String contentDisposition = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentType = BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		Assertions.assertEquals(MediaType.TEXT_HTML_VALUE, contentType);
 		Assertions.assertEquals("inline; filename=\""+TestFileName+"\"", contentDisposition);
 	}
@@ -59,8 +59,8 @@ public class TestFileViewer extends BusTestBase {
 		request.setHeader("fileName", TestFileUtils.getTestFilePath(TestFilePath));
 
 		Message<?> response = callSyncGateway(request);
-		String contentType = BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY, null);
-		String contentDisposition = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentType = BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		Assertions.assertEquals(MediaType.APPLICATION_XML_VALUE, contentType);
 		Assertions.assertEquals("inline; filename=\""+TestFileName+"\"", contentDisposition);
 	}
@@ -72,8 +72,8 @@ public class TestFileViewer extends BusTestBase {
 		request.setHeader("fileName", TestFileUtils.getTestFilePath(TestFilePath));
 
 		Message<?> response = callSyncGateway(request);
-		String contentType = BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY, null);
-		String contentDisposition = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentType = BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		Assertions.assertEquals(MediaType.TEXT_PLAIN_VALUE, contentType);
 		Assertions.assertEquals("inline; filename=\""+TestFileName+"\"", contentDisposition);
 	}
@@ -85,8 +85,8 @@ public class TestFileViewer extends BusTestBase {
 		request.setHeader("fileName", TestFileUtils.getTestFilePath(TestFilePath));
 
 		Message<?> response = callSyncGateway(request);
-		String contentType = BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY, null);
-		String contentDisposition = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentType = BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		Assertions.assertEquals("application/zip", contentType);
 		Assertions.assertEquals("attachment; filename=\""+TestFileName+"\"", contentDisposition);
 	}
@@ -98,8 +98,8 @@ public class TestFileViewer extends BusTestBase {
 		request.setHeader("fileName", TestFileUtils.getTestFilePath(TestFilePath));
 
 		Message<?> response = callSyncGateway(request);
-		String contentType = BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY, null);
-		String contentDisposition = BusMessageUtils.getHeader(response, MessageBase.CONTENT_DISPOSITION_KEY, null);
+		String contentType = BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY, null);
+		String contentDisposition = BusMessageUtils.getHeader(response, AbstractMessage.CONTENT_DISPOSITION_KEY, null);
 		Assertions.assertEquals(MediaType.APPLICATION_OCTET_STREAM_VALUE, contentType);
 		Assertions.assertEquals("attachment; filename=\""+TestFileName+"\"", contentDisposition);
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestManageSchedule.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestManageSchedule.java
@@ -21,7 +21,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.pipes.EchoPipe;
 import org.frankframework.receivers.JavaListener;
 import org.frankframework.receivers.Receiver;
@@ -95,7 +95,7 @@ public class TestManageSchedule extends BusTestBase {
 		Message<?> response = callSyncGateway(request);
 
 		String result = response.getPayload().toString();
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 		assertEquals("no-content", result);
 	}
 
@@ -117,7 +117,7 @@ public class TestManageSchedule extends BusTestBase {
 		Message<?> response = callSyncGateway(request);
 
 		String result = response.getPayload().toString();
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 		assertEquals("no-content", result);
 	}
 
@@ -128,7 +128,7 @@ public class TestManageSchedule extends BusTestBase {
 		Message<?> response = callSyncGateway(request);
 
 		String result = response.getPayload().toString();
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 		assertEquals("no-content", result);
 	}
 }

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestMonitoring.java
@@ -30,7 +30,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.monitoring.AdapterFilter;
 import org.frankframework.monitoring.EventType;
 import org.frankframework.monitoring.IMonitorDestination;
@@ -185,7 +185,7 @@ public class TestMonitoring extends BusTestBase {
 				() -> assertFalse(getMonitorManager().getMonitor("newName").isRaised()),
 				() -> assertEquals("newName", getMonitorManager().getMonitor("newName").getName()),
 				() -> assertEquals(EventType.TECHNICAL, getMonitorManager().getMonitor("newName").getType()),
-				() -> assertEquals(201, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(201, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload()),
 				() -> assertEquals("mockDestination", getMonitorManager().getMonitor("newName").getDestinationsAsString())
 			);
@@ -207,7 +207,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals("raise".equals(state), getMonitorManager().getMonitor(TEST_MONITOR_NAME).isRaised()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 	}
@@ -230,7 +230,7 @@ public class TestMonitoring extends BusTestBase {
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals("newName", getMonitorManager().getMonitor(TEST_MONITOR_NAME).getName()),
 				() -> assertEquals(EventType.TECHNICAL, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getType()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload()),
 				() -> assertEquals("mockDestination", getMonitorManager().getMonitor(TEST_MONITOR_NAME).getDestinationsAsString())
 			);
@@ -277,7 +277,7 @@ public class TestMonitoring extends BusTestBase {
 		// Assert
 		assertAll(
 			() -> assertEquals(0, getMonitorManager().getMonitors().size()),
-			() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+			() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 			() -> assertEquals("no-content", response.getPayload())
 		);
 	}
@@ -331,7 +331,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals(2, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getTriggers().size()),
-				() -> assertEquals(201, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(201, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 
@@ -392,7 +392,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals(1, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getTriggers().size()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 
@@ -462,7 +462,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals(1, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getTriggers().size()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 
@@ -498,7 +498,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals(1, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getTriggers().size()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 
@@ -549,7 +549,7 @@ public class TestMonitoring extends BusTestBase {
 		assertAll(
 				() -> assertEquals(1, getMonitorManager().getMonitors().size()),
 				() -> assertEquals(0, getMonitorManager().getMonitor(TEST_MONITOR_NAME).getTriggers().size()),
-				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0)),
+				() -> assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0)),
 				() -> assertEquals("no-content", response.getPayload())
 			);
 	}

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestUpdateLogDefinitions.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestUpdateLogDefinitions.java
@@ -22,7 +22,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.testutil.SpringRootInitializer;
 
 /**
@@ -113,7 +113,7 @@ public class TestUpdateLogDefinitions extends BusTestBase {
 		request.setHeader("reconfigure", "true");
 		Message<?> response = callSyncGateway(request);
 
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
@@ -152,7 +152,7 @@ public class TestUpdateLogDefinitions extends BusTestBase {
 		request.setHeader("level", "debug");
 		Message<?> response = callSyncGateway(request);
 
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
@@ -191,6 +191,6 @@ public class TestUpdateLogDefinitions extends BusTestBase {
 		request.setHeader("level", "debug");
 		Message<?> response = callSyncGateway(request);
 
-		assertEquals(202, BusMessageUtils.getIntHeader(response, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(response, AbstractMessage.STATUS_KEY, 0));
 	}
 }

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestWebServices.java
@@ -33,7 +33,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTestBase;
 import org.frankframework.management.bus.BusTopic;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.pipes.EchoPipe;
 import org.frankframework.pipes.XmlValidator;
 import org.frankframework.receivers.Receiver;
@@ -216,7 +216,7 @@ public class TestWebServices extends BusTestBase {
 		request.setHeader("configuration", getConfiguration().getName());
 
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 
 		String expectedWsdl = TestFileUtils.getTestFile("/Management/WebServices/wsdl-without-includes.wsdl");
 		MatchUtils.assertXmlEquals(expectedWsdl, convertPayloadAndApplyIgnores(response));
@@ -231,7 +231,7 @@ public class TestWebServices extends BusTestBase {
 		request.setHeader("useIncludes", true);
 
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 
 		String expectedWsdl = TestFileUtils.getTestFile("/Management/WebServices/wsdl-with-includes.wsdl");
 		MatchUtils.assertXmlEquals(expectedWsdl, convertPayloadAndApplyIgnores(response));
@@ -246,7 +246,7 @@ public class TestWebServices extends BusTestBase {
 		request.setHeader("indent", false);
 
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/xml", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/xml", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 
 		String expectedWsdl = TestFileUtils.getTestFile("/Management/WebServices/wsdl-without-includes.wsdl");
 		MatchUtils.assertXmlEquals(expectedWsdl, convertPayloadAndApplyIgnores(response));
@@ -261,7 +261,7 @@ public class TestWebServices extends BusTestBase {
 		request.setHeader("zip", true);
 
 		Message<?> response = callSyncGateway(request);
-		assertEquals("application/octet-stream", BusMessageUtils.getHeader(response, MessageBase.MIMETYPE_KEY));
+		assertEquals("application/octet-stream", BusMessageUtils.getHeader(response, AbstractMessage.MIMETYPE_KEY));
 		InputStream payload = (InputStream) response.getPayload();
 
 		String wsdl = null;

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/tibet2/Tibet2ToFrameworkDispatcher.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/tibet2/Tibet2ToFrameworkDispatcher.java
@@ -18,12 +18,9 @@ package org.frankframework.ladybug.tibet2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.UUID;
 
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationContext;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.wearefrank.ladybug.echo2.reports.ReportsComponent;
@@ -34,7 +31,8 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.OutboundGateway;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
+import org.frankframework.management.bus.message.RequestMessageBuilder;
 import org.frankframework.util.JacksonUtils;
 import org.frankframework.util.StreamUtil;
 
@@ -55,13 +53,13 @@ public class Tibet2ToFrameworkDispatcher {
 
 	public String authorisationCheck(String storageId, String viewName) {
 		try {
-			MessageBuilder<String> builder = createRequestMessage("<dummy />", AUTHORISATION_CHECK_ADAPTER_CONFIG, AUTHORISATION_CHECK_ADAPTER_NAME);
-			builder.setHeader(BusMessageUtils.HEADER_PREFIX+"sessionKeys", toJson(storageId, viewName));
+			RequestMessageBuilder builder = createRequestMessage("<dummy />", AUTHORISATION_CHECK_ADAPTER_CONFIG, AUTHORISATION_CHECK_ADAPTER_NAME);
+			builder.addHeader("sessionKeys", toJson(storageId, viewName));
 
 			@NonNull
-			Message<Object> result = sendMessage(builder.build());
+			Message<Object> result = sendMessage(builder.build(null));
 
-			if ("SUCCESS".equalsIgnoreCase(BusMessageUtils.getHeader(result, MessageBase.STATE_KEY))) {
+			if ("SUCCESS".equalsIgnoreCase(BusMessageUtils.getHeader(result, AbstractMessage.STATE_KEY))) {
 				return ReportsComponent.OPEN_REPORT_ALLOWED;
 			} else {
 				return "Not allowed. Result of adapter " + AUTHORISATION_CHECK_ADAPTER_NAME + ": " + convertPayload(result.getPayload());
@@ -73,12 +71,12 @@ public class Tibet2ToFrameworkDispatcher {
 
 	public void deleteReport(String checkpointMessage) throws StorageException {
 		try {
-			MessageBuilder<String> builder = createRequestMessage(checkpointMessage, AUTHORISATION_CHECK_ADAPTER_CONFIG, AUTHORISATION_CHECK_DELETE_ADAPTER_NAME);
+			RequestMessageBuilder builder = createRequestMessage(checkpointMessage, AUTHORISATION_CHECK_ADAPTER_CONFIG, AUTHORISATION_CHECK_DELETE_ADAPTER_NAME);
 
 			@NonNull
-			Message<Object> result = sendMessage(builder.build());
+			Message<Object> result = sendMessage(builder.build(null));
 
-			if (BusMessageUtils.getIntHeader(result, MessageBase.STATUS_KEY, 500) == 200) {
+			if (BusMessageUtils.getIntHeader(result, AbstractMessage.STATUS_KEY, 500) == 200) {
 				String stringResult = convertPayload(result.getPayload());
 				if (!"<ok/>".equalsIgnoreCase(stringResult)) {
 					throw new StorageException("Delete failed: " + stringResult);
@@ -94,7 +92,7 @@ public class Tibet2ToFrameworkDispatcher {
 	/**
 	 * Ideally we only get BusExceptions and MessageHandlingException which wrap one.
 	 */
-	private Message<Object> sendMessage(Message<String> message) throws BusException {
+	private Message<Object> sendMessage(Message<?> message) throws BusException {
 		try {
 			return gateway.sendSyncMessage(message);
 		} catch (BusException e) {
@@ -108,24 +106,11 @@ public class Tibet2ToFrameworkDispatcher {
 	}
 
 	@NonNull
-	private static MessageBuilder<String> createRequestMessage(BusTopic topic, BusAction action, String payload, @Nullable UUID uuid) {
-		MessageBuilder<String> builder = MessageBuilder.withPayload(payload);
-		builder.setHeader(BusTopic.TOPIC_HEADER_NAME, topic.name());
-		builder.setHeader(BusAction.ACTION_HEADER_NAME, action.name());
-
-		// Optional target parameter, to target a specific backend node.
-		if(uuid != null) {
-			builder.setHeader(BusMessageUtils.HEADER_TARGET_KEY, uuid);
-		}
-
-		return builder;
-	}
-
-	@NonNull
-	private static MessageBuilder<String> createRequestMessage(String inputMessage, String configName, String adapterName) {
-		MessageBuilder<String> builder = createRequestMessage(BusTopic.TEST_PIPELINE, BusAction.UPLOAD, inputMessage, null);
-		builder.setHeader(BusMessageUtils.HEADER_PREFIX+BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, configName);
-		builder.setHeader(BusMessageUtils.HEADER_PREFIX+BusMessageUtils.HEADER_ADAPTER_NAME_KEY, adapterName);
+	private static RequestMessageBuilder createRequestMessage(String inputMessage, String configName, String adapterName) {
+		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.TEST_PIPELINE, BusAction.UPLOAD);
+		builder.setPayload(inputMessage);
+		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, configName);
+		builder.addHeader(BusMessageUtils.HEADER_ADAPTER_NAME_KEY, adapterName);
 		return builder;
 	}
 

--- a/ladybug/debugger/src/test/java/org/frankframework/ladybug/tibet2/SpringUnitTestLocalGateway.java
+++ b/ladybug/debugger/src/test/java/org/frankframework/ladybug/tibet2/SpringUnitTestLocalGateway.java
@@ -9,7 +9,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 
 import org.frankframework.management.bus.OutboundGateway;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.util.JacksonUtils;
 
 /**
@@ -40,8 +40,8 @@ public class SpringUnitTestLocalGateway implements OutboundGateway {
 				Map<String, Object> headers = new HashMap<>(in.getHeaders());
 				headers.put("state", "SUCCESS");
 				headers.put("meta-state", "SUCCESS");
-				headers.put(MessageBase.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
-				headers.put("meta-" + MessageBase.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
+				headers.put(AbstractMessage.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
+				headers.put("meta-" + AbstractMessage.MIMETYPE_KEY, MediaType.APPLICATION_JSON_VALUE);
 
 				return new MessageHeaders(headers);
 			}

--- a/ladybug/rerunner/src/main/java/org/frankframework/ladybug/SpringBusRerunner.java
+++ b/ladybug/rerunner/src/main/java/org/frankframework/ladybug/SpringBusRerunner.java
@@ -18,12 +18,9 @@ package org.frankframework.ladybug;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
-import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.wearefrank.ladybug.Checkpoint;
 import org.wearefrank.ladybug.Report;
@@ -36,6 +33,7 @@ import org.frankframework.management.bus.BusException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.OutboundGateway;
+import org.frankframework.management.bus.message.RequestMessageBuilder;
 import org.frankframework.util.JacksonUtils;
 import org.frankframework.util.UUIDUtil;
 
@@ -105,12 +103,13 @@ public class SpringBusRerunner implements Rerunner {
 		threadContext.put(MESSAGE_ID_KEY, messageId);
 		threadContext.put(CORRELATION_ID_KEY, correlationId);
 
-		MessageBuilder<String> builder = createRequestMessage(BusTopic.TEST_PIPELINE, BusAction.UPLOAD, inputMessage, null);
-		builder.setHeader(BusMessageUtils.HEADER_PREFIX+BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, configName);
-		builder.setHeader(BusMessageUtils.HEADER_PREFIX+BusMessageUtils.HEADER_ADAPTER_NAME_KEY, adapterName);
-		builder.setHeader(BusMessageUtils.HEADER_PREFIX+"sessionKeys", toJson(threadContext));
+		RequestMessageBuilder builder = RequestMessageBuilder.create(BusTopic.TEST_PIPELINE, BusAction.UPLOAD);
+		builder.setPayload(inputMessage);
+		builder.addHeader(BusMessageUtils.HEADER_CONFIGURATION_NAME_KEY, configName);
+		builder.addHeader(BusMessageUtils.HEADER_ADAPTER_NAME_KEY, adapterName);
+		builder.addHeader("sessionKeys", toJson(threadContext));
 
-		return processRequest(builder.build()); // A null result implies success
+		return processRequest(builder.build(null)); // A null result implies success
 	}
 
 	protected String toJson(Map<String, String> threadContext) {
@@ -128,20 +127,7 @@ public class SpringBusRerunner implements Rerunner {
 		}
 	}
 
-	private MessageBuilder<String> createRequestMessage(BusTopic topic, BusAction action, String payload, @Nullable UUID uuid) {
-		MessageBuilder<String> builder = MessageBuilder.withPayload(payload);
-		builder.setHeader(BusTopic.TOPIC_HEADER_NAME, topic.name());
-		builder.setHeader(BusAction.ACTION_HEADER_NAME, action.name());
-
-		// Optional target parameter, to target a specific backend node.
-		if(uuid != null) {
-			builder.setHeader(BusMessageUtils.HEADER_TARGET_KEY, uuid);
-		}
-
-		return builder;
-	}
-
-	private String processRequest(Message<String> request) {
+	private String processRequest(Message<?> request) {
 		try {
 			getGateway().sendSyncMessage(request);
 			// Nothing is done with the response at the moment

--- a/management-gateway/src/main/java/org/frankframework/management/bus/message/AbstractMessage.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/message/AbstractMessage.java
@@ -25,7 +25,7 @@ import org.springframework.util.MimeType;
 
 import org.frankframework.management.bus.BusMessageUtils;
 
-public class MessageBase<T> implements Message<T> {
+public class AbstractMessage<T> implements Message<T> {
 	public static final String STATUS_KEY = "status";
 	public static final String MIMETYPE_KEY = "type";
 	public static final String CONTENT_DISPOSITION_KEY = "contentdisposition";
@@ -35,7 +35,7 @@ public class MessageBase<T> implements Message<T> {
 	private final Map<String, Object> headers = new HashMap<>();
 	private MessageHeaders messageHeaders;
 
-	protected MessageBase(T payload, MimeType defaultMimeType) {
+	protected AbstractMessage(T payload, MimeType defaultMimeType) {
 		this.payload = payload;
 		setStatus(200);
 		setMimeType(defaultMimeType);

--- a/management-gateway/src/main/java/org/frankframework/management/bus/message/BinaryMessage.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/message/BinaryMessage.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2023-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.io.InputStream;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 
-public class BinaryMessage extends MessageBase<InputStream> {
+import org.frankframework.management.gateway.SerializableInputStream;
+
+public class BinaryMessage extends AbstractMessage<InputStream> {
 
 	public BinaryMessage(byte[] payload) {
 		this(new ByteArrayInputStream(payload));
@@ -36,6 +38,6 @@ public class BinaryMessage extends MessageBase<InputStream> {
 	}
 
 	public BinaryMessage(InputStream payload, MimeType defaultMimeType) {
-		super(payload, defaultMimeType);
+		super(new SerializableInputStream(payload), defaultMimeType);
 	}
 }

--- a/management-gateway/src/main/java/org/frankframework/management/bus/message/RequestMessageBuilder.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/message/RequestMessageBuilder.java
@@ -50,7 +50,7 @@ public class RequestMessageBuilder {
 	private final @Getter @NonNull BusTopic topic;
 	private final @Getter @NonNull BusAction action;
 
-	private MessageBase<?> payload = null;
+	private AbstractMessage<?> payload = null;
 
 	private static final Logger SEC_LOG = LogManager.getLogger("SEC");
 

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastInboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastInboundGateway.java
@@ -16,7 +16,7 @@
 package org.frankframework.management.gateway;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,7 +26,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -110,7 +109,7 @@ public class HazelcastInboundGateway extends MessagingGatewaySupport {
 
 		log.trace("received message with id [{}] from member [{}]", () -> messageId, () -> rawMessage.getPublishingMember().getUuid());
 
-		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put("messageId", messageId.toString())) {
+		try (final CloseableThreadContext.Instance ctc = CloseableThreadContext.put("mid", messageId.toString())) {
 			String tempReplyChannel = (String) message.getHeaders().getReplyChannel();
 
 			log.debug("received message [{}] {} reply-channel", message, tempReplyChannel == null ? "without" : "with");
@@ -129,10 +128,10 @@ public class HazelcastInboundGateway extends MessagingGatewaySupport {
 			propagateAuthenticationContext(headers);
 
 			if (tempReplyChannel == null) { // send async
-				log.trace("processing message id [{}] asynchronous", headers::getId);
+				log.trace("processing asynchronous");
 				super.send(incomingMessage);
 			} else {
-				log.trace("processing message id [{}] synchronous", headers::getId);
+				log.trace("processing synchronous");
 				Message<?> response = super.sendAndReceiveMessage(incomingMessage);
 				if (response == null) {
 					log.trace("synchronous message did not return a response");
@@ -144,14 +143,14 @@ public class HazelcastInboundGateway extends MessagingGatewaySupport {
 			// Catch all exceptions with a failed-message.
 			if (log.isInfoEnabled()) {
 				// Only log the stacktrace if loglevel is INFO.
-				log.warn("error processing message id [{}]", headers.getId(), e);
+				log.warn("error processing", e);
 			} else {
 				// Hide the message when the loglevel is WARN.
-				log.warn("error processing message id [{}]", headers.getId());
+				log.warn("error processing");
 			}
 		} catch (Exception e) {
 			// Log other exceptions normally.
-			log.error("error processing message id [{}]", headers.getId(), e);
+			log.error("error processing", headers.getId(), e);
 		}
 	}
 
@@ -164,10 +163,13 @@ public class HazelcastInboundGateway extends MessagingGatewaySupport {
 		MessageHeaders headers = response.getHeaders();
 
 		if (response instanceof ErrorMessage errMsg) {
+			// Don't leak the error to others.
 			throw Lombok.sneakyThrow(errMsg.getPayload());
 		}
-		if (response.getPayload() instanceof InputStream inputStream) {
-			response = MessageBuilder.withPayload(new SerializableInputStream(inputStream)).copyHeaders(headers).build();
+
+		if (!(response.getPayload() instanceof Serializable)) {
+			// Since we have control over the responses, always expect valid -serializable- response messages.
+			throw new MessagingException(response, "unable to send response, message  is not serializable");
 		}
 
 		log.trace("sending response message id [{}] to reply-channel [{}]", headers::getId, () -> tempReplyChannel);

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastMessageBuilder.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastMessageBuilder.java
@@ -23,12 +23,12 @@ import org.springframework.integration.support.BaseMessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
-public class OogaBooga<T> extends BaseMessageBuilder<T, OogaBooga<T>> {
+public class HazelcastMessageBuilder<T> extends BaseMessageBuilder<T, HazelcastMessageBuilder<T>> {
 
 	/**
 	 * Private constructor to be invoked from the static factory methods only.
 	 */
-	private OogaBooga(T payload, @Nullable Message<T> originalMessage) {
+	private HazelcastMessageBuilder(T payload, @Nullable Message<T> originalMessage) {
 		super(payload, originalMessage);
 	}
 
@@ -37,20 +37,20 @@ public class OogaBooga<T> extends BaseMessageBuilder<T, OogaBooga<T>> {
 	 * Ensure messages are safely exchanged between nodes and ensures that they are always Serializable.
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public static <T> OogaBooga<T> fromMessage(Message<T> message) {
+	public static <T> HazelcastMessageBuilder<T> fromMessage(Message<T> message) {
 		Assert.notNull(message, "message must not be null");
 
 		if (message.getPayload() instanceof InputStream in && !(in instanceof Serializable)) {
-			return new OogaBooga(new SerializableInputStream(in), message);
+			return new HazelcastMessageBuilder(new SerializableInputStream(in), message);
 		}
 
-		return new OogaBooga<>(message.getPayload(), message);
+		return new HazelcastMessageBuilder<>(message.getPayload(), message);
 	}
 
 	/**
 	 * Set the authentication header.
 	 */
-	public OogaBooga<T> setAuthentication(String authentication) {
+	public HazelcastMessageBuilder<T> setAuthentication(String authentication) {
 		setHeader(HazelcastConfig.AUTHENTICATION_HEADER_KEY, authentication);
 		return this;
 	}

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.core.GenericMessagingTemplate;
 
@@ -105,9 +104,9 @@ public class HazelcastOutboundGateway implements InitializingBean, ApplicationCo
 		// Create the response queue here, before sending the request.
 		IQueue<Message<O>> responseQueue = hzInstance.getQueue(tempReplyChannelName);
 
-		Message<I> requestMessage = MessageBuilder.fromMessage(in)
+		Message<I> requestMessage = OogaBooga.fromMessage(in)
 				.setReplyChannelName(tempReplyChannelName)
-				.setHeader(HazelcastConfig.AUTHENTICATION_HEADER_KEY, getAuthentication())
+				.setAuthentication(getAuthentication())
 				.build();
 		requestTopic.publish(requestMessage);
 
@@ -193,9 +192,9 @@ public class HazelcastOutboundGateway implements InitializingBean, ApplicationCo
 	@Override
 	public <I> void sendAsyncMessage(Message<I> in) {
 		log.debug("sending asynchronous request to topic [{}] message [{}]", requestTopicName, in);
-		Message<I> requestMessage = MessageBuilder.fromMessage(in)
+		Message<I> requestMessage = OogaBooga.fromMessage(in)
 				.setReplyChannelName(null)
-				.setHeader(HazelcastConfig.AUTHENTICATION_HEADER_KEY, getAuthentication())
+				.setAuthentication(getAuthentication())
 				.build();
 
 		requestTopic.publishAsync(requestMessage);

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/HazelcastOutboundGateway.java
@@ -104,7 +104,7 @@ public class HazelcastOutboundGateway implements InitializingBean, ApplicationCo
 		// Create the response queue here, before sending the request.
 		IQueue<Message<O>> responseQueue = hzInstance.getQueue(tempReplyChannelName);
 
-		Message<I> requestMessage = OogaBooga.fromMessage(in)
+		Message<I> requestMessage = HazelcastMessageBuilder.fromMessage(in)
 				.setReplyChannelName(tempReplyChannelName)
 				.setAuthentication(getAuthentication())
 				.build();
@@ -192,7 +192,7 @@ public class HazelcastOutboundGateway implements InitializingBean, ApplicationCo
 	@Override
 	public <I> void sendAsyncMessage(Message<I> in) {
 		log.debug("sending asynchronous request to topic [{}] message [{}]", requestTopicName, in);
-		Message<I> requestMessage = OogaBooga.fromMessage(in)
+		Message<I> requestMessage = HazelcastMessageBuilder.fromMessage(in)
 				.setReplyChannelName(null)
 				.setAuthentication(getAuthentication())
 				.build();

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/ImmutableMessage.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/ImmutableMessage.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 WeAreFrank!
+   Copyright 2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,18 +13,21 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-package org.frankframework.management.bus.message;
+package org.frankframework.management.gateway;
 
-import org.springframework.http.MediaType;
-import org.springframework.util.MimeType;
+import java.util.Map;
 
-public class StringMessage extends AbstractMessage<String> {
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
 
-	public StringMessage(String payload) {
-		this(payload, MediaType.TEXT_PLAIN);
+public final class ImmutableMessage<T> extends GenericMessage<T> implements Message<T> {
+
+	public ImmutableMessage(T payload, Map<String, Object> headers) {
+		super(payload, headers);
 	}
 
-	public StringMessage(String payload, MimeType defaultMediaType) {
-		super(payload, defaultMediaType);
+	@Override
+	public String toString() {
+		return "ImmutableMessage@" + Integer.toHexString(hashCode());
 	}
 }

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/OogaBooga.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/OogaBooga.java
@@ -1,0 +1,62 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.management.gateway;
+
+import java.io.InputStream;
+import java.io.Serializable;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.integration.support.BaseMessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+public class OogaBooga<T> extends BaseMessageBuilder<T, OogaBooga<T>> {
+
+	/**
+	 * Private constructor to be invoked from the static factory methods only.
+	 */
+	private OogaBooga(T payload, @Nullable Message<T> originalMessage) {
+		super(payload, originalMessage);
+	}
+
+
+	/**
+	 * Ensure messages are safely exchanged between nodes and ensures that they are always Serializable.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T> OogaBooga<T> fromMessage(Message<T> message) {
+		Assert.notNull(message, "message must not be null");
+
+		if (message.getPayload() instanceof InputStream in && !(in instanceof Serializable)) {
+			return new OogaBooga(new SerializableInputStream(in), message);
+		}
+
+		return new OogaBooga<>(message.getPayload(), message);
+	}
+
+	/**
+	 * Set the authentication header.
+	 */
+	public OogaBooga<T> setAuthentication(String authentication) {
+		setHeader(HazelcastConfig.AUTHENTICATION_HEADER_KEY, authentication);
+		return this;
+	}
+
+	@Override
+	public Message<T> build() {
+		return new ImmutableMessage<>(getPayload(), getHeaders());
+	}
+}

--- a/management-gateway/src/main/resources/ff-hazelcast-default.xml
+++ b/management-gateway/src/main/resources/ff-hazelcast-default.xml
@@ -288,6 +288,7 @@
             </blacklist>
             <whitelist>
 <!--                 <class>org.frankframework.management.gateway.SerializableInputStream</class> -->
+                <class>org.frankframework.management.gateway.ImmutableMessage</class>
                 <class>org.springframework.messaging.support.GenericMessage</class>
                 <class>org.springframework.messaging.MessageHeaders</class>
                 <package>org.frankframework.management.gateway</package>

--- a/management-gateway/src/test/java/org/frankframework/management/bus/BusResponseTypesTest.java
+++ b/management-gateway/src/test/java/org/frankframework/management/bus/BusResponseTypesTest.java
@@ -13,10 +13,10 @@ import jakarta.json.JsonObjectBuilder;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.management.bus.message.BinaryMessage;
 import org.frankframework.management.bus.message.EmptyMessage;
 import org.frankframework.management.bus.message.JsonMessage;
-import org.frankframework.management.bus.message.MessageBase;
 import org.frankframework.management.bus.message.StringMessage;
 import org.frankframework.util.StreamUtil;
 
@@ -28,8 +28,8 @@ public class BusResponseTypesTest {
 		message.setStatus(300);
 		String result = StreamUtil.streamToString(message.getPayload());
 		assertEquals("binary", result);
-		assertEquals("application/octet-stream", BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY));
-		assertEquals(300, BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 0));
+		assertEquals("application/octet-stream", BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY));
+		assertEquals(300, BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
@@ -39,24 +39,24 @@ public class BusResponseTypesTest {
 		message.setStatus(503);
 		String result = StreamUtil.streamToString(message.getPayload());
 		assertEquals("binary", result);
-		assertEquals("application/octet-stream", BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY));
-		assertEquals(503, BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 0));
+		assertEquals("application/octet-stream", BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY));
+		assertEquals(503, BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
 	public void testString() {
 		StringMessage message = new StringMessage("json");
 		assertEquals("json", message.getPayload());
-		assertEquals("text/plain", BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY));
-		assertEquals(200, BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 0));
+		assertEquals("text/plain", BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY));
+		assertEquals(200, BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
 	public void testJson() {
 		JsonMessage message = new JsonMessage("json");
 		assertEquals("\"json\"", message.getPayload());
-		assertEquals("application/json", BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY));
-		assertEquals(200, BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 0));
+		assertEquals("application/json", BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY));
+		assertEquals(200, BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
@@ -74,8 +74,8 @@ public class BusResponseTypesTest {
 		JsonMessage message = new JsonMessage(json.build());
 
 		assertEquals("{\"key\":\"value\"}", message.getPayload().replace(" ", "").replace("\n", ""));
-		assertEquals("application/json", BusMessageUtils.getHeader(message, MessageBase.MIMETYPE_KEY));
-		assertEquals(200, BusMessageUtils.getIntHeader(message, MessageBase.STATUS_KEY, 0));
+		assertEquals("application/json", BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY));
+		assertEquals(200, BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 0));
 	}
 
 	@Test
@@ -93,16 +93,16 @@ public class BusResponseTypesTest {
 		message.setFilename("testnaam");
 		message.setHeader("test123", "dummy");
 		assertEquals("dummy", BusMessageUtils.getHeader(message, "test123"));
-		assertEquals("attachment; filename=\"testnaam\"", BusMessageUtils.getHeader(message, MessageBase.CONTENT_DISPOSITION_KEY));
+		assertEquals("attachment; filename=\"testnaam\"", BusMessageUtils.getHeader(message, AbstractMessage.CONTENT_DISPOSITION_KEY));
 	}
 
 	@Test
 	public void testEmptyResponseMessage() {
 		EmptyMessage created = EmptyMessage.created();
-		assertEquals(201, BusMessageUtils.getIntHeader(created, MessageBase.STATUS_KEY, 0));
+		assertEquals(201, BusMessageUtils.getIntHeader(created, AbstractMessage.STATUS_KEY, 0));
 		EmptyMessage accepted = EmptyMessage.accepted();
-		assertEquals(202, BusMessageUtils.getIntHeader(accepted, MessageBase.STATUS_KEY, 0));
+		assertEquals(202, BusMessageUtils.getIntHeader(accepted, AbstractMessage.STATUS_KEY, 0));
 		EmptyMessage noContent = EmptyMessage.noContent();
-		assertEquals(204, BusMessageUtils.getIntHeader(noContent, MessageBase.STATUS_KEY, 0));
+		assertEquals(204, BusMessageUtils.getIntHeader(noContent, AbstractMessage.STATUS_KEY, 0));
 	}
 }

--- a/management-gateway/src/test/java/org/frankframework/management/gateway/HazelcastEndToEndTest.java
+++ b/management-gateway/src/test/java/org/frankframework/management/gateway/HazelcastEndToEndTest.java
@@ -1,12 +1,18 @@
 package org.frankframework.management.gateway;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +40,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import org.frankframework.management.bus.BusMessageUtils;
+import org.frankframework.management.bus.message.BinaryMessage;
 import org.frankframework.util.SpringRootInitializer;
 
 @SpringJUnitConfig(classes = {SpringRootInitializer.class})
@@ -56,15 +63,28 @@ public class HazelcastEndToEndTest {
 			@RolesAllowed("IbisTester")
 			public void handleMessage(@NonNull Message<?> message) throws MessagingException {
 				assertTrue(BusMessageUtils.hasRole("IbisTester"));
-				String request = (String) message.getPayload();
-				if ("sync-string".equals(request)) {
-					Message<String> response = new GenericMessage<>("response-string", new MessageHeaders(null));
-					MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
-					replyChannel.send(response);
-				} else if (request.startsWith("load-req-")) {
-					Message<String> response = new GenericMessage<>(request.replace("-req-", "-resp-"), new MessageHeaders(null));
-					MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
-					replyChannel.send(response);
+
+				if (message.getPayload() instanceof String request) {
+					if ("sync-string".equals(request)) {
+						Message<String> response = new GenericMessage<>("response-string", new MessageHeaders(null));
+						MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
+						replyChannel.send(response);
+					} else if (request.startsWith("load-req-")) {
+						Message<String> response = new GenericMessage<>(request.replace("-req-", "-resp-"), new MessageHeaders(null));
+						MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
+						replyChannel.send(response);
+					}
+				} else if (message.getPayload() instanceof InputStream stream) {
+					try {
+						String request = new String(stream.readAllBytes());
+						if ("sync-string".equals(request)) {
+							InputStream response = new ByteArrayInputStream("response-string".getBytes(StandardCharsets.UTF_8));
+							MessageChannel replyChannel = (MessageChannel) message.getHeaders().getReplyChannel();
+							replyChannel.send(new BinaryMessage(response));
+						}
+					} catch (IOException e) {
+						fail(e);
+					}
 				}
 			}
 		});
@@ -147,4 +167,38 @@ public class HazelcastEndToEndTest {
 		assertEquals("async-string", capturedRequest.getPayload());
 	}
 
+	@Test
+	@WithMockUser(authorities = { "ROLE_IbisTester" })
+	@Tag("slow")
+	public void testStreamingFrameworkMessage() throws IOException {
+		// Arrange
+		InputStream stream = new ByteArrayInputStream("sync-string".getBytes(StandardCharsets.UTF_8));
+		Message<InputStream> request = new BinaryMessage(stream);
+
+		// Act
+		Message<String> response = outboundGateway.sendSyncMessage(request);
+
+		// Assert
+		InputStream responseStream = assertInstanceOf(InputStream.class, response.getPayload());
+		String responseString = new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
+		assertEquals("response-string", responseString);
+	}
+
+	@Test
+	@WithMockUser(authorities = { "ROLE_IbisTester" })
+	@Tag("slow")
+	public void testStreamingGenericMessage() throws IOException {
+		// Arrange
+		InputStream stream = new ByteArrayInputStream("sync-string".getBytes(StandardCharsets.UTF_8));
+		// Request should be automatically wrapped so its serializable.
+		Message<InputStream> request = new GenericMessage<>(stream, new MessageHeaders(null));
+
+		// Act
+		Message<String> response = outboundGateway.sendSyncMessage(request);
+
+		// Assert
+		InputStream responseStream = assertInstanceOf(InputStream.class, response.getPayload());
+		String responseString = new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
+		assertEquals("response-string", responseString);
+	}
 }

--- a/test/src/test/java/org/frankframework/runner/PluginTest.java
+++ b/test/src/test/java/org/frankframework/runner/PluginTest.java
@@ -27,7 +27,7 @@ import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.LocalGateway;
-import org.frankframework.management.bus.message.MessageBase;
+import org.frankframework.management.bus.message.AbstractMessage;
 import org.frankframework.management.bus.message.RequestMessageBuilder;
 
 @Tag("slow")
@@ -88,7 +88,7 @@ class PluginTest {
 
 		Message<Object> response = gateway.sendSyncMessage(builder.build(null));
 
-		assertEquals("SUCCESS", BusMessageUtils.getHeader(response, MessageBase.STATE_KEY));
+		assertEquals("SUCCESS", BusMessageUtils.getHeader(response, AbstractMessage.STATE_KEY));
 		assertEquals("Niels was here!", ResponseUtils.parseAsString(response));
 	}
 }


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Rename MessageBase to AbstractMessage
Don't use GenericMessage
Implement the `RequestMessageBuilder` for the ladybug 'bus actions'.

I've created a new `ImmutableMessage` which right now is used as an alternative to `GenericMessage`. 
Perhaps we can use it in the future to [Further encrypt certain bus traffic #8940](https://github.com/frankframework/frankframework/issues/8940).



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
