### PR TITLE
Change WsdlXmlValidator to correctly try to get a targetNamespace

### DIFF
--- a/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/PdfPipe.java
+++ b/aspose/src/main/java/org/frankframework/extensions/aspose/pipe/PdfPipe.java
@@ -316,7 +316,7 @@ public class PdfPipe extends FixedForwardPipe {
 	 * This behavior differs from v10.0 and earlier where conversion results were persistent and always stored on disk.
 	 * In order to use the old (non-streaming) behavior, set this to {@code ${ibis.tmpdir}/Pdf}.
 	 * By setting a location the {@code convertedDocument} attribute will be used to store the PDF location.
-	 * 
+	 *
 	 * @ff.default null
 	 */
 	@Deprecated

--- a/console/backend/src/main/java/org/frankframework/console/controllers/Logging.java
+++ b/console/backend/src/main/java/org/frankframework/console/controllers/Logging.java
@@ -18,9 +18,6 @@ package org.frankframework.console.controllers;
 import jakarta.annotation.security.RolesAllowed;
 
 import org.apache.logging.log4j.Level;
-
-import org.frankframework.console.util.RequestUtils;
-
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +32,7 @@ import org.frankframework.console.AllowAllIbisUserRoles;
 import org.frankframework.console.ApiException;
 import org.frankframework.console.Description;
 import org.frankframework.console.Relation;
+import org.frankframework.console.util.RequestUtils;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusTopic;
 import org.frankframework.management.bus.message.RequestMessageBuilder;

--- a/console/backend/src/test/java/org/frankframework/console/controllers/LoggingTest.java
+++ b/console/backend/src/test/java/org/frankframework/console/controllers/LoggingTest.java
@@ -1,6 +1,8 @@
 package org.frankframework.console.controllers;
 
-import org.frankframework.management.bus.message.StringMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,9 +17,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.frankframework.management.bus.message.StringMessage;
 
 @ContextConfiguration(classes = {WebTestConfiguration.class, Logging.class})
 class LoggingTest extends FrankApiTestBase {

--- a/core/src/main/java/org/frankframework/pipes/WsdlXmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/WsdlXmlValidator.java
@@ -426,7 +426,6 @@ public class WsdlXmlValidator extends SoapValidator {
 	public void setSoapBodyNamespace(String soapBodyNamespace) {
 		this.soapBodyNamespace = soapBodyNamespace;
 	}
-
 }
 
 class ClassLoaderWSDLLocator implements WSDLLocator, IScopeProvider {

--- a/core/src/main/java/org/frankframework/pipes/WsdlXmlValidator.java
+++ b/core/src/main/java/org/frankframework/pipes/WsdlXmlValidator.java
@@ -93,16 +93,15 @@ public class WsdlXmlValidator extends SoapValidator {
 	private @Setter SharedWsdlDefinitions sharedWsdlDefinitions;
 	private Definition definition;
 
-
 	static {
-		WSDLFactory f;
+		WSDLFactory wsdlFactory;
 		try {
-			f = WSDLFactory.newInstance();
+			wsdlFactory = WSDLFactory.newInstance();
 		} catch (WSDLException e) {
-			f = null;
+			wsdlFactory = null;
 			LOG.error(e.getMessage(), e);
 		}
-		FACTORY = f;
+		FACTORY = wsdlFactory;
 	}
 
 	@Override
@@ -380,10 +379,27 @@ public class WsdlXmlValidator extends SoapValidator {
 			xsd.setImportedSchemaLocationsToIgnore(getImportedSchemaLocationsToIgnore());
 			xsd.setUseBaseImportedSchemaLocationsToIgnore(isUseBaseImportedSchemaLocationsToIgnore());
 			xsd.setImportedNamespacesToIgnore(getImportedNamespacesToIgnore());
-			xsd.initNamespace(StringUtils.isNotEmpty(getSchemaLocation())?filteredNamespaces.get(schema):null,this, getWsdl());
+
+			String namespaceToInit = getNamespaceToInit(filteredNamespaces, schema);
+			xsd.initNamespace(namespaceToInit,this, getWsdl());
 			xsds.add(xsd);
 		}
 		return xsds;
+	}
+
+	/**
+	 * Make sure to get the right namespace to init, or use the configurable fallback namespace for complex wsdl/with schema constructions
+	 */
+	private String getNamespaceToInit(Map<Schema, String> filteredNamespaces, Schema schema) {
+		if (StringUtils.isNotEmpty(getSchemaLocation())) {
+			return filteredNamespaces.get(schema);
+		}
+
+		if (StringUtils.isNotEmpty(getTargetNamespace())) {
+			return getTargetNamespace();
+		}
+
+		return null;
 	}
 
 	public String toExtendedString() {

--- a/core/src/main/java/org/frankframework/soap/KeyStoreCrypto.java
+++ b/core/src/main/java/org/frankframework/soap/KeyStoreCrypto.java
@@ -70,14 +70,14 @@ import org.frankframework.util.AppConstants;
  * WSS4J does not come with a method to use a KeyStore.
  * There is a property based WSS4J Merlin implementation, but that does not suit the
  * configuration based approach we use in the Frank!Framework.
- * 
+ *
  * This way the {@code keystore} element can be used to provided a certificate.
- * 
+ *
  * NOTE: When no TrustStore is provided the default (CACERTS) is used.
- * 
+ *
  * The KeyStore is used for signing and encrypting SOAP Messages, the TrustStore is used to validate the CA Chains.
  * The default should suffice but it's configurable for those who have their own Certificate Authority.
- * 
+ *
  * @author Niels Meijer
  */
 @Log4j2

--- a/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/WsdlXmlValidatorTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,9 +23,11 @@ import org.frankframework.stream.Message;
 import org.frankframework.testutil.MessageTestUtils;
 import org.frankframework.testutil.TestAppender;
 import org.frankframework.testutil.TestFileUtils;
+import org.frankframework.validation.IXSD;
 import org.frankframework.validation.ValidatorTestBase;
 import org.frankframework.validation.XmlValidatorContentHandler;
 import org.frankframework.validation.XmlValidatorException;
+import org.frankframework.validation.xsd.WsdlXsd;
 
 
 /**
@@ -32,16 +35,17 @@ import org.frankframework.validation.XmlValidatorException;
  */
 
 public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
-	private static final String SIMPLE					= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/SimpleWsdl/simple.wsdl";
-	private static final String SIMPLE_WITH_INCLUDE		= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/SimpleWsdl/simple_withinclude.wsdl";
-	private static final String SIMPLE_WITH_REFERENCE 	= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/SimpleWsdl/simple_withreference.wsdl";
-	private static final String TIBCO					= ValidatorTestBase.BASE_DIR_VALIDATION+"/Tibco/wsdl/BankingCustomer_01_GetPartyBasicDataBanking_01_concrete1.wsdl";
-	private static final String DOUBLE_BODY				= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/GetPolicyDetails/GetPolicyDetailsDoubleBody.wsdl";
-	private static final String BASIC					= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/GetPolicyDetails/GetPolicyDetails.wsdl";
-	private static final String SIVTR					= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/StartIncomingValueTransferProcess_1.wsdl";
-	private static final String SIVTRX					= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/IgnoreImport/StartIncomingValueTransferProcess_1x.wsdl";
-	private static final String MULTIPLE_OPERATIONS		= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/multipleOperations.wsdl";
-	private static final String MULTIPLE_ROOT_ELEMENTS	= ValidatorTestBase.BASE_DIR_VALIDATION+"/Wsdl/multipleRootElements.wsdl";
+	private static final String SIMPLE = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/SimpleWsdl/simple.wsdl";
+	private static final String SIMPLE_WITH_INCLUDE = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/SimpleWsdl/simple_withinclude.wsdl";
+	private static final String SIMPLE_WITH_REFERENCE = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/SimpleWsdl/simple_withreference.wsdl";
+	private static final String TIBCO = ValidatorTestBase.BASE_DIR_VALIDATION + "/Tibco/wsdl/BankingCustomer_01_GetPartyBasicDataBanking_01_concrete1.wsdl";
+	private static final String DOUBLE_BODY = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/GetPolicyDetails/GetPolicyDetailsDoubleBody.wsdl";
+	private static final String BASIC = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/GetPolicyDetails/GetPolicyDetails.wsdl";
+	private static final String SIVTR = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/IgnoreImport/StartIncomingValueTransferProcess_1.wsdl";
+	private static final String SIVTRX = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/IgnoreImport/StartIncomingValueTransferProcess_1x.wsdl";
+	private static final String MULTIPLE_OPERATIONS = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/multipleOperations.wsdl";
+	private static final String MULTIPLE_ROOT_ELEMENTS = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/multipleRootElements.wsdl";
+	private static final String WSDL_XSD_IMPORT = ValidatorTestBase.BASE_DIR_VALIDATION + "/Wsdl/WsdlImport/WsdlXsdImport.wsdl";
 
 	@Override
 	public WsdlXmlValidator createPipe() {
@@ -658,5 +662,44 @@ public class WsdlXmlValidatorTest extends PipeTestBase<WsdlXmlValidator> {
 
 		assertThat(e.getMessage(), containsString("Invalid content was found starting with element"));
 		assertThat(e.getMessage(), containsString("CountryKode"));
+	}
+
+	@Test
+	public void testImportedWsdlWithCustomSchema() throws Exception{
+		pipe.setWsdl(WSDL_XSD_IMPORT);
+		pipe.setThrowException(true);
+		pipe.addForward(new PipeForward("success", null));
+
+		configureAndStartPipe();
+
+		Set<IXSD> xsds = pipe.getXsds();
+
+		// Assert WsdlXsd implementation doesn't have a namespace
+		xsds.forEach(xsd -> {
+			if (xsd instanceof WsdlXsd wsdlXsd) {
+				assertEquals("", wsdlXsd.getNamespace());
+			}
+		});
+	}
+
+	@Test
+	public void testImportedWsdlWithCustomSchemaAndTargetNamespace() throws Exception{
+		pipe.setWsdl(WSDL_XSD_IMPORT);
+		pipe.setThrowException(true);
+		pipe.addForward(new PipeForward("success", null));
+
+		String namespace = "http://www.egem.nl/StUF/sector/bg/0310";
+		pipe.setTargetNamespace(namespace);
+
+		configureAndStartPipe();
+
+		Set<IXSD> xsds = pipe.getXsds();
+
+		// Assert WsdlXsd implementation does have a namespace
+		xsds.forEach(xsd -> {
+			if (xsd instanceof WsdlXsd wsdlXsd) {
+				assertEquals(namespace, wsdlXsd.getNamespace());
+			}
+		});
 	}
 }

--- a/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
+++ b/core/src/test/java/org/frankframework/soap/WsdlGeneratorTest.java
@@ -85,4 +85,28 @@ public class WsdlGeneratorTest {
 		result = result.replaceAll("[0-9]{4}-.*:[0-9]{2}", "DATETIME");
 		TestAssertions.assertEqualsIgnoreCRLF(TestFileUtils.getTestFile("/WsdlGenerator/GeneratedHelloWorld.wsdl"), result);
 	}
+
+	@Test
+	public void testInputValidatorWithSchemaImport() throws Exception {
+		PipeLine pipeline = createPipeline();
+
+		WsdlXmlValidator inputValidator = configuration.createBean();
+		inputValidator.setWsdl(validateResource("/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl"));
+		inputValidator.setSoapBody("npsLv01");
+		inputValidator.setTargetNamespace("http://www.egem.nl/StUF/sector/bg/0310");
+		inputValidator.setThrowException(true);
+
+		pipeline.setInputValidator(inputValidator);
+		pipeline.getAdapter().configure();
+
+		WsdlGenerator generator = new WsdlGenerator(pipeline);
+		assertNotNull(generator);
+
+		generator.init();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		generator.wsdl(out, "dummyServlet");
+		String result = new String(out.toByteArray());
+		result = result.replaceAll("[0-9]{4}-.*:[0-9]{2}", "DATETIME");
+		TestAssertions.assertEqualsIgnoreWhitespaces(TestFileUtils.getTestFile("/WsdlGenerator/TargetNamespace.wsdl"), result);
+	}
 }

--- a/core/src/test/resources/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl
+++ b/core/src/test/resources/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:definitions
+	xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310"
+	xmlns:w="http://schemas.xmlsoap.org/wsdl/"
+	xmlns="http://www.w3.org/2001/XMLSchema">
+	<w:types>
+		<schema>
+			<import namespace="http://www.egem.nl/StUF/sector/bg/0310"
+				schemaLocation="types.xsd" />
+		</schema>
+	</w:types>
+	<w:message name="npsLv01">
+		<w:part name="body" element="BG:npsLv01" />
+	</w:message>
+
+</w:definitions>

--- a/core/src/test/resources/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl
+++ b/core/src/test/resources/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:definitions
+<wsdl:definitions
 	xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310"
-	xmlns:w="http://schemas.xmlsoap.org/wsdl/"
+	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
 	xmlns="http://www.w3.org/2001/XMLSchema">
-	<w:types>
+	<wsdl:types>
 		<schema>
 			<import namespace="http://www.egem.nl/StUF/sector/bg/0310"
 				schemaLocation="types.xsd" />
 		</schema>
-	</w:types>
-	<w:message name="npsLv01">
-		<w:part name="body" element="BG:npsLv01" />
-	</w:message>
+	</wsdl:types>
+	<wsdl:message name="npsLv01">
+		<wsdl:part name="body" element="BG:npsLv01" />
+	</wsdl:message>
 
-</w:definitions>
+</wsdl:definitions>

--- a/core/src/test/resources/Validation/Wsdl/WsdlImport/types.xsd
+++ b/core/src/test/resources/Validation/Wsdl/WsdlImport/types.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="http://www.egem.nl/StUF/sector/bg/0310">
+	<element name="npsLv01">
+		<complexType>
+			<sequence>
+				<group ref="BG:npsVraagBody"/>
+			</sequence>
+		</complexType>
+	</element>
+
+	<group name="npsVraagBody">
+		<sequence>
+			<element name="gelijk" type="boolean" minOccurs="0"/>
+			<element name="vanaf" type="decimal" minOccurs="0"/>
+			<element name="totEnMet" type="decimal" minOccurs="0"/>
+		</sequence>
+	</group>
+</schema>

--- a/core/src/test/resources/WsdlGenerator/TargetNamespace.wsdl
+++ b/core/src/test/resources/WsdlGenerator/TargetNamespace.wsdl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="${wsdl.EchoPipe4WsdlGeneratorTest.targetNamespace}">
+	<wsdl:documentation>Generated as EchoPipe4WsdlGeneratorTest.wsdl on DATETIME.</wsdl:documentation>
+	<wsdl:types>
+		<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="http://www.egem.nl/StUF/sector/bg/0310">
+			<import namespace="http://www.egem.nl/StUF/sector/bg/0310"/>
+
+
+			<element name="npsLv01">
+				<complexType>
+					<sequence>
+						<group ref="BG:npsVraagBody"/>
+					</sequence>
+				</complexType>
+			</element>
+
+			<group name="npsVraagBody">
+				<sequence>
+					<element minOccurs="0" name="gelijk" type="boolean"/>
+					<element minOccurs="0" name="vanaf" type="decimal"/>
+					<element minOccurs="0" name="totEnMet" type="decimal"/>
+				</sequence>
+			</group>
+		</schema>
+	</wsdl:types>
+	<wsdl:message name="Message_npsLv01">
+		<wsdl:part name="Part_npsLv01" element="ns1:npsLv01"/>
+	</wsdl:message>
+	<wsdl:portType name="PortType_EchoPipe4WsdlGeneratorTest"></wsdl:portType>
+	<!--Warning: XSD '/Validation/Wsdl/WsdlImport/WsdlXsdImport.wsdl!schema1' doesn't have a targetNamespace and addNamespaceToSchema is false-->
+</wsdl:definitions>

--- a/core/src/test/resources/WsdlGenerator/TargetNamespace.wsdl
+++ b/core/src/test/resources/WsdlGenerator/TargetNamespace.wsdl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:ns1="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="${wsdl.EchoPipe4WsdlGeneratorTest.targetNamespace}">
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="${wsdl.EchoPipe4WsdlGeneratorTest.targetNamespace}" xmlns:ns1="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="${wsdl.EchoPipe4WsdlGeneratorTest.targetNamespace}">
 	<wsdl:documentation>Generated as EchoPipe4WsdlGeneratorTest.wsdl on DATETIME.</wsdl:documentation>
 	<wsdl:types>
 		<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:BG="http://www.egem.nl/StUF/sector/bg/0310" targetNamespace="http://www.egem.nl/StUF/sector/bg/0310">

--- a/dbms/pom.xml
+++ b/dbms/pom.xml
@@ -59,12 +59,12 @@
 			<artifactId>log4j-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.4.240</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.4.240</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>


### PR DESCRIPTION
## Changes
WsdlXmlValidator had a hard time figuring out the schema for an included wsdl, which included an xsd which has an import namespace. I've modified the code slightly to be able to actually use the configured targetNamespace in the generated WSDL:

```
<wsdl:types>
	<xsd:schema targetNamespace="NOT_EMPTY_ANYMORE">
		<xsd:include schemaLocation="file/location.xsd"/>
	</xsd:schema>
</wsdl:types>
```

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [x] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [n/a] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
