### PR TITLE
Fix error on the Ibisstore Summary page

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
@@ -587,7 +587,13 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 					resultset.absolute(getStartRow()-1);
 					log.debug("Index set at position: {}", resultset.getRow());
 				}
-				return new SenderResult(getResult(resultset, blobOrClobFilename));
+				// When no blob/clob target file is set (the normal SELECT case), dispatch through
+				// the overridable getResult(ResultSet) so subclasses such as
+				// IbisstoreSummaryQuerySender can format the result themselves (e.g. as JSON).
+				// The private two-arg variant is only needed for blob/clob streaming to a file.
+				return new SenderResult(blobOrClobFilename == null
+						? getResult(resultset)
+						: getResult(resultset, blobOrClobFilename));
 			}
 		} catch (SQLException|JdbcException|IOException e) {
 			throw new SenderException("got exception executing a SELECT SQL command", e );


### PR DESCRIPTION
## What's wrong
  
Opening **JDBC → Ibisstore Summary** (or pressing **Send**) shows an error instead of the summary table.
  
## Why
  
The page expects the summary as JSON, but the backend sends it back as XML:
  
{ "result":...}

That isn't valid JSON, so the frontend can't parse it and shows an error.

Under the hood, `IbisstoreSummaryQuerySender` overrides `getResult(ResultSet)` to build the grouped JSON. But the SELECT path in `AbstractJdbcQuerySender` calls the private `getResult(ResultSet, Path)` variant directly, so the override is never reached — and the query falls back to the default XML writer.

## The fix

One line in `executeSelectQuery`: when there's no blob/clob target file (the normal SELECT case), go through the overridable `getResult(resultset)` again so subclass formatting is honoured. The blob/clob-to-file path keeps using the two-arg variant. No behaviour change for senders that don't override it.

## Testing

`POST /iaf/api/jdbc/summary` with `{ "datasource": "jdbc/..." }`:

- **Before:** `{ "result":<result>...XML...}` → HTTP 200 but invalid JSON → page errors
- **After:** `{ "result":[] }` → valid JSON → page renders

Verified end-to-end against a running instance (Postgres `IBISSTORE`).