### PR TITLE
Refactor JdbcTransactionalStorage to remove table creation logic

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/JdbcTransactionalStorage.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcTransactionalStorage.java
@@ -15,7 +15,6 @@
 */
 package org.frankframework.jdbc;
 
-import static org.frankframework.functional.FunctionalUtil.logValue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,7 +26,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -49,7 +47,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.core.ITransactionalStorage;
 import org.frankframework.core.IbisTransaction;
@@ -62,7 +59,6 @@ import org.frankframework.dbms.DbmsException;
 import org.frankframework.dbms.IDbmsSupport;
 import org.frankframework.dbms.JdbcException;
 import org.frankframework.jdbc.datasource.JdbcPoolUtil;
-import org.frankframework.lifecycle.LifecycleException;
 import org.frankframework.receivers.MessageWrapper;
 import org.frankframework.receivers.RawMessageWrapper;
 import org.frankframework.stream.Message;
@@ -96,7 +92,7 @@ import org.frankframework.util.TimeProvider;
  * a key based on the sent or received message. Messages with the same key are considered to
  * be the same.
  * <br/><br/>
- * Storage structure is defined in /IAF_util/IAF_DatabaseChangelog.xml. If these database objects do not exist,
+ * Storage structure is defined in the liquibase migration `/IAF_util/IAF_DatabaseChangelog.xml`. If these database objects do not exist,
  * the Frank!Framework will try to create them.
  * <br/><br/>
  * {@ff.warning When using an XA transaction manager like Narayana, make sure to configure an XA-capable datasource
@@ -118,7 +114,6 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 
 	private @Getter boolean checkTable; 		// default set from appConstant jdbc.storage.checkTable
 	private @Getter boolean checkIndices;		// default set from appConstant jdbc.storage.checkIndices
-	private @Getter boolean createTable=false;
 
 	private String host;
 	private @Getter boolean blobsCompressed=true;
@@ -329,7 +324,7 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 	}
 
 	/**
-	 * Creates a connection, checks if the table is existing and creates it when necessary
+	 * Creates a connection, checks if the necessary tables, indices and sequences exist.
 	 */
 	@Override
 	public void configure() throws ConfigurationException {
@@ -367,17 +362,6 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 			}
 		} catch (JdbcException e) {
 			throw new ConfigurationException("Cannot get the configured datasource [" + getDatasourceName() + "]", e);
-		}
-	}
-
-	@Override
-	public void start() {
-		try {
-			initialize(getDbmsSupport());
-		} catch (JdbcException e) {
-			throw new LifecycleException(e);
-		} catch (SQLException e) {
-			throw new LifecycleException(getLogPrefix()+"exception creating table ["+getTableName()+"]",e);
 		}
 	}
 
@@ -448,77 +432,6 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 		 * selectListQuery zou FIRST_ROWS(500) hint kunnen krijgen
 		 * we zouden de index hint via een custom property aan en uit kunnen zetten...
 		 */
-	}
-
-	/**
-	 *	Checks if table exists, and creates when necessary.
-	 */
-	public void initialize(IDbmsSupport dbmsSupport) throws JdbcException, SQLException {
-		try (Connection conn = getConnection()) {
-			boolean tableMustBeCreated;
-
-			if (isCheckTable()) {
-				try {
-					tableMustBeCreated = !getDbmsSupport().isTablePresent(conn, getPrefix()+getTableName());
-					if (!isCreateTable() && tableMustBeCreated) {
-						throw new LifecycleException("table ["+getPrefix()+getTableName()+"] does not exist");
-					}
-					log.info("table [{}{}] does {}exist", this::getPrefix, this::getTableName, logValue(tableMustBeCreated?"NOT ":""));
-				} catch (JdbcException e) {
-					log.warn("{}exception determining existence of table [{}{}] for transactional storage, trying to create anyway.{}", getLogPrefix(), getPrefix(), getTableName(), e.getMessage());
-					tableMustBeCreated=true;
-				}
-			} else {
-				log.info("did not check for existence of table [{}{}]", getPrefix(), getTableName());
-				tableMustBeCreated = false;
-			}
-
-			if (isCreateTable() && tableMustBeCreated) {
-				log.info("{}creating table [{}{}] for transactional storage", getLogPrefix(), getPrefix(), getTableName());
-				try (Statement stmt = conn.createStatement()) {
-					createStorage(conn, stmt, dbmsSupport);
-				}
-				conn.commit();
-			}
-		}
-	}
-
-	/**
-	 *	Acutaly creates storage. Can be overridden in descender classes
-	 */
-	protected void createStorage(Connection conn, Statement stmt, IDbmsSupport dbmsSupport) throws JdbcException {
-		String query=null;
-		try {
-			query="CREATE TABLE "+getPrefix()+getTableName()+" ("+
-						getKeyField()+" "+getKeyFieldType()+" CONSTRAINT " +getPrefix()+getTableName()+ "_pk PRIMARY KEY, "+
-						(StringUtils.isNotEmpty(getTypeField())?getTypeField()+" CHAR(1), ":"")+
-						(StringUtils.isNotEmpty(getSlotId())? getSlotIdField()+" "+getTextFieldType()+"("+MAXIDLEN+"), ":"")+
-						(StringUtils.isNotEmpty(getHostField())?getHostField()+" "+getTextFieldType()+"("+MAXIDLEN+"), ":"")+
-						getIdField()+" "+getTextFieldType()+"("+MAXIDLEN+"), "+
-						getCorrelationIdField()+" "+getTextFieldType()+"("+MAXCIDLEN+"), "+
-						getDateField()+" "+getDateFieldType()+", "+
-						getCommentField()+" "+getTextFieldType()+"("+MAXCOMMENTLEN+"), "+
-						getMessageField()+" "+getMessageFieldType()+", "+
-						getExpiryDateField()+" "+getDateFieldType()+
-						(StringUtils.isNotEmpty(getLabelField())?getLabelField()+" "+getTextFieldType()+"("+MAXLABELLEN+"), ":"")+
-					")";
-
-			log.debug("{}creating table [{}{}] using query [{}]", this::getLogPrefix, this::getPrefix, this::getTableName, logValue(query));
-			stmt.execute(query);
-			if (StringUtils.isNotEmpty(getIndexName())) {
-				query = "CREATE INDEX "+getPrefix()+getIndexName()+" ON "+getPrefix()+getTableName()+"("+(StringUtils.isNotEmpty(getSlotId())?getSlotIdField()+",":"")+getDateField()+","+getExpiryDateField()+")";
-				log.debug("{}creating index [{}{}] using query [{}]", this::getLogPrefix, this::getPrefix, this::getIndexName, logValue(query));
-				stmt.execute(query);
-			}
-			if (dbmsSupport.autoIncrementUsesSequenceObject()) {
-				query="CREATE SEQUENCE "+getPrefix()+getSequenceName()+" START WITH 1 INCREMENT BY 1";
-				log.debug("{}creating sequence for table [{}{}] using query [{}]", this::getLogPrefix, this::getPrefix, this::getTableName, logValue(query));
-				stmt.execute(query);
-			}
-			conn.commit();
-		} catch (SQLException e) {
-			throw new JdbcException(getLogPrefix()+" executing query ["+query+"]", e);
-		}
 	}
 
 	@NonNull
@@ -837,16 +750,6 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 		checkTable = b;
 	}
 
-	/**
-	 * If set to <code>true</code>, the table is created if it does not exist
-	 * @ff.default false
-	 */
-	@Deprecated(forRemoval = true, since = "7.9.0")
-	@ConfigurationWarning("if you want to create and maintain database tables, please enable Liquibase")
-	public void setCreateTable(boolean b) {
-		createTable = b;
-	}
-
 	/** The type of the column message themselves are stored in */
 	public void setMessageFieldType(String string) {
 		messageFieldType = string;
@@ -906,5 +809,4 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 	public void setOnlyStoreWhenMessageIdUnique(boolean onlyStoreWhenMessageIdUnique) {
 		this.onlyStoreWhenMessageIdUnique = onlyStoreWhenMessageIdUnique;
 	}
-
 }

--- a/core/src/main/java/org/frankframework/jdbc/JdbcTransactionalStorage.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcTransactionalStorage.java
@@ -92,8 +92,8 @@ import org.frankframework.util.TimeProvider;
  * a key based on the sent or received message. Messages with the same key are considered to
  * be the same.
  * <br/><br/>
- * Storage structure is defined in the liquibase migration `/IAF_util/IAF_DatabaseChangelog.xml`. If these database objects do not exist,
- * the Frank!Framework will try to create them.
+ * Storage structure is defined in the liquibase migration `/IAF_util/IAF_DatabaseChangelog.xml`. On startup, liquibase will try to create this structure
+ * if not present already.
  * <br/><br/>
  * {@ff.warning When using an XA transaction manager like Narayana, make sure to configure an XA-capable datasource
  * for the JdbcErrorStorage or JdbcMessageLog. Otherwise messages may get lost.}

--- a/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
@@ -199,12 +199,12 @@ public class JdbcTransactionalStorageTest {
 	}
 
 	@DatabaseTest
-	public void testRetrieveObjectWithADifferentColumnNotCompressed() throws Exception {
+	public void testRetrieveObjectWithADifferentColumnNotCompressed() {
 		assertThrows(JdbcException.class, () -> testRetrieveObjectWithADifferentColumnHelper(false), "unknown compression method");
 	}
 
 	@DatabaseTest
-	public void testRetrieveObjectWithADifferentColumn() throws Exception {
+	public void testRetrieveObjectWithADifferentColumn() {
 		assertThrows(JdbcException.class, () -> testRetrieveObjectWithADifferentColumnHelper(true), "invalid stream header");
 	}
 
@@ -272,5 +272,4 @@ public class JdbcTransactionalStorageTest {
 		assertEquals(message, result);
 		storage.getTxManager().commit(tx);
 	}
-
 }

--- a/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
@@ -195,10 +195,7 @@ public class JdbcTransactionalStorageTest {
 	}
 
 	private String createMessage() {
-		StringBuilder sb = new StringBuilder();
-		sb.repeat("message", 5);
-
-		return sb.toString();
+		return "message".repeat(5);
 	}
 
 	@DatabaseTest

--- a/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcTransactionalStorageTest.java
@@ -150,9 +150,7 @@ public class JdbcTransactionalStorageTest {
 		assertEquals(storageKey, ro.getId());
 		assertNotNull(o);
 		assertEquals(message, o);
-
 	}
-
 
 	private String insertARecord(boolean blobsCompressed, String message, char type) throws SQLException, IOException {
 		try (Connection connection = env.getConnection()) {
@@ -198,9 +196,8 @@ public class JdbcTransactionalStorageTest {
 
 	private String createMessage() {
 		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < 5; i++) {
-			sb.append("message");
-		}
+		sb.repeat("message", 5);
+
 		return sb.toString();
 	}
 


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Removed table creation logic since that is handled by liquibase or a dba


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [n/a] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [n/a] FF! Doc updated (user-facing behavior/config)
- [n/a] FF! Manual updated (if applicable)
- [x] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
