### PR TITLE
Cleanup RequestUtils

### DIFF
--- a/console/backend/src/main/java/org/frankframework/console/util/RequestUtils.java
+++ b/console/backend/src/main/java/org/frankframework/console/util/RequestUtils.java
@@ -19,62 +19,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.NoArgsConstructor;
 
 import org.frankframework.console.ApiException;
-import org.frankframework.util.ClassUtils;
 import org.frankframework.util.StreamUtil;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class RequestUtils {
-
-	@SuppressWarnings("unchecked")
-	protected static <T> T convert(Class<T> clazz, InputStream is) throws IOException {
-		if(clazz.isAssignableFrom(InputStream.class)) {
-			return (T) is;
-		}
-		String str = StreamUtil.streamToString(is);
-		if(clazz.isAssignableFrom(boolean.class) || clazz.isAssignableFrom(Boolean.class)) {
-			return (T) Boolean.valueOf(str); // At the moment we allow null/empty -> FALSE
-		}
-		return ClassUtils.convertToType(clazz, str);
-	}
-
-	/**
-	 * If present returns the value as String
-	 * Else returns NULL
-	 */
-	public static @Nullable String getValue(Map<String, Object> json, String key) {
-		Object val = json.get(key);
-		if(val != null) {
-			return val.toString();
-		}
-		return null;
-	}
-
-	public static @Nullable Integer getIntegerValue(Map<String, Object> json, String key) {
-		String value = getValue(json, key);
-		if(value != null) {
-			return Integer.parseInt(value);
-		}
-		return null;
-	}
-
-	public static @Nullable Boolean getBooleanValue(Map<String, Object> json, String key) {
-		String value = getValue(json, key);
-		if(value != null) {
-			return Boolean.parseBoolean(value);
-		}
-		return null;
-	}
 
 	@NonNull
 	public static <T> T resolveRequiredProperty(String key, T multiFormProperty, T defaultValue) throws ApiException {

--- a/console/backend/src/test/java/org/frankframework/console/util/RequestUtilsTest.java
+++ b/console/backend/src/test/java/org/frankframework/console/util/RequestUtilsTest.java
@@ -1,53 +1,83 @@
 package org.frankframework.console.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import org.frankframework.console.ApiException;
 
 public class RequestUtilsTest {
 
 	@Test
-	public void testConversions() throws Exception {
-		InputStream string = new ByteArrayInputStream("string".getBytes());
-		InputStream number = new ByteArrayInputStream("50".getBytes());
-		InputStream boolTrue = new ByteArrayInputStream("true".getBytes());
-		InputStream boolFalse = new ByteArrayInputStream("false".getBytes());
-		InputStream boolNull = new ByteArrayInputStream("".getBytes());
-
-		assertEquals("string", RequestUtils.convert(String.class, string));
-		assertTrue(RequestUtils.convert(boolean.class, boolTrue));
-		assertFalse(RequestUtils.convert(Boolean.class, boolFalse));
-		assertFalse(RequestUtils.convert(boolean.class, boolNull));
-		assertEquals(50, RequestUtils.convert(Integer.class, number).intValue());
-		assertEquals(string, RequestUtils.convert(InputStream.class, string));
+	public void testResolveRequiredProperty() throws Exception {
+		assertEquals("value", RequestUtils.resolveRequiredProperty("testKey", "value", "default"));
+		assertEquals("", RequestUtils.resolveRequiredProperty("testKey", "", "default"));
+		assertEquals("default", RequestUtils.resolveRequiredProperty("testKey", null, "default"));
+		ApiException ex = assertThrows(ApiException.class, () -> RequestUtils.resolveRequiredProperty("testKey", null, null));
+		assertEquals("Key [testKey] not defined", ex.getMessage());
 	}
 
 	@Test
-	public void testGetValue() {
+	public void testResolveStringWithISO88591Encoding() throws IOException {
 		// Arrange
-		Map<String, Object> input = new HashMap<>();
-		input.put("string", "value");
-		input.put("integer", "123");
-		input.put("boolean", "true");
-		input.put("empty", "");
-		input.put("null", null);
+		URL testFile = RequestUtilsTest.class.getResource("/files-with-charset/iso-8859-1.txt");
+		assertNotNull(testFile, "unable to find testfile");
 
+		MultipartFile file = new MockMultipartFile("name", testFile.openStream());
+
+		String expected = readFile(testFile, StandardCharsets.ISO_8859_1);
 		// Act + Assert
-		assertEquals("value", RequestUtils.getValue(input, "string"));
-		assertEquals(123, RequestUtils.getIntegerValue(input, "integer"));
-		assertTrue(RequestUtils.getBooleanValue(input, "boolean"));
-		assertFalse(RequestUtils.getBooleanValue(input, "empty"));
-		assertNull(RequestUtils.getIntegerValue(input, "non-existing-integer"));
-		assertNull(RequestUtils.getBooleanValue(input, "non-existing-boolean"));
-		assertEquals("", RequestUtils.getValue(input, "empty"));
-		assertNull(RequestUtils.getValue(input, "null"));
+		assertNotEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, null, false));
+		assertNotEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "", false));
+		assertNotEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "utf-8", false));
+		assertEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "iso-8859-1", false));
+	}
+
+	@Test
+	public void testResolveStringWithISO88591ContentType() throws IOException {
+		// Arrange
+		URL testFile = RequestUtilsTest.class.getResource("/files-with-charset/iso-8859-1.txt");
+		assertNotNull(testFile, "unable to find testfile");
+
+		MediaType contentType = new MediaType("text", "plain", StandardCharsets.ISO_8859_1);
+		MultipartFile file = new MockMultipartFile("name", "filename.txt", contentType.toString(), testFile.openStream());
+
+		String expected = readFile(testFile, StandardCharsets.ISO_8859_1);
+		// Act + Assert with file with ContentType
+		// 3rd parameter is ignored when a charset is provided.
+		assertEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, null, false));
+		assertEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "", false));
+		assertEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "utf-8", false));
+		assertEquals(expected, RequestUtils.resolveStringWithEncoding("testkey-ignored", file, "iso-8859-1", false));
+	}
+
+	@Test
+	public void testResolveEmptyString() throws IOException {
+		assertEquals("", RequestUtils.resolveStringWithEncoding("testkey-ignored", new MockMultipartFile("name", new ByteArrayInputStream("".getBytes())), null, false));
+		assertNull(RequestUtils.resolveStringWithEncoding("testkey-ignored", new MockMultipartFile("name", new ByteArrayInputStream("".getBytes())), null, true));
+		assertNull(RequestUtils.resolveStringWithEncoding("testkey-ignored", null, null, true));
+	}
+
+	private static String readFile(URL resource, Charset charset) throws IOException {
+		assertNotNull(resource, "unable to find resource");
+		try (Reader reader = new InputStreamReader(resource.openStream(), charset)) {
+			return IOUtils.toString(reader);
+		}
 	}
 }

--- a/console/backend/src/test/resources/files-with-charset/iso-8859-1.txt
+++ b/console/backend/src/test/resources/files-with-charset/iso-8859-1.txt
@@ -1,0 +1,15 @@
+BARNDOMSOMGIVELSERNE<b/>
+ Skønt H. C. Andersens barndomsomgivelser var meget fattige, blev de i hans rige fantasi
+ solbeskinnede.
+    Der findes en mandtalsliste fra nogle få år ______ H. C. Andersens fødsel. Den er ______ 1801
+ og den giver klare oplysninger om, hvor mange der boede ______ Odense og hvad de var
+ beskæftigede ______. Den omfatter 1199 husstande. Hvis man fordeler disse ______ erhverv,
+ får man 102 embeds- og bestillingsmænd, 26 officerer, 12 der beskæftiger sig med
+ immaterielle erhverv, 81 som lever ______ handel, 36 værtshusholdere, 460 håndværkere, 39
+ avlsmænd og urtemænd, 121 soldater, 97 daglejere, 139 enlige kvinder og
+ almissemedlemmer, 29 pensionister og rentenydere.
+    H. C. Andersens forældre tilhørte samfundets laveste lag. Faderen var friskomager, og
+ når han meldte sig ______ militærtjeneste ______ Napoleons side, har det nok ikke så meget været
+ idealisme som praktisk økonomi. For at sikre sig en soldats værgeløn. Han kom ikke
+ længere end ______ Holsten. Han fik høj feber og måtte sendes hjem. Da han kom hjem,
+ forværredes sygdommen og han døde.


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

- Remove unused methods from the CXF era.
- Add tests to cover remaining methods.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
