### PR TITLE
Give configuration warnings when using deprecated classnames for CredentialProvider

### DIFF
--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -15,6 +15,10 @@
 */
 package org.frankframework.configuration;
 
+import static org.frankframework.credentialprovider.CredentialFactory.CREDENTIAL_FACTORY_KEY;
+import static org.frankframework.credentialprovider.CredentialFactory.LEGACY_PACKAGE_NAME;
+import static org.frankframework.credentialprovider.CredentialFactory.ORG_FRANKFRAMEWORK_PACKAGE_NAME;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +40,7 @@ import lombok.Getter;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.configuration.util.ConfigurationUtils;
 import org.frankframework.core.IScopeProvider;
+import org.frankframework.credentialprovider.util.CredentialConstants;
 import org.frankframework.http.RestServiceDispatcher;
 import org.frankframework.jdbc.JdbcPropertySourceFactory;
 import org.frankframework.lifecycle.IbisApplicationContext;
@@ -77,6 +82,15 @@ public class IbisContext extends IbisApplicationContext {
 		String autoDatabaseClassLoader = APP_CONSTANTS.getProperty("configurations.autoDatabaseClassLoader");
 		if (StringUtils.isNotEmpty(autoDatabaseClassLoader))
 			ApplicationWarnings.add(LOG, "DEPRECATED property [configurations.autoDatabaseClassLoader], please use [configurations.database.autoLoad] instead");
+
+		String credentialFactoryClassNames = CredentialConstants.getInstance().getProperty(CREDENTIAL_FACTORY_KEY);
+		// Legacy support for old package names; to be removed in Frank!Framework 8.1 or later
+		if (StringUtils.isNotEmpty(credentialFactoryClassNames) && credentialFactoryClassNames.contains(LEGACY_PACKAGE_NAME)) {
+			ApplicationWarnings.add(LOG, "DEPRECATED legacy classnames from package [" +
+					LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders, please update to use new classnames starting with [" +
+					ORG_FRANKFRAMEWORK_PACKAGE_NAME + "]: [" + credentialFactoryClassNames + "]");
+		}
+
 	}
 
 	private @Getter IbisManager ibisManager;

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -15,10 +15,6 @@
 */
 package org.frankframework.configuration;
 
-import static org.frankframework.credentialprovider.CredentialFactory.CREDENTIAL_FACTORY_KEY;
-import static org.frankframework.credentialprovider.CredentialFactory.LEGACY_PACKAGE_NAME;
-import static org.frankframework.credentialprovider.CredentialFactory.ORG_FRANKFRAMEWORK_PACKAGE_NAME;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +36,7 @@ import lombok.Getter;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.configuration.util.ConfigurationUtils;
 import org.frankframework.core.IScopeProvider;
+import org.frankframework.credentialprovider.CredentialFactory;
 import org.frankframework.credentialprovider.util.CredentialConstants;
 import org.frankframework.http.RestServiceDispatcher;
 import org.frankframework.jdbc.JdbcPropertySourceFactory;
@@ -72,6 +69,10 @@ public class IbisContext extends IbisApplicationContext {
 	private static final Logger APPLICATION_LOG = LogUtil.getLogger("APPLICATION");
 
 	static {
+		checkForDeprecations();
+	}
+
+	public static void checkForDeprecations() {
 		if (!APP_CONSTANTS.getBoolean("jdbc.convertFieldnamesToUppercase", true))
 			ApplicationWarnings.add(LOG, "DEPRECATED: jdbc.convertFieldnamesToUppercase is set to false, please set to true. XML field definitions of SQL senders will be uppercased!");
 
@@ -83,14 +84,13 @@ public class IbisContext extends IbisApplicationContext {
 		if (StringUtils.isNotEmpty(autoDatabaseClassLoader))
 			ApplicationWarnings.add(LOG, "DEPRECATED property [configurations.autoDatabaseClassLoader], please use [configurations.database.autoLoad] instead");
 
-		String credentialFactoryClassNames = CredentialConstants.getInstance().getProperty(CREDENTIAL_FACTORY_KEY);
+		String credentialFactoryClassNames = CredentialConstants.getInstance().getProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY);
 		// Legacy support for old package names; to be removed in Frank!Framework 8.1 or later
-		if (StringUtils.isNotEmpty(credentialFactoryClassNames) && credentialFactoryClassNames.contains(LEGACY_PACKAGE_NAME)) {
+		if (StringUtils.isNotEmpty(credentialFactoryClassNames) && credentialFactoryClassNames.contains(CredentialFactory.LEGACY_PACKAGE_NAME)) {
 			ApplicationWarnings.add(LOG, "DEPRECATED legacy classnames from package [" +
-					LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders, please update to use new classnames starting with [" +
-					ORG_FRANKFRAMEWORK_PACKAGE_NAME + "]: [" + credentialFactoryClassNames + "]");
+					CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders, please update to use new classnames starting with [" +
+					CredentialFactory.ORG_FRANKFRAMEWORK_PACKAGE_NAME + "]: [" + credentialFactoryClassNames + "]");
 		}
-
 	}
 
 	private @Getter IbisManager ibisManager;

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -73,14 +73,15 @@ public class IbisContext extends IbisApplicationContext {
 	}
 
 	public static void checkForDeprecations() {
-		if (!APP_CONSTANTS.getBoolean("jdbc.convertFieldnamesToUppercase", true))
+		AppConstants appConstants = AppConstants.getInstance();
+		if (!appConstants.getBoolean("jdbc.convertFieldnamesToUppercase", true))
 			ApplicationWarnings.add(LOG, "DEPRECATED: jdbc.convertFieldnamesToUppercase is set to false, please set to true. XML field definitions of SQL senders will be uppercased!");
 
-		String loadFileSuffix = APP_CONSTANTS.getProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
+		String loadFileSuffix = appConstants.getProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
 		if (StringUtils.isNotEmpty(loadFileSuffix))
 			ApplicationWarnings.add(LOG, "DEPRECATED: SUFFIX [_"+loadFileSuffix+"] files are deprecated, property files are now inherited from their parent!");
 
-		String autoDatabaseClassLoader = APP_CONSTANTS.getProperty("configurations.autoDatabaseClassLoader");
+		String autoDatabaseClassLoader = appConstants.getProperty("configurations.autoDatabaseClassLoader");
 		if (StringUtils.isNotEmpty(autoDatabaseClassLoader))
 			ApplicationWarnings.add(LOG, "DEPRECATED property [configurations.autoDatabaseClassLoader], please use [configurations.database.autoLoad] instead");
 
@@ -428,7 +429,7 @@ public class IbisContext extends IbisApplicationContext {
 	}
 
 	public String getApplicationName() {
-		return APP_CONSTANTS.getProperty("instance.name", null);
+		return AppConstants.getInstance().getProperty("instance.name", null);
 	}
 
 	public boolean isLoadingConfigs() {

--- a/core/src/main/java/org/frankframework/lifecycle/IbisApplicationContext.java
+++ b/core/src/main/java/org/frankframework/lifecycle/IbisApplicationContext.java
@@ -65,7 +65,6 @@ public class IbisApplicationContext implements Closeable {
 	private ApplicationContext parentContext = null;
 
 	private static final Logger LOG = LogUtil.getLogger(IbisApplicationContext.class);
-	protected static final AppConstants APP_CONSTANTS = AppConstants.getInstance();
 	private static final Logger APPLICATION_LOG = LogUtil.getLogger("APPLICATION");
 	private BootState state = BootState.FIRST_START;
 
@@ -168,13 +167,13 @@ public class IbisApplicationContext implements Closeable {
 		MutablePropertySources propertySources = classPathApplicationContext.getEnvironment().getPropertySources();
 		propertySources.remove(StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME);
 		propertySources.remove(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME);
-		propertySources.addFirst(new PropertiesPropertySource(SpringContextScope.APPLICATION.getFriendlyName(), APP_CONSTANTS));
+		propertySources.addFirst(new PropertiesPropertySource(SpringContextScope.APPLICATION.getFriendlyName(), AppConstants.getInstance()));
 
 		ClassLoader classLoader = classPathApplicationContext.getClassLoader();
 		if (classLoader == null) throw new IllegalStateException("no ClassLoader found to initialize Spring from");
 		classPathApplicationContext.setConfigLocations(getSpringConfigurationFiles(classLoader));
 
-		String instanceName = APP_CONSTANTS.getProperty("instance.name");
+		String instanceName = AppConstants.getInstance().getProperty("instance.name");
 		classPathApplicationContext.setId(requireNonNull(instanceName));
 		classPathApplicationContext.setDisplayName("IbisApplicationContext [" + instanceName + "]");
 

--- a/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
+++ b/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
@@ -157,8 +157,8 @@ public class IbisContextTest {
 		ApplicationWarnings.removeInstance();
 		AppConstants.removeInstance();
 		AppConstants appConstants = AppConstants.getInstance();
-		Object jdbcFieldNamesOriginalValue = appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
-		Object additionalPropFilesSuffixOriginalValue = appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
+		appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
+		appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
 		appConstants.setProperty("configurations.autoDatabaseClassLoader", "not-empty");
 
 		CredentialConstants credentialConstants = CredentialConstants.getInstance();
@@ -172,7 +172,6 @@ public class IbisContextTest {
 			List<String> warnings = ApplicationWarnings.getWarningsList();
 
 			assertEquals(4, warnings.size());
-
 			assertThat(warnings, containsInAnyOrder(
 					containsString("DEPRECATED legacy classnames from package [" + CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders"),
 					containsString("DEPRECATED property [configurations.autoDatabaseClassLoader]"),

--- a/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
+++ b/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
@@ -152,9 +152,10 @@ public class IbisContextTest {
 	}
 
 	@Test
-	public void testDeprecationChecksAllDes() {
+	public void testDeprecationChecksAllDeps() {
 		// Arrange
 		ApplicationWarnings.removeInstance();
+		AppConstants.removeInstance();
 		AppConstants appConstants = AppConstants.getInstance();
 		Object jdbcFieldNamesOriginalValue = appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
 		Object additionalPropFilesSuffixOriginalValue = appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
@@ -180,17 +181,8 @@ public class IbisContextTest {
 					));
 		} finally {
 			// Clean up properties set for this test to make sure we do not mess up any other tests
-			if (jdbcFieldNamesOriginalValue == null) {
-				appConstants.remove("jdbc.convertFieldnamesToUppercase");
-			} else {
-				appConstants.setProperty("jdbc.convertFieldnamesToUppercase", jdbcFieldNamesOriginalValue.toString());
-			}
-			if (additionalPropFilesSuffixOriginalValue == null) {
-				appConstants.remove(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
-			} else {
-				appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, additionalPropFilesSuffixOriginalValue.toString());
-			}
-			appConstants.remove("configurations.autoDatabaseClassLoader");
+			AppConstants.removeInstance();
+			ApplicationWarnings.removeInstance();
 			if (credentialFactoryOriginalValue == null) {
 				credentialConstants.remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
 			} else {

--- a/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
+++ b/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
@@ -1,6 +1,8 @@
 package org.frankframework.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -15,8 +17,11 @@ import org.springframework.context.support.AbstractApplicationContext;
 
 import org.frankframework.configuration.classloaders.DummyClassLoader;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
+import org.frankframework.credentialprovider.CredentialFactory;
+import org.frankframework.credentialprovider.util.CredentialConstants;
 import org.frankframework.lifecycle.events.MessageEventListener;
 import org.frankframework.testutil.NullClassLoader;
+import org.frankframework.util.AppConstants;
 import org.frankframework.util.MessageKeeperMessage;
 
 public class IbisContextTest {
@@ -129,6 +134,68 @@ public class IbisContextTest {
 			assertThat(ex.getMessage(), Matchers.startsWith("error instantiating configuration"));
 			Throwable[] suppressed = ex.getCause().getSuppressed();
 			assertEquals(0, suppressed.length, "no further information");
+		}
+	}
+
+	@Test
+	public void testDeprecationChecksNoDeps() {
+		// Arrange
+		ApplicationWarnings.removeInstance();
+
+		// Act
+		IbisContext.checkForDeprecations();
+
+		// Assert
+		List<String> warnings = ApplicationWarnings.getWarningsList();
+
+		assertEquals(0, warnings.size());
+	}
+
+	@Test
+	public void testDeprecationChecksAllDes() {
+		// Arrange
+		ApplicationWarnings.removeInstance();
+		AppConstants appConstants = AppConstants.getInstance();
+		Object jdbcFieldNamesOriginalValue = appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
+		Object additionalPropFilesSuffixOriginalValue = appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
+		appConstants.setProperty("configurations.autoDatabaseClassLoader", "not-empty");
+
+		CredentialConstants credentialConstants = CredentialConstants.getInstance();
+		Object credentialFactoryOriginalValue = credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, "nl.nn.credentialprovider.PropertyFileCredentialFactory");
+
+		// Act
+		IbisContext.checkForDeprecations();
+
+		// Assert
+		try {
+			List<String> warnings = ApplicationWarnings.getWarningsList();
+
+			assertEquals(4, warnings.size());
+
+			assertThat(warnings, containsInAnyOrder(
+					containsString("DEPRECATED legacy classnames from package [" + CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders"),
+					containsString("DEPRECATED property [configurations.autoDatabaseClassLoader]"),
+					containsString("DEPRECATED: SUFFIX [_"),
+					containsString("DEPRECATED: jdbc.convertFieldnamesToUppercase is set to false, please set to true")
+					));
+		} finally {
+			// Clean up properties set for this test to make sure we do not mess up any other tests
+			if (jdbcFieldNamesOriginalValue == null) {
+				appConstants.remove("jdbc.convertFieldnamesToUppercase");
+			} else {
+				appConstants.setProperty("jdbc.convertFieldnamesToUppercase", jdbcFieldNamesOriginalValue.toString());
+			}
+			if (additionalPropFilesSuffixOriginalValue == null) {
+				appConstants.remove(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
+			} else {
+				appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, additionalPropFilesSuffixOriginalValue.toString());
+			}
+			appConstants.remove("configurations.autoDatabaseClassLoader");
+			if (credentialFactoryOriginalValue == null) {
+				credentialConstants.remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
+			} else {
+				credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, credentialFactoryOriginalValue.toString());
+			}
 		}
 	}
 }

--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialFactory.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialFactory.java
@@ -49,7 +49,7 @@ public class CredentialFactory {
 
 	protected final List<ISecretProvider> delegates = new ArrayList<>();
 	protected static boolean ALLOW_DEFAULT_PASSWORD = CredentialConstants.getInstance().getBoolean("credentialFactory.allowDefaultPassword", true);
-	private static boolean ALLOW_FALLBACK = CredentialConstants.getInstance().getBoolean("credentialFactory.allowFallbackProvider", true);
+	private static final boolean ALLOW_FALLBACK = CredentialConstants.getInstance().getBoolean("credentialFactory.allowFallbackProvider", true);
 
 	private static @Nullable CredentialFactory self;
 

--- a/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialFactory.java
+++ b/credentialProvider/src/main/java/org/frankframework/credentialprovider/CredentialFactory.java
@@ -36,7 +36,7 @@ import org.frankframework.util.ClassUtils;
 @Log
 public class CredentialFactory {
 
-	private static final String CREDENTIAL_FACTORY_KEY = "credentialFactory.class";
+	public static final String CREDENTIAL_FACTORY_KEY = "credentialFactory.class";
 	public static final String CREDENTIAL_FACTORY_ALIAS_PREFIX_KEY = "credentialFactory.optionalPrefix";
 
 	private static final String FALLBACK_CREDENTIAL_FACTORY = FileSystemCredentialFactory.class.getName();


### PR DESCRIPTION
Closes #8503
## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
