### PR TITLE
Fix use of relative root folder

### DIFF
--- a/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/LocalFileSystem.java
@@ -82,26 +82,38 @@ public class LocalFileSystem extends AbstractFileSystem<Path> implements IWritab
 	}
 
 	@Override
-	public Path toFile(@Nullable String filename) {
+	public Path toFile(@Nullable String filename) throws FileSystemException {
 		return toFile(null, filename);
 	}
 
 	@Override
-	public Path toFile(@Nullable String folder, @Nullable String filename) {
-		if (filename==null) {
-			filename="";
+	public Path toFile(@Nullable String folder, @Nullable String filename) throws FileSystemException {
+		if (filename == null) {
+			filename = "";
 		}
+
 		if (StringUtils.isNotEmpty(folder) && !(filename.contains("/") || filename.contains("\\"))) {
 			filename = folder + "/" + filename;
 		}
-		if (StringUtils.isNotEmpty(getRoot())) {
-			Path result = Paths.get(filename);
-			if (result.isAbsolute()) {
-				return result;
+
+		Path result = Paths.get(filename);
+
+		if (StringUtils.isNotEmpty(getRoot()) && !result.isAbsolute()) {
+			// Filename will always contain the folder, if it's passed as parameter or within the filename.
+			// We need to make sure that the root is not prepended if it's already part of the filename.
+			// Use normalized Path-based comparison to avoid false positives (for example root x/y vs filename x/y2/file).
+			if (!result.normalize().startsWith(Paths.get(getRoot()).normalize())) {
+				return Paths.get(getRoot()).resolve(filename);
 			}
-			filename = getRoot()+ "/" + filename;
+
+			filename = result.toString();
 		}
-		return Paths.get(filename);
+
+		if (StringUtils.isEmpty(filename)) {
+			throw new FileSystemException("no filesystem-root, file or folder specified");
+		}
+
+		return result;
 	}
 
 	@Override

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -98,8 +98,6 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		assertTrue(_fileExists(filename), "Expected file [" + filename + "] to be present");
 	}
 
-
-
 	@Test
 	public void basicFileSystemTestDelete() throws Exception {
 		String filename = "tobeDeleted" + FILE1;

--- a/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/LocalFileSystemTest.java
@@ -15,7 +15,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Map;
+import java.util.UUID;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -39,6 +41,65 @@ public class LocalFileSystemTest extends FileSystemTest<Path, LocalFileSystem> {
 	@Override
 	protected IFileSystemTestHelper getFileSystemTestHelper() {
 		return new LocalFileSystemTestHelper(folder);
+	}
+
+	@Test
+	void testRelativeCreateRootFolder() throws Exception {
+		Path currentWorkingDirectory = Paths.get("").toAbsolutePath().normalize();
+		Path testRootBase = folder.resolve("relative-root-" + UUID.randomUUID());
+		Path absoluteRoot = testRootBase.resolve("x").resolve("y");
+		Path relativeRoot = currentWorkingDirectory.relativize(absoluteRoot);
+
+		fileSystem.setRoot(relativeRoot.toString());
+		fileSystem.setCreateRootFolder(true);
+		fileSystem.configure();
+		fileSystem.open();
+
+		Path file = null;
+		try {
+			String filename = "createFileAbsolute" + FILE1;
+			String contents = "regeltje tekst";
+
+			file = fileSystem.toFile(filename);
+
+			try (ByteArrayInputStream input = new ByteArrayInputStream(contents.getBytes())) {
+				fileSystem.createFile(file, input);
+			}
+
+			waitForActionToFinish();
+			// test
+			assertTrue(fileSystem.exists(file), "Expected file [" + filename + "] to be present");
+
+			String actual = fileSystem.readFile(file, null).asString();
+			// test
+			assertEquals(contents.trim(), actual.trim());
+		} finally {
+			// Clean up relatively created 'x/y/createFileAbsolutefile1.txt' directory and contents
+			if (file != null) {
+				Files.deleteIfExists(file);
+			}
+
+			if (Files.exists(testRootBase)) {
+				FileUtils.deleteDirectory(testRootBase.toFile());
+			}
+		}
+	}
+
+	@Test
+	void testToFileDoesNotTreatSimilarRootPrefixAsRoot() throws Exception {
+		fileSystem.setRoot("x/y");
+		Path resolved = fileSystem.toFile("x/y2/file.txt");
+
+		assertEquals(Paths.get("x/y").resolve("x/y2/file.txt"), resolved);
+	}
+
+	@Test
+	void testToFilePrependsRootWhenNormalizedPathIsOutsideRoot() throws Exception {
+		fileSystem.setRoot("x/y");
+		Path resolved = fileSystem.toFile("x/y/../outside/file.txt");
+
+		assertTrue(resolved.normalize().startsWith(Paths.get("x/y")));
+		assertEquals(Paths.get("x/y").resolve("x/y/../outside/file.txt"), resolved);
 	}
 
 	@Test


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
This PR adjusts LocalFileSystem path resolution to better handle a configured root folder when callers already provide root-qualified relative paths, and adds a regression test around creating a relative root folder.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/8.x, release/9.x
-->
- [x] Backport PRs created (if needed) and linked
  - [x] release/9.0

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Doc, FF! Manual, Javadoc.
-->
- [n/a] FF! Doc updated (user-facing behavior/config)
- [n/a] FF! Manual updated (if applicable)
- [x] Javadoc updated/generated (developer-facing APIs)

### Tests
<!--
Changes should be covered so behavior is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behavior or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes markdown (e.g., BREAKING_CHANGES.md or CHANGELOG.md)
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
