### PR TITLE
Add maven-shade-plugin configuration to the build-templates

### DIFF
--- a/build-templates/plugin-parent/pom.xml
+++ b/build-templates/plugin-parent/pom.xml
@@ -35,7 +35,7 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
+				<artifactId>maven-shade-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/build-templates/pom.xml
+++ b/build-templates/pom.xml
@@ -139,6 +139,9 @@
 								<Project-URL>${project.url}</Project-URL>
 								<Sealed>true</Sealed>
 								<Classifier>${plugin.type}</Classifier>
+
+								<Plugin-Class>${plugin.class}</Plugin-Class>
+								<Plugin-Dependencies>${plugin.dependencies}</Plugin-Dependencies>
 							</manifestEntries>
 						</archive>
 					</configuration>
@@ -274,6 +277,42 @@
 							<id>make-assembly</id>
 							<goals>
 								<goal>single</goal>
+							</goals>
+							<phase>package</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-shade-plugin</artifactId>
+					<version>3.6.2</version>
+					<configuration>
+						<createDependencyReducedPom>false</createDependencyReducedPom>
+						<minimizeJar>true</minimizeJar>
+						<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+						<shadedArtifactAttached>true</shadedArtifactAttached>
+						<shadedClassifierName>${plugin.type}</shadedClassifierName>
+						<filters>
+							<filter>
+								<artifact>*:*</artifact>
+								<includes>
+									<include>**</include>
+								</includes>
+								<excludes>
+									<exclude>**/module-info.class</exclude>
+								</excludes>
+							</filter>
+						</filters>
+						<transformers>
+							<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+							<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+							<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+						</transformers>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>shade</goal>
 							</goals>
 							<phase>package</phase>
 						</execution>
@@ -485,6 +524,13 @@
 						<artifactId>maven-assembly-plugin</artifactId>
 						<configuration>
 							<skipAssembly>true</skipAssembly>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
I wanted to shade a plugin but the assembly plugin kept overwriting files.
Since the assembly plugin is more rigid compared to the shade plugin, let's allow them both to create fat-jars.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
