### PR TITLE
Add automerge label for dependency updates, for Kodiak merging

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,18 @@
     "commitMessageSuffix": "",
     "packageRules": [
         {
+            "description": "Automerge non-major updates",
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ],
+            "addLabels": [
+                "automerge"
+            ]
+        },
+        {
             "description": "Maven dependencies - daily at 6 AM, ignore major updates",
             "matchManagers": [
                 "maven"
@@ -42,7 +54,7 @@
             "addLabels": [
                 "Java"
             ],
-            "ignoreDeps" : [
+            "ignoreDeps": [
                 "software.amazon.awssdk:bom",
                 "org.ibissource:ibis-ladybug",
                 "org.wearefrank:ladybug",
@@ -102,7 +114,7 @@
             "matchBaseBranches": [
                 "/^release\\/8\\.0$/"
             ],
-            "ignoreDeps" : [
+            "ignoreDeps": [
                 "org.apache.tika:tika-parsers",
                 "org.springframework.boot:spring-boot-loader",
                 "org.springframework:"

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -5,10 +5,7 @@ method = "squash"
 delete_branch_on_merge = true
 notify_on_conflict = false
 show_missing_automerge_label_message = false
-
-[merge.automerge_dependencies]
-versions = ["minor", "patch"]
-usernames = ["dependabot", "renovate"]
+automerge_label = "automerge"
 
 [approve]
 auto_approve_usernames = ["dependabot", "renovate"]


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Instead of using the build in dependency merge of Kodiak. Use the automerge label and let Renovate add it to the PRs

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
