### PR TITLE
Fix use of relative root folder

### DIFF
--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -117,9 +117,10 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 			}
 
 			// Filename will always contain the folder, if it's passed as parameter or within the filename.
-			// We need to make sure that the root is not prepended if it's the same as the root specified in the filename
-			if (!filename.startsWith(getRoot())) {
-				filename = getRoot() + FILE_DELIMITER + filename;
+			// We need to make sure that the root is not prepended if it's already part of the filename.
+			// Use normalized Path-based comparison to avoid false positives (for example root x/y vs filename x/y2/file).
+			if (!result.normalize().startsWith(Paths.get(getRoot()).normalize())) {
+				filename = Paths.get(getRoot()).resolve(filename).toString();
 			}
 		}
 		if (StringUtils.isEmpty(filename)) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -105,15 +105,22 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 		if (filename==null) {
 			filename="";
 		}
+
 		if (StringUtils.isNotEmpty(folder) && !(filename.contains(FILE_DELIMITER) || filename.contains("\\"))) {
 			filename = folder + FILE_DELIMITER + filename;
 		}
+
 		if (StringUtils.isNotEmpty(getRoot())) {
 			Path result = Paths.get(filename);
 			if (result.isAbsolute()) {
 				return result;
 			}
-			filename = getRoot()+ FILE_DELIMITER + filename;
+
+			// Filename will always contain the folder, if it's passed as parameter or within the filename.
+			// We need to make sure that the root is not prepended if it's the same as the root specified in the filename
+			if (!filename.startsWith(getRoot())) {
+				filename = getRoot() + FILE_DELIMITER + filename;
+			}
 		}
 		if (StringUtils.isEmpty(filename)) {
 			throw new FileSystemException("no filesystem-root, file or folder specified");
@@ -262,7 +269,7 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 			throw new FolderAlreadyExistsException("Create folder for [" + folder + "] has failed. Directory already exists.");
 		}
 		try {
-			Files.createDirectories(toFile(folder));
+			Files.createDirectories(toFile(folder, null));
 		} catch (IOException e) {
 			throw new FileSystemException("Cannot create folder ["+ folder +"]", e);
 		}

--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -102,7 +102,7 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 
 	@Override
 	public Path toFile(@Nullable String folder, @Nullable String filename) throws FileSystemException {
-		if (filename==null) {
+		if (filename == null) {
 			filename="";
 		}
 
@@ -110,23 +110,24 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 			filename = folder + FILE_DELIMITER + filename;
 		}
 
-		if (StringUtils.isNotEmpty(getRoot())) {
-			Path result = Paths.get(filename);
-			if (result.isAbsolute()) {
-				return result;
-			}
+		Path result = Paths.get(filename);
 
+		if (StringUtils.isNotEmpty(getRoot()) && !result.isAbsolute()) {
 			// Filename will always contain the folder, if it's passed as parameter or within the filename.
 			// We need to make sure that the root is not prepended if it's already part of the filename.
 			// Use normalized Path-based comparison to avoid false positives (for example root x/y vs filename x/y2/file).
 			if (!result.normalize().startsWith(Paths.get(getRoot()).normalize())) {
-				filename = Paths.get(getRoot()).resolve(filename).toString();
+				return Paths.get(getRoot()).resolve(filename);
 			}
+
+			filename = result.toString();
 		}
+
 		if (StringUtils.isEmpty(filename)) {
 			throw new FileSystemException("no filesystem-root, file or folder specified");
 		}
-		return Paths.get(filename);
+
+		return result;
 	}
 
 	@NonNull

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -101,8 +101,6 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		assertTrue(_fileExists(filename), "Expected file [" + filename + "] to be present");
 	}
 
-
-
 	@Test
 	public void basicFileSystemTestDelete() throws Exception {
 		String filename = "tobeDeleted" + FILE1;

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -61,7 +61,10 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 			String contents = "regeltje tekst";
 
 			file = fileSystem.toFile(filename);
-			fileSystem.createFile(file, new ByteArrayInputStream(contents.getBytes()));
+
+			try (ByteArrayInputStream input = new ByteArrayInputStream(contents.getBytes())) {
+				fileSystem.createFile(file, input);
+			}
 
 			waitForActionToFinish();
 			// test

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -42,6 +42,33 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 	}
 
 	@Test
+	void testRelativeCreateRootFolder() throws Exception {
+		fileSystem.setRoot("x/y");
+		fileSystem.setCreateRootFolder(true);
+		fileSystem.configure();
+		fileSystem.open();
+
+		String filename = "createFileAbsolute" + FILE1;
+		String contents = "regeltje tekst";
+
+		Path file = fileSystem.toFile(filename);
+		fileSystem.createFile(file, new ByteArrayInputStream(contents.getBytes()));
+
+		waitForActionToFinish();
+		// test
+		assertTrue(fileSystem.exists(file), "Expected file [" + filename + "] to be present");
+
+		String actual = fileSystem.readFile(file, null).asString();
+		// test
+		assertEquals(contents.trim(), actual.trim());
+
+		// Cleanup relatively created 'x/y/createFileAbsolutefile1.txt' directory and contents
+		Files.delete(file);
+		Files.delete(file.getParent());
+		Files.delete(file.getParent().getParent());
+	}
+
+	@Test
 	void localFileSystemTestCreateNewFileAbsolute() throws Exception {
 		String filename = "createFileAbsolute" + FILE1;
 		String contents = "regeltje tekst";

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -15,7 +15,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Map;
+import java.util.UUID;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -46,8 +48,8 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 		String filename = "createFileAbsolute" + FILE1;
 		String contents = "regeltje tekst";
 		Path currentWorkingDirectory = Paths.get("").toAbsolutePath().normalize();
-		Path relativeRootParent = folder.resolve("relative-root-" + System.nanoTime());
-		Path absoluteRoot = relativeRootParent.resolve("x").resolve("y");
+		Path testRootBase = folder.resolve("relative-root-" + UUID.randomUUID());
+		Path absoluteRoot = testRootBase.resolve("x").resolve("y");
 		Path relativeRoot = currentWorkingDirectory.relativize(absoluteRoot);
 
 		fileSystem.setRoot(relativeRoot.toString());
@@ -71,9 +73,9 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 			if (file != null) {
 				Files.deleteIfExists(file);
 			}
-			Files.deleteIfExists(absoluteRoot);
-			Files.deleteIfExists(absoluteRoot.getParent());
-			Files.deleteIfExists(relativeRootParent);
+			if (Files.exists(testRootBase)) {
+				FileUtils.deleteDirectory(testRootBase.toFile());
+			}
 		}
 	}
 

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -45,8 +45,6 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 
 	@Test
 	void testRelativeCreateRootFolder() throws Exception {
-		String filename = "createFileAbsolute" + FILE1;
-		String contents = "regeltje tekst";
 		Path currentWorkingDirectory = Paths.get("").toAbsolutePath().normalize();
 		Path testRootBase = folder.resolve("relative-root-" + UUID.randomUUID());
 		Path absoluteRoot = testRootBase.resolve("x").resolve("y");
@@ -59,6 +57,9 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 
 		Path file = null;
 		try {
+			String filename = "createFileAbsolute" + FILE1;
+			String contents = "regeltje tekst";
+
 			file = fileSystem.toFile(filename);
 			fileSystem.createFile(file, new ByteArrayInputStream(contents.getBytes()));
 
@@ -70,9 +71,11 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 			// test
 			assertEquals(contents.trim(), actual.trim());
 		} finally {
+			// Clean up relatively created 'x/y/createFileAbsolutefile1.txt' directory and contents
 			if (file != null) {
 				Files.deleteIfExists(file);
 			}
+
 			if (Files.exists(testRootBase)) {
 				FileUtils.deleteDirectory(testRootBase.toFile());
 			}

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -43,29 +43,38 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 
 	@Test
 	void testRelativeCreateRootFolder() throws Exception {
-		fileSystem.setRoot("x/y");
+		String filename = "createFileAbsolute" + FILE1;
+		String contents = "regeltje tekst";
+		Path currentWorkingDirectory = Paths.get("").toAbsolutePath().normalize();
+		Path relativeRootParent = folder.resolve("relative-root-" + System.nanoTime());
+		Path absoluteRoot = relativeRootParent.resolve("x").resolve("y");
+		Path relativeRoot = currentWorkingDirectory.relativize(absoluteRoot);
+
+		fileSystem.setRoot(relativeRoot.toString());
 		fileSystem.setCreateRootFolder(true);
 		fileSystem.configure();
 		fileSystem.open();
 
-		String filename = "createFileAbsolute" + FILE1;
-		String contents = "regeltje tekst";
+		Path file = null;
+		try {
+			file = fileSystem.toFile(filename);
+			fileSystem.createFile(file, new ByteArrayInputStream(contents.getBytes()));
 
-		Path file = fileSystem.toFile(filename);
-		fileSystem.createFile(file, new ByteArrayInputStream(contents.getBytes()));
+			waitForActionToFinish();
+			// test
+			assertTrue(fileSystem.exists(file), "Expected file [" + filename + "] to be present");
 
-		waitForActionToFinish();
-		// test
-		assertTrue(fileSystem.exists(file), "Expected file [" + filename + "] to be present");
-
-		String actual = fileSystem.readFile(file, null).asString();
-		// test
-		assertEquals(contents.trim(), actual.trim());
-
-		// Cleanup relatively created 'x/y/createFileAbsolutefile1.txt' directory and contents
-		Files.delete(file);
-		Files.delete(file.getParent());
-		Files.delete(file.getParent().getParent());
+			String actual = fileSystem.readFile(file, null).asString();
+			// test
+			assertEquals(contents.trim(), actual.trim());
+		} finally {
+			if (file != null) {
+				Files.deleteIfExists(file);
+			}
+			Files.deleteIfExists(absoluteRoot);
+			Files.deleteIfExists(absoluteRoot.getParent());
+			Files.deleteIfExists(relativeRootParent);
+		}
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -69,6 +69,23 @@ class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 	}
 
 	@Test
+	void testToFileDoesNotTreatSimilarRootPrefixAsRoot() throws Exception {
+		fileSystem.setRoot("x/y");
+		Path resolved = fileSystem.toFile("x/y2/file.txt");
+
+		assertEquals(Paths.get("x/y").resolve("x/y2/file.txt"), resolved);
+	}
+
+	@Test
+	void testToFilePrependsRootWhenNormalizedPathIsOutsideRoot() throws Exception {
+		fileSystem.setRoot("x/y");
+		Path resolved = fileSystem.toFile("x/y/../outside/file.txt");
+
+		assertTrue(resolved.normalize().startsWith(Paths.get("x/y")));
+		assertEquals(Paths.get("x/y").resolve("x/y/../outside/file.txt"), resolved);
+	}
+
+	@Test
 	void localFileSystemTestCreateNewFileAbsolute() throws Exception {
 		String filename = "createFileAbsolute" + FILE1;
 		String contents = "regeltje tekst";


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
This PR adjusts LocalFileSystem path resolution to better handle a configured root folder when callers already provide root-qualified relative paths, and adds a regression test around creating a relative root folder.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [x] Backport PRs created (if needed) and linked
  - [x] [release/9.0](https://github.com/frankframework/frankframework/pull/10900)
  - [x] [release/10.0](https://github.com/frankframework/frankframework/pull/10901)

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [n/a] FF! Doc updated (user-facing behavior/config)
- [n/a] FF! Manual updated (if applicable)
- [x] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
