### PR TITLE
Add documentation for kubernetes credential provider classes

### DIFF
--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/AbstractKubernetesCredentialProvider.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/AbstractKubernetesCredentialProvider.java
@@ -30,6 +30,25 @@ import lombok.extern.java.Log;
 
 import org.frankframework.credentialprovider.util.CredentialConstants;
 
+/**
+ * Abstract base class for Kubernetes-backed credential providers.
+ *
+ * <p>Handles shared concerns: building and configuring the {@link KubernetesClient},
+ * verifying connectivity to the cluster, and validating alias names against the
+ * Kubernetes RFC 1123 naming rules (must start and end with an alphanumeric character).
+ *
+ * <p>Subclasses implement {@link #postInitialize(CredentialConstants)} to perform
+ * their own startup work after the client is ready, and must provide implementations
+ * of {@link #getSecret(CredentialAlias)} and {@link #getConfiguredAliases()}.
+ *
+ * <p>The following properties are read from {@link CredentialConstants} during initialization:
+ * <ul>
+ *   <li>{@value #K8_MASTER_URL} — override the Kubernetes API server URL</li>
+ *   <li>{@value #K8_USERNAME} — optional username for cluster authentication</li>
+ *   <li>{@value #K8_PASSWORD} — optional password for cluster authentication</li>
+ *   <li>{@value #K8_NAMESPACE_PROPERTY} — namespace to operate in (defaults to {@value #DEFAULT_NAMESPACE})</li>
+ * </ul>
+ */
 @Log
 public abstract class AbstractKubernetesCredentialProvider implements ISecretProvider {
 	static final String K8_USERNAME = "credentialFactory.kubernetes.username";

--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/AuthAliasPrefixKubernetesSecret.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/AuthAliasPrefixKubernetesSecret.java
@@ -23,6 +23,17 @@ import org.jspecify.annotations.Nullable;
 import io.fabric8.kubernetes.api.model.Secret;
 import lombok.extern.java.Log;
 
+/**
+ * An {@link ISecret} implementation that reads credential fields from a Kubernetes secret
+ * using a dot-separated key prefix derived from the auth alias name.
+ *
+ * <p>Keys in the Kubernetes secret are expected to follow the convention
+ * {@code <alias>.<fieldname>}, for example {@code myalias.username} or {@code myalias.password}.
+ * When {@link #getField(String)} is called, the alias prefix is prepended to the field name
+ * to form the full key, and the corresponding Base64-encoded value is decoded and returned.
+ *
+ * <p>Returns {@code null} if the field name is blank or no matching key exists in the secret.
+ */
 @Log
 public class AuthAliasPrefixKubernetesSecret extends org.frankframework.credentialprovider.Secret {
 

--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesNamedSecretProvider.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesNamedSecretProvider.java
@@ -34,6 +34,25 @@ import lombok.extern.java.Log;
 import org.frankframework.credentialprovider.util.Cache;
 import org.frankframework.credentialprovider.util.CredentialConstants;
 
+/**
+ * Credential provider that resolves auth aliases from a fixed set of named Kubernetes secrets.
+ *
+ * <p>Unlike {@link KubernetesCredentialFactory}, which maps one Kubernetes secret to one alias,
+ * this provider expects each configured secret to hold credentials for <em>multiple</em> aliases
+ * using a dot-prefixed key convention. For example, a secret containing the keys
+ * {@code myalias.username} and {@code myalias.password} exposes the alias {@code myalias}
+ * with fields {@code username} and {@code password}.
+ *
+ * <p>The names of the Kubernetes secrets to read from must be specified via the property
+ * {@value #K8_SECRET_NAMES_PROPERTY} as a comma-separated list. Secrets are searched in order;
+ * the first secret that contains any key with the requested alias prefix is used.
+ *
+ * <p>Both individual secrets and the full alias discovery result are cached for
+ * {@value AbstractKubernetesCredentialProvider#CACHE_DURATION_MILLIS} ms to limit calls
+ * to the Kubernetes API.
+ * <p>
+ * The credentials are cached for 60 seconds to prevent unnecessary calls to the Kubernetes API.
+ */
 @Log
 public class KubernetesNamedSecretProvider extends AbstractKubernetesCredentialProvider {
 

--- a/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesSecret.java
+++ b/kubernetes/src/main/java/org/frankframework/credentialprovider/KubernetesSecret.java
@@ -24,6 +24,17 @@ import org.jspecify.annotations.Nullable;
 import io.fabric8.kubernetes.api.model.Secret;
 import lombok.extern.java.Log;
 
+/**
+ * An {@link ISecret} implementation backed by a single Kubernetes secret.
+ *
+ * <p>The Kubernetes secret name must match the auth alias name exactly. Fields are looked up
+ * directly by key (e.g. {@code username}, {@code password}), and the Base64-encoded values
+ * stored by Kubernetes are decoded before being returned.
+ *
+ * <p>Returns {@code null} if the requested field key is not present in the secret.
+ *
+ * @see KubernetesCredentialFactory
+ */
 @NullMarked
 @Log
 public class KubernetesSecret extends org.frankframework.credentialprovider.Secret {
@@ -45,7 +56,7 @@ public class KubernetesSecret extends org.frankframework.credentialprovider.Secr
 	public String getField(@Nullable String key) {
 		String foundKey = secret.getData().get(key);
 		if (StringUtils.isEmpty(foundKey)) {
-			log.info("no value found for alias [" + getAlias() + "] and field " +  key);
+			log.info("no value found for alias [" + getAlias() + "] and field " + key);
 			return null;
 		}
 		return new String(Base64.getDecoder().decode(foundKey));


### PR DESCRIPTION
Missing documentation added for the kubernetes credential provider classes.

Closes #10806 