### PR TITLE
Fix and add tests for IbisStoreSummary

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcQuerySender.java
@@ -432,11 +432,11 @@ public abstract class AbstractJdbcQuerySender<H> extends AbstractJdbcSender<H> {
 				.collect(Collectors.joining(", "));
 	}
 
-	protected Message getResult(ResultSet resultset) throws JdbcException, SQLException, IOException {
+	private Message getResult(ResultSet resultset) throws JdbcException, SQLException, IOException {
 		return getResult(resultset, null);
 	}
 
-	private Message getResult(ResultSet resultset, @Nullable Path blobOrClobFilename) throws JdbcException, SQLException, IOException {
+	protected Message getResult(ResultSet resultset, @Nullable Path blobOrClobFilename) throws JdbcException, SQLException, IOException {
 		if (isScalar()) {
 			String result=null;
 			if (resultset.next()) {

--- a/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
+++ b/core/src/main/java/org/frankframework/jdbc/StoredProcedureQuerySender.java
@@ -267,7 +267,7 @@ public class StoredProcedureQuerySender extends FixedQuerySender {
 			return getUpdateStatementResult(callableStatement, resultQuery, resStmt, updateCount);
 		}
 		if (isScalar() || isScalarExtended()) {
-			return getResult(new StoredProcedureResultWrapper(getDbmsSupport(), callableStatement, callableStatement.getParameterMetaData(), outputParameters));
+			return getResult(new StoredProcedureResultWrapper(getDbmsSupport(), callableStatement, callableStatement.getParameterMetaData(), outputParameters), null);
 		}
 
 		DB2XMLWriter db2xml = buildDb2XMLWriter();

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/IbisstoreSummary.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/IbisstoreSummary.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2025 WeAreFrank!
+   Copyright 2022-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 */
 package org.frankframework.management.bus.endpoints;
 
+import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -64,7 +65,8 @@ public class IbisstoreSummary extends BusEndpointBase {
 		return execute(datasource, query);
 	}
 
-	private StringMessage execute(String datasource, String query) {
+	// Protected for testing purposes only!
+	protected StringMessage execute(String datasource, String query) {
 		String result = "";
 		try {
 			IbisstoreSummaryQuerySender qs;
@@ -78,8 +80,10 @@ public class IbisstoreSummary extends BusEndpointBase {
 				qs.setAvoidLocking(true);
 				qs.configure(true);
 				qs.start();
+
 				String actualQuery = query != null ? query : this.getIbisStoreSummaryQuery(qs.getDbmsSupport());
 				org.frankframework.stream.Message message = qs.sendMessageOrThrow(new org.frankframework.stream.Message(actualQuery), session);
+
 				result = message.asString();
 			} catch (Throwable t) {
 				throw new BusException("An error occurred on executing jdbc query", t);
@@ -94,7 +98,8 @@ public class IbisstoreSummary extends BusEndpointBase {
 		return new StringMessage(resultObject, MediaType.APPLICATION_JSON);
 	}
 
-	private List<Adapter> getAdapters() {
+	// Protected for testing purposes only!
+	protected List<Adapter> getAdapters() {
 		List<Adapter> registeredAdapters = new ArrayList<>();
 		for (Configuration configuration : getIbisManager().getConfigurations()) {
 			if(configuration.isActive()) {
@@ -175,7 +180,7 @@ class IbisstoreSummaryQuerySender extends DirectQuerySender {
 	}
 
 	@Override
-	protected org.frankframework.stream.Message getResult(ResultSet resultset) throws SQLException {
+	protected org.frankframework.stream.Message getResult(ResultSet resultset, Path ignored) throws SQLException {
 		JsonArrayBuilder types = Json.createArrayBuilder();
 		String previousType=null;
 		JsonObjectBuilder typeBuilder=null;

--- a/core/src/test/java/org/frankframework/management/bus/endpoints/TestIbisstoreSummary.java
+++ b/core/src/test/java/org/frankframework/management/bus/endpoints/TestIbisstoreSummary.java
@@ -1,0 +1,51 @@
+package org.frankframework.management.bus.endpoints;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.frankframework.core.Adapter;
+import org.frankframework.management.bus.message.StringMessage;
+import org.frankframework.receivers.Receiver;
+import org.frankframework.testutil.MatchUtils;
+import org.frankframework.testutil.TestConfiguration;
+import org.frankframework.testutil.TestFileUtils;
+import org.frankframework.testutil.junit.DatabaseTestEnvironment;
+import org.frankframework.testutil.junit.TxManagerTest;
+import org.frankframework.testutil.junit.WithLiquibase;
+import org.frankframework.util.SpringUtils;
+
+/**
+ * Unlike the other test classes in this package, this one doesn't use the message-bus.
+ * Here we test the underlying database class.
+ */
+public class TestIbisstoreSummary {
+
+	@TxManagerTest
+	@WithLiquibase
+	@WithLiquibase(file = "/Migrator/PrefillErrorStore.xml")
+	public void testBrowseTableWithoutTablename(DatabaseTestEnvironment env) throws IOException {
+		IbisstoreSummary instance = spy(IbisstoreSummary.class);
+		List<Adapter> adapters = getTestAdapters(env.getConfiguration());
+		doReturn(adapters).when(instance).getAdapters();
+
+		env.autowire(instance);
+
+		StringMessage result = instance.execute(env.getDataSourceName(), null);
+		String expected = TestFileUtils.getTestFile("/Management/TestIbisstoreSummary.json");
+		MatchUtils.assertJsonEquals(expected, result.getPayload());
+	}
+
+	private List<Adapter> getTestAdapters(TestConfiguration config) {
+		Adapter adapter = config.createBean();
+		adapter.setName("myAdapter");
+		Receiver<?> receiver = SpringUtils.createBean(adapter, Receiver.class);
+		receiver.setName("myReceiver");
+		adapter.addReceiver(receiver);
+
+		return Collections.singletonList(adapter);
+	}
+}

--- a/core/src/test/resources/Management/TestIbisstoreSummary.json
+++ b/core/src/test/resources/Management/TestIbisstoreSummary.json
@@ -1,0 +1,59 @@
+{
+    "result": [
+        {
+            "type": "E",
+            "name": "errorlog",
+            "slotcount": 2,
+            "datecount": 3,
+            "msgcount": 6,
+            "slots": [
+                {
+                    "id": "slot1",
+                    "datecount": 1,
+                    "msgcount": 1,
+                    "dates": [
+                        {
+                            "id": "2026-05-15",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "id": "slot2",
+                    "datecount": 2,
+                    "msgcount": 5,
+                    "dates": [
+                        {
+                            "id": "2026-05-15",
+                            "count": 3
+                        },
+                        {
+                            "id": "2026-06-15",
+                            "count": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "M",
+            "name": "messagelog",
+            "slotcount": 1,
+            "datecount": 1,
+            "msgcount": 2,
+            "slots": [
+                {
+                    "id": "slot1",
+                    "datecount": 1,
+                    "msgcount": 2,
+                    "dates": [
+                        {
+                            "id": "2026-06-15",
+                            "count": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/core/src/test/resources/Migrator/PrefillErrorStore.xml
+++ b/core/src/test/resources/Migrator/PrefillErrorStore.xml
@@ -1,0 +1,108 @@
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"
+	objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+	<property name="uuid" value="gen_random_uuid()" dbms="postgresql"/>
+	<property name="uuid" value="NEWID()" dbms="mssql"/>
+	<property name="uuid" value="sys_guid()" dbms="oracle"/>
+	<property name="uuid" value="random_uuid()" dbms="h2"/>
+
+	<changeSet id="insert-row-into-ibisstores" author="Niels Meijer">
+		<!-- SLOT 1 -->
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot1" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-05-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+
+		<!-- SLOT 2 -->
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot2" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-05-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot2" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-05-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot2" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-05-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot2" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-06-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="E" />
+			<column name="SLOTID" value="slot2" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-06-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+
+		<!-- SLOT 1 - TYPE M -->
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="M" />
+			<column name="SLOTID" value="slot1" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-06-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+		<insert tableName="${tableName}">
+			<column name="TYPE" value="M" />
+			<column name="SLOTID" value="slot1" />
+			<column name="HOST" value="${hostname}" />
+			<column name="MESSAGEID" valueComputed="${uuid}" />
+			<column name="CORRELATIONID" valueComputed="${uuid}" />
+			<column name="MESSAGEDATE" valueDate="2026-06-15T10:30:00" />
+			<column name="MESSAGE" valueBlobFile="SetupConfigsInDatabase.xml" />
+			<column name="EXPIRYDATE" valueDate="3026-06-15T10:30:00" />
+			<column name="LABEL" valueBoolean="false"/>
+		</insert>
+	</changeSet>
+</databaseChangeLog>

--- a/core/src/test/resources/Migrator/PrefillErrorStore.xml
+++ b/core/src/test/resources/Migrator/PrefillErrorStore.xml
@@ -8,7 +8,9 @@
 	<property name="uuid" value="gen_random_uuid()" dbms="postgresql"/>
 	<property name="uuid" value="NEWID()" dbms="mssql"/>
 	<property name="uuid" value="sys_guid()" dbms="oracle"/>
-	<property name="uuid" value="random_uuid()" dbms="h2"/>
+	<property name="uuid" value="random_uuid()" dbms="h2"/> 
+	<property name="uuid" value="UUID()" dbms="mariadb"/>
+	<property name="uuid" value="UUID()" dbms="mysql"/>
 
 	<changeSet id="insert-row-into-ibisstores" author="Niels Meijer">
 		<!-- SLOT 1 -->


### PR DESCRIPTION
(cherry picked from commit c617a7e61aac8daecf0011fddb4bf14fd15dcf4a)

## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
