### PR TITLE
Optionally show host and application in Ladybug table

### DIFF
--- a/ladybug/debugger/src/main/resources/springIbisTestToolApi.xml
+++ b/ladybug/debugger/src/main/resources/springIbisTestToolApi.xml
@@ -52,6 +52,10 @@
 				<value>namespace</value>
 				<value>status</value>
 				<value>numberOfCheckpoints</value>
+				<!-- These will not appear in the debug table when host and application are not set
+				     on Ladybug's TestTool class -->
+				<value>host</value>
+				<value>application</value>
 			</list>
 		</property>
 	</bean>

--- a/ladybug/debugger/src/main/resources/springIbisTestToolIgnoreReport.xml
+++ b/ladybug/debugger/src/main/resources/springIbisTestToolIgnoreReport.xml
@@ -38,6 +38,8 @@
 				<value>numberOfCheckpoints</value>
 				<value>estimatedMemoryUsage</value>
 				<value>storageSize</value>
+				<value>host</value>
+				<value>application</value>
 			</list>
 		</property>
 		<property name="metadataFilter">


### PR DESCRIPTION
## Changes

Please await https://github.com/wearefrank/ladybug/pull/833 before merging. Show columns host and application in the debug tab of ladybug when the Frank!Framework passes a host and an application to Ladybug. Passing these values can be done using setters in Ladybug's TestTool class. When these setters are not called, the Ladybug table will omit both the host and the application even when host and application are supplied as metadata names.