### PR TITLE
Don't store the ladybug enabled state in AppConstants

### DIFF
--- a/core/src/main/java/org/frankframework/management/bus/endpoints/UpdateLogSettings.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/UpdateLogSettings.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022-2025 WeAreFrank!
+   Copyright 2022-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 import jakarta.annotation.security.RolesAllowed;
 
@@ -50,7 +51,6 @@ import org.frankframework.util.LogUtil;
 @TopicSelector(BusTopic.LOG_CONFIGURATION)
 public class UpdateLogSettings extends BusEndpointBase implements ApplicationEventPublisherAware {
 	private static final String LOG_INTERMEDIARY_RESULTS_PROPERTY = "log.logIntermediaryResults";
-	private static final String TESTTOOL_ENABLED_PROPERTY = "testtool.enabled";
 	private @Setter ApplicationEventPublisher applicationEventPublisher;
 
 	@ActionSelector(BusAction.GET)
@@ -68,7 +68,7 @@ public class UpdateLogSettings extends BusEndpointBase implements ApplicationEve
 
 		logSettings.put("logIntermediaryResults", AppConstants.getInstance().getBoolean(LOG_INTERMEDIARY_RESULTS_PROPERTY, true));
 
-		logSettings.put("enableDebugger", AppConstants.getInstance().getBoolean(TESTTOOL_ENABLED_PROPERTY, true));
+		logSettings.put("enableDebugger", isTesttoolEnabled());
 
 		return new JsonMessage(logSettings);
 	}
@@ -117,9 +117,8 @@ public class UpdateLogSettings extends BusEndpointBase implements ApplicationEve
 		}
 
 		if (enableDebugger != null) {
-			boolean testtoolEnabled=AppConstants.getInstance().getBoolean(TESTTOOL_ENABLED_PROPERTY, true);
-			if (testtoolEnabled!=enableDebugger) {
-				AppConstants.setGlobalProperty(TESTTOOL_ENABLED_PROPERTY, "" + enableDebugger);
+			boolean testtoolEnabled = isTesttoolEnabled();
+			if (testtoolEnabled != enableDebugger) {
 				DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enableDebugger);
 				if (applicationEventPublisher!=null) {
 					log.info("setting debugger enabled [{}]", enableDebugger);
@@ -137,6 +136,16 @@ public class UpdateLogSettings extends BusEndpointBase implements ApplicationEve
 		if (!msg.isEmpty()) {
 			log.warn(msg);
 			LogUtil.getLogger("SEC").info(msg);
+		}
+	}
+
+	private boolean isTesttoolEnabled() {
+		try {
+			return getApplicationContext().getBean("debuggerActive", BooleanSupplier.class).getAsBoolean();
+		} catch (Exception e) {
+			// Ignore all exceptions. If the bean is not present, assume false!
+			log.warn("unable to determine ladybug testtool state", e);
+			return false;
 		}
 	}
 }

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/DebuggerActive.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/DebuggerActive.java
@@ -15,11 +15,17 @@
 */
 package org.frankframework.ladybug;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.ApplicationListener;
+
+import lombok.extern.log4j.Log4j2;
 
 import org.frankframework.management.bus.DebuggerStatusChangedEvent;
 import org.frankframework.util.AppConstants;
@@ -32,7 +38,10 @@ import org.frankframework.util.AppConstants;
  * @see LadybugDebugger
  * @see IbisDebuggerAdvice
  */
-public class DebuggerActive implements ApplicationEventPublisherAware, InitializingBean {
+@Log4j2
+public class DebuggerActive implements ApplicationEventPublisherAware, ApplicationListener<DebuggerStatusChangedEvent>, InitializingBean, BooleanSupplier {
+	private AtomicBoolean IS_LADYBUG_ACTIVE = new AtomicBoolean(false);
+	private static final String TESTTOOL_ENABLED_PROPERTY = "testtool.enabled";
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
@@ -46,26 +55,51 @@ public class DebuggerActive implements ApplicationEventPublisherAware, Initializ
 		// Contract for testtool state:
 		// - when the state changes a DebuggerStatusChangedEvent must be fired to notify others
 		// - to get notified of changes, components should listen to DebuggerStatusChangedEvents
-		// IbisDebuggerAdvice stores state in appconstants testtool.enabled for use by GUI
 
-		final AppConstants appConstants = AppConstants.getInstance();
-		String testToolEnabledProperty = appConstants.getProperty("testtool.enabled");
+		boolean testToolEnabled = inferTestToolState();
 
-		boolean testToolEnabled = true;
-		if (StringUtils.isNotEmpty(testToolEnabledProperty)) {
-			testToolEnabled = "true".equalsIgnoreCase(testToolEnabledProperty) || "!false".equalsIgnoreCase(testToolEnabledProperty);
-		} else {
-			String stage = appConstants.getProperty("dtap.stage");
-			if ("ACC".equals(stage) || "PRD".equals(stage)) {
-				testToolEnabled = false;
-			}
-			AppConstants.setGlobalProperty("testtool.enabled", testToolEnabled);
-		}
+		// update the state
+		setState(testToolEnabled);
 
 		// notify other components of status of debugger
 		DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, testToolEnabled);
 		if (applicationEventPublisher != null) {
+			log.debug("sending DebuggerStatusChangedEvent [{}]", event);
 			applicationEventPublisher.publishEvent(event);
 		}
+	}
+
+	private boolean inferTestToolState() {
+		final AppConstants appConstants = AppConstants.getInstance();
+		String testToolEnabledProperty = appConstants.getProperty(TESTTOOL_ENABLED_PROPERTY);
+
+		if (StringUtils.isNotEmpty(testToolEnabledProperty)) {
+			return "true".equalsIgnoreCase(testToolEnabledProperty) || "!false".equalsIgnoreCase(testToolEnabledProperty);
+		}
+
+		// Property has not been set, so determine it based on the dtap.stage.
+		String stage = appConstants.getProperty("dtap.stage");
+		return !("ACC".equals(stage) || "PRD".equals(stage));
+	}
+
+	// Store the state in AppConstants testtool.enabled for use by GUI/Larva
+	private void setState(boolean testToolEnabled) {
+		// Always store the new updated value in the AppConstants
+		AppConstants.setGlobalProperty(TESTTOOL_ENABLED_PROPERTY, testToolEnabled);
+
+		IS_LADYBUG_ACTIVE.set(testToolEnabled);
+	}
+
+	@Override
+	public void onApplicationEvent(@NonNull DebuggerStatusChangedEvent event) {
+		if (event.getSource() != this) {
+			log.debug("received DebuggerStatusChangedEvent [{}]", event);
+			setState(event.isEnabled());
+		}
+	}
+
+	@Override
+	public boolean getAsBoolean() {
+		return IS_LADYBUG_ACTIVE.get();
 	}
 }


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

This allows end-users to enable/disable the ladybug through the FF! Console when the `testtool.enabled` property has been set.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
