### PR TITLE
Update Renovate configuration for version separation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -157,7 +157,7 @@
                 "JavaScript"
             ],
             "groupName": "npm-dependencies",
-            "separateMajorMinor": true,
+            "separateMinorPatch": true,
             "minimumReleaseAge": "5 days"
         },
         {


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Changed configuration to separate minor and patch updates. This hopefully fixes the validation error. Otherwise, it needs to be removed altogether.
