### PR TITLE
Enhance JAVA_OPTS to reduce production memory footprint

### DIFF
--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -14,7 +14,9 @@ export JAVA_OPTS="\
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-if [ ${dtap.stage:-PRD} == "LOC" ]; then
+# Default we want to disable this functionality. When dtap is LOC, enable GC debugging.
+DTAP_STAGE="${dtap.stage:-}"
+if [ "$DTAP_STAGE" == "LOC" ]; then
 	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
 else
 	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"

--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -14,9 +14,9 @@ export JAVA_OPTS="\
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-# Default we want to disable this functionality. When dtap is LOC, enable GC debugging.
-DTAP_STAGE="${dtap.stage:-}"
-if [ "$DTAP_STAGE" == "LOC" ]; then
+# By default, GC debugging is disabled. Enable it when dtap.stage is LOC.
+DTAP_STAGE="$(printenv 'dtap.stage' 2>/dev/null || true)"
+if [ "$DTAP_STAGE" = "LOC" ]; then
 	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
 else
 	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"

--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 export JAVA_OPTS="\
 	-XX:HeapDumpPath=/usr/local/tomcat/logs \
 	-XX:+HeapDumpOnOutOfMemoryError \
+	-XX:+UseCompactObjectHeaders \
 	--add-modules java.se \
 	--add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
 	--add-opens java.base/java.lang=ALL-UNNAMED \
@@ -12,5 +13,11 @@ export JAVA_OPTS="\
 	--add-opens java.management/sun.management=ALL-UNNAMED \
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
+
+if [ ${dtap.stage:-PRD} == "LOC" ]; then
+	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
+else
+	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"
+fi
 
 exec "$@"

--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -14,9 +14,8 @@ export JAVA_OPTS="\
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
 	$JAVA_OPTS"
 
-# By default, GC debugging is disabled. Enable it when dtap.stage is LOC.
-DTAP_STAGE="$(printenv 'dtap.stage' 2>/dev/null || true)"
-if [ "$DTAP_STAGE" = "LOC" ]; then
+# By default, GC debugging is disabled.
+if [ "$GC_ENABLED" = "true" ]; then
 	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
 else
 	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"

--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -15,7 +15,7 @@ export JAVA_OPTS="\
 	$JAVA_OPTS"
 
 # By default, GC debugging is disabled.
-if [ "$GC_ENABLED" = "true" ]; then
+if [ "$GC_LOG_ENABLED" = "true" ]; then
 	export JAVA_OPTS="-Xlog:gc*,gc+age=trace:file=/usr/local/tomcat/logs/gc-log.log:time,uptime:filesize=104857600,filecount=5 $JAVA_OPTS"
 else
 	export JAVA_OPTS="-XX:+PerfDisableSharedMem $JAVA_OPTS"


### PR DESCRIPTION
Add conditional logging options for garbage collection based on the deployment stage.
Enhance JAVA_OPTS to dynamically enable GC settings.

## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
