### PR TITLE
Use Ladybug 4.1-20260605.152411 in FF 9.4.x

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>3.0-20260202.113151</ladybug.version>
+		<ladybug.version>4.1-20260605.152411</ladybug.version>
 	</properties>
 
 </project>


### PR DESCRIPTION
## Changes

Let Frank!Framework use Ladybug 4.1-20260605.152411 in a new 9.4.x release of the FF!. This PR by itself has a limited value for customers because customers who want the newest Ladybug features should ideally migrate to the newest Frank!Framework version. However, a customer intends to view Ladybug reports originating from different applications and different hosts that are stored in the same database. That customer wants that in a 9.4.x release of the Frank!Framework. This PR is a check that we will be able to backport the new Ladybug features to the 9.4.x version of the FF!.