### PR TITLE
Add support for exotic HTTP status codes in OpenApiGenerator (#10995)

### DIFF
--- a/core/src/main/java/org/frankframework/http/openapi/OpenApiGenerator.java
+++ b/core/src/main/java/org/frankframework/http/openapi/OpenApiGenerator.java
@@ -28,10 +28,10 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
-import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.xerces.xs.XSModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.MimeType;
 
 import lombok.NoArgsConstructor;
@@ -222,8 +222,11 @@ public class OpenApiGenerator {
 
 			JsonObjectBuilder exit = Json.createObjectBuilder();
 
-			Response.Status status = Response.Status.fromStatusCode(exitCode);
-			exit.add("description", status.getReasonPhrase());
+			// Make sure that we don't fail here because HttpStatus is missing a status
+			HttpStatus status = HttpStatus.resolve(exitCode);
+			if (status != null) {
+				exit.add("description", status.getReasonPhrase());
+			}
 
 			Optional<Json2XmlValidator> outputValidator = ApiServiceDispatcher.getJsonOutputValidator(pipeline, pipeLineExit.getName());
 			outputValidator.ifPresent(validator -> addComponentsToTheSchema(schemas, validator.getXSModels()));

--- a/core/src/test/java/org/frankframework/http/openapi/OpenApiTest.java
+++ b/core/src/test/java/org/frankframework/http/openapi/OpenApiTest.java
@@ -603,4 +603,24 @@ class OpenApiTest extends OpenApiTestBase {
 		String expected = TestFileUtils.getTestFile("/OpenApi/multipleMethods.json");
 		MatchUtils.assertJsonEquals(expected, result);
 	}
+
+	@Test
+	@DisplayName("Prove that exotic http status codes are supported")
+	void exitCode422ShouldNotThrowNullPointerException() throws Exception {
+		String uri = "/exitCode422";
+		assertEquals(0, dispatcher.findAllMatchingConfigsForUri(uri).size(), "there are still registered patterns! Threading issue?");
+
+		new AdapterBuilder(DEFAULT_ADAPTER_NAME, DEFAULT_SUMMARY)
+				.setListener(uri, HttpMethod.POST, null)
+				.setInputValidator("simple.xsd", null, "user", null)
+				.addExit(200)
+				.addExit(422, null, false)
+				.build(true);
+
+		assertEquals(1, dispatcher.findAllMatchingConfigsForUri(uri).size(), "more then 1 registered pattern found!");
+		String result = callOpenApi(uri);
+
+		String expected = TestFileUtils.getTestFile("/OpenApi/exitCode422.json");
+		MatchUtils.assertJsonEquals(expected, result);
+	}
 }

--- a/core/src/test/resources/OpenApi/exitCode422.json
+++ b/core/src/test/resources/OpenApi/exitCode422.json
@@ -1,0 +1,75 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "TestConfiguration",
+        "description": "OpenApi auto-generated at -timestamp- for TestConfiguration (xxx)",
+        "version": "unknown"
+    },
+    "servers": [
+        {
+            "url": "http://mock-hostname/mock-context-path/mock-servlet-path"
+        }
+    ],
+    "paths": {
+        "/exitCode422": {
+            "post": {
+                "summary": "description4simple-get",
+                "parameters": [
+                    {
+                        "name": "Message-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/user"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Content",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/user"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "user": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "password": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "email",
+                    "username",
+                    "password"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 11f11fce4e676d79af673f4568a2cbc98a9dca0a)

10.0 backport of #10933 