### PR TITLE
Fix AmqpSender false-positive warning for RabbitMQ 4.x AMQP 1.0 v2 ad…

### DIFF
--- a/messaging/src/main/java/org/frankframework/messaging/amqp/AmqpSender.java
+++ b/messaging/src/main/java/org/frankframework/messaging/amqp/AmqpSender.java
@@ -154,9 +154,11 @@ public class AmqpSender extends AbstractSenderWithParameters implements ISenderW
 			serverIsRabbitMQ = "RabbitMQ".equals(connection.properties().get("product"));
 
 			if (serverIsRabbitMQ) {
-				// The "/" should be legal in RabbitMQ queue names, but there are errors when I use it. Perhaps because queues are not pre-created? Dunno.
-				// For now, giving a warning on it.
-				if (Strings.CS.contains(address, "/") || Strings.CS.contains(replyAddress, "/")) {
+				// RabbitMQ 4.x AMQP 1.0 v2 addresses (/queues/<name>, /exchanges/<name>) require a slash prefix and are valid.
+				// Only warn for addresses that contain slashes but do not follow the v2 pattern.
+				boolean addressIsV1 = Strings.CS.contains(address, "/") && !address.startsWith("/queues/") && !address.startsWith("/exchanges/");
+				boolean replyIsV1 = replyAddress != null && Strings.CS.contains(replyAddress, "/") && !replyAddress.startsWith("/queues/") && !replyAddress.startsWith("/exchanges/");
+				if (addressIsV1 || replyIsV1) {
 					ConfigurationWarnings.add(this, log, "RabbitMQ might not allow slashes in queue names (queue: [" + address + "]; reply queue: [" + replyAddress + "])");
 				}
 


### PR DESCRIPTION
…dresses

RabbitMQ 4.x requires AMQP 1.0 v2 address format (/queues/<name> or /exchanges/<name>) and rejects bare queue names by default. The existing warning fired unconditionally on any slash in the address, producing a false positive for valid v2 addresses.

Narrow the condition: only warn when the address contains a slash but does NOT start with /queues/ or /exchanges/ (i.e. a slash that is not part of the recognised v2 prefix).

## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
