### PR TITLE
Add optional target property to customViews links

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.html
@@ -1,8 +1,8 @@
 <ul class="nav">
   @for (view of customViews; track view.view) {
-    @if (view.url.startsWith('http')) {
+    @if (view.target || view.url.startsWith('http')) {
       <li>
-        <a [href]="view.url" target="_blank"
+        <a [href]="view.url" [target]="view.target ?? '_blank'"
         ><fa-icon [icon]="faDesktop" /> <span class="nav-label">{{ view.name }}</span></a
         >
       </li>

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -19,6 +19,7 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
     view: string;
     name: string;
     url: string;
+    target?: string;
   }[] = [];
 
   private appService: AppService = inject(AppService);
@@ -45,11 +46,13 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
         const viewId = views[index];
         const name = appConstants[`customViews.${viewId}.name`] as string;
         const url = appConstants[`customViews.${viewId}.url`] as string;
+        const target = appConstants[`customViews.${viewId}.target`] as string | undefined;
         if (name && url)
           this.customViews.push({
             view: viewId,
             name: name,
             url: url,
+            ...(target ? { target } : {}),
           });
       }
     }

--- a/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
+++ b/console/frontend/src/main/frontend/src/app/components/custom-views/custom-views.component.ts
@@ -46,7 +46,7 @@ export class CustomViewsComponent implements OnInit, OnDestroy {
         const viewId = views[index];
         const name = appConstants[`customViews.${viewId}.name`] as string;
         const url = appConstants[`customViews.${viewId}.url`] as string;
-        const target = appConstants[`customViews.${viewId}.target`] as string | undefined;
+        const target = appConstants[`customViews.${viewId}.target`] as string | null;
         if (name && url)
           this.customViews.push({
             view: viewId,

--- a/example/src/main/resources/DeploymentSpecifics.properties
+++ b/example/src/main/resources/DeploymentSpecifics.properties
@@ -23,8 +23,12 @@ jdbc.migrator.active=true
 
 # Specify details for each view
 # url is either a relative path from the webapp folder or an external url, eq. http://google.com/
+# target controls how the link opens. Relative URLs open in the console iframe by default.
+# Set target=_self to navigate the current tab, or target=_blank to open a new tab.
+# External (http/https) URLs always open as direct links and default to target=_blank.
 # customViews.MyApplication.name=Custom View
 # customViews.MyApplication.url=myWebapp
+# customViews.MyApplication.target=_self
 
 warnings.suppress.sqlInjections.ManageDatabase=true
 


### PR DESCRIPTION
Relative URL custom views currently always open inside the console iframe. The new `customViews.{id}.target` property lets deployers control this per view using standard HTML anchor target values:

- Omitted (default): relative URLs open in the console iframe, external (http/https) URLs open in a new tab — existing behaviour.
- `_self`: navigate the current tab directly, bypassing the iframe.
- `_blank`: open a new tab regardless of URL scheme.

External URLs that have no explicit target still default to `_blank`.

## Changes
Add optional target property to custom view links
  
Custom views with relative URLs currently always open inside the console iframe. This makes it impossible to use the `customViews` mechanism to link to a sibling web application that should replace the
  current page rather than render inside the console.

### Change

  A new optional property `customViews.{id}.target` controls how the link opens:

  | `target` value | Behaviour |
  |---|---|
  | _(omitted)_ | Existing behaviour: relative URLs open in the console iframe, external URLs open in a new tab |
  | `_self` | Navigates the current tab directly, bypassing the iframe |
  | `_blank` | Opens a new tab regardless of URL scheme |

  External (`http`/`https`) URLs that have no explicit `target` continue to default to `_blank`, preserving backwards compatibility.

  ### Example
  
  ```properties
  customViews.names=myApp
  customViews.myApp.name=My Application
  customViews.myApp.url=/myapp/
  customViews.myApp.target=_self
```
<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [ ] FF! Doc updated (user-facing behavior/config)
- [ ] FF! Manual updated (if applicable)
- [ ] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
