### PR TITLE
Remove wrong deprecation warning in FixedResultPipe

### DIFF
--- a/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
@@ -398,8 +398,6 @@ public class FixedResultPipe extends FixedForwardPipe {
 	/**
 	 * Name of the session key containing the file name of the file that contains the result message.
 	 */
-	@Deprecated(since = "8.2", forRemoval = true)
-	@ConfigurationWarning("fileNameSessionKey is scheduled for removal. Please use a <param> if you need a session value")
 	public void setFilenameSessionKey(String filenameSessionKey) {
 		this.filenameSessionKey = filenameSessionKey;
 	}

--- a/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/FixedResultPipe.java
@@ -47,9 +47,8 @@ import org.frankframework.util.StringResolver;
 import org.frankframework.util.TransformerPool;
 
 /**
- * This Pipe opens and returns a file from the classpath. The filename is a mandatory parameter to use. You can
- * provide this by using the <code>filename</code> attribute or with a <code>param</code> element to be able to
- * use a sessionKey for instance.
+ * This Pipe opens and returns a file from the classpath. You can provide this by using the
+ * <code>filenameSessionKey</code> attribute or with the <code>filename</code> attribute.
  *
  * <h2>Migrating from deprecated features</h2>
  * The FixedResultPipe was a jack of all trades. You could use it to read a file (only text) and/or use
@@ -238,8 +237,6 @@ public class FixedResultPipe extends FixedForwardPipe {
 		parameterNamesMustBeUnique = true;
 		super.configure();
 
-		filename = getFilename();
-
 		appConstants = AppConstants.getInstance(getConfigurationClassLoader());
 
 		if (StringUtils.isNotEmpty(getFilename())) {
@@ -255,7 +252,7 @@ public class FixedResultPipe extends FixedForwardPipe {
 		}
 
 		if(useOldSubstitutionStartDelimiter) {
-			if(StringUtils.isBlank(filename)) {
+			if(StringUtils.isBlank(getFilename())) {
 				throw new ConfigurationException("attribute [useOldSubstitutionStartDelimiter] may only be used in combination with attribute [filename]");
 			}
 			substitutionStartDelimiter = "$";
@@ -275,18 +272,19 @@ public class FixedResultPipe extends FixedForwardPipe {
 		Message resultMessage = null;
 		String resultString = getReturnString();
 
+		String filenameToUse;
 		if (StringUtils.isNotEmpty(getFilenameSessionKey())) {
-			filename = session.getString(getFilenameSessionKey());
+			filenameToUse = session.getString(getFilenameSessionKey());
 		} else {
-			filename = getFilename();
+			filenameToUse = getFilename();
 		}
 
-		if (StringUtils.isNotEmpty(filename)) {
+		if (StringUtils.isNotEmpty(filenameToUse)) {
 			URL resource;
 			try {
-				resource = ClassLoaderUtils.getResourceURL(this, filename);
+				resource = ClassLoaderUtils.getResourceURL(this, filenameToUse);
 			} catch (Exception e) {
-				throw new PipeRunException(this, "got exception searching for [" + filename + "]", e);
+				throw new PipeRunException(this, "got exception searching for [" + filenameToUse + "]", e);
 			}
 
 			if (resource == null) {
@@ -294,14 +292,14 @@ public class FixedResultPipe extends FixedForwardPipe {
 				if (fileNotFoundForward != null) {
 					return new PipeRunResult(fileNotFoundForward, message);
 				}
-				throw new PipeRunException(this, "cannot find resource [" + filename + "]");
+				throw new PipeRunException(this, "cannot find resource [" + filenameToUse + "]");
 			}
 
 			if (stringBasedOperationNeeded()) {
 				try {
 					resultString = new UrlMessage(resource).asString();
 				} catch (Exception e) {
-					throw new PipeRunException(this, "got exception loading [" + filename + "]", e);
+					throw new PipeRunException(this, "got exception loading [" + filenameToUse + "]", e);
 				}
 			} else {
 				resultMessage = new UrlMessage(resource);

--- a/core/src/test/java/org/frankframework/pipes/FixedResultPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/FixedResultPipeTest.java
@@ -26,6 +26,7 @@ import org.frankframework.testutil.ParameterBuilder;
  *
  * @author <Sina Sen>
  */
+@SuppressWarnings("removal")
 public class FixedResultPipeTest extends PipeTestBase<FixedResultPipe> {
 
 	private static final String PIPES_2_TXT = "/Pipes/2.txt";


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

I believe this attribute should stay, but correct me if I'm wrong...

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
