### PR TITLE
Add config rule for readonly private instance members

### DIFF
--- a/console/frontend/src/main/frontend/eslint.config.mjs
+++ b/console/frontend/src/main/frontend/eslint.config.mjs
@@ -54,7 +54,9 @@ export default [
               'public-instance-field',
               'protected-instance-field',
               'private-instance-field',
+              'private-instance-readonly-field',
               '#private-instance-field',
+              '#private-instance-readonly-field',
 
               'public-abstract-field',
               'protected-abstract-field',


### PR DESCRIPTION
Force private readonly instance members to go after private instance members:

Before:
```ts
private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
private application: ApplicationConfigDto | null = null;
private readonly currentApplicationService: CurrentApplicationService = inject(CurrentApplicationService);
```
After:
```ts
private application: ApplicationConfigDto | null = null;
private readonly configurationsService: ConfigurationsService = inject(ConfigurationsService);
private readonly currentApplicationService: CurrentApplicationService = inject(CurrentApplicationService);
```