### PR TITLE
Update Renovate release branches and disable major grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     "dependencyDashboardApproval": false,
     "baseBranchPatterns": [
         "master",
-        "/^release\\/9\\./",
+        "/^release\\/(9\\.0|9\\.4)$/",
         "/^release\\/8\\.0$/",
         "/^release\\/10\\./"
     ],
@@ -92,6 +92,16 @@
                 "/^org\\.springframework\\.security:/"
             ],
             "separateMinorPatch": true
+        },
+        {
+            "description": "Ungroup Maven major updates - each major gets its own PR",
+            "matchManagers": [
+                "maven"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "groupName": null
         },
         {
             "description": "Release branches - disable ALL regular updates (only security/CVE updates via vulnerabilityAlerts)",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -148,7 +148,7 @@
             ],
             "matchUpdateTypes": [
                 "minor",
-                "patch",
+                "patch"
             ],
             "schedule": [
                 "before 6am on the first day of the week"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -63,7 +63,6 @@
                 "org.eclipse.m2e:lifecycle-mapping",
                 "com.eclipsesource.j2v8:j2v8_linux_x86_64"
             ],
-            "groupName": "maven-dependencies",
             "separateMajorMinor": true,
             "separateMultipleMinor": true,
             "separateMultipleMajor": true,
@@ -94,14 +93,26 @@
             "separateMinorPatch": true
         },
         {
-            "description": "Ungroup Maven major updates - each major gets its own PR",
+            "description": "Tomcat Dependencies",
+            "matchManagers": [
+                "maven",
+                "docker"
+            ],
+            "groupName": "Tomcat",
+            "matchPackageNames": [
+                "/^org\\.apache\\.tomcat:/"
+            ],
+            "separateMinorPatch": true
+        },
+        {
+            "description": "Group Maven patch updates",
             "matchManagers": [
                 "maven"
             ],
             "matchUpdateTypes": [
-                "major"
+                "patch"
             ],
-            "groupName": null
+            "groupName": "maven-dependencies"
         },
         {
             "description": "Release branches - disable ALL regular updates (only security/CVE updates via vulnerabilityAlerts)",
@@ -134,6 +145,10 @@
             "description": "All NPM dependencies - weekly schedule, ignore major updates",
             "matchManagers": [
                 "npm"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
             ],
             "schedule": [
                 "before 6am on the first day of the week"


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Major Maven dependencies won't be grouped anymore.

Now we only scan for 9.0 (TLS) and 9.4 (security support window)
