### PR TITLE
Provide a JdbcTableListener without a message store

### DIFF
--- a/core/src/main/java/org/frankframework/jdbc/AbstractJdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/AbstractJdbcListener.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2026 WeAreFrank!
+   Copyright 2013, 2016, 2018-2020 Nationale-Nederlanden, 2020-2025 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,9 +25,12 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,10 +43,12 @@ import lombok.Lombok;
 import lombok.Setter;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.core.IHasProcessState;
 import org.frankframework.core.IPeekableListener;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.ProcessState;
 import org.frankframework.dbms.DbmsException;
 import org.frankframework.dbms.JdbcException;
 import org.frankframework.lifecycle.LifecycleException;
@@ -58,17 +63,17 @@ import org.frankframework.util.MessageUtils;
 import org.frankframework.util.StringUtil;
 
 /**
- * JdbcListener which doesn't implement {@link org.frankframework.core.IHasProcessState} and therefore doesn't support changing the process state
- * of messages. Please note that you should use the JdbcTableListener or MessageStoreListener. Message browsing, and error and status updates are not performed
- * and have to be done manually.
+ * JdbcListener base class.
  *
  * @param <M> MessageWrapper or key. Key is also used as messageId
- * @see JdbcTableListener
- * @see MessageStoreListener
  *
+ * @author  Gerrit van Brakel
+ * @since   4.7
  */
-public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>, ReceiverAware<M> {
-	public static final String ADDITIONAL_QUERY_FIELDS_KEY = "ADDITIONAL_QUERY_FIELDS";
+@SuppressWarnings("SynchronizeOnNonFinalField")
+public abstract class AbstractJdbcListener<M> extends JdbcFacade implements IPeekableListener<M>, IHasProcessState<M>, ReceiverAware<M> {
+
+	 public static final String ADDITIONAL_QUERY_FIELDS_KEY = "ADDITIONAL_QUERY_FIELDS";
 
 	private @Getter @Setter Receiver<M> receiver;
 
@@ -81,7 +86,7 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	private @Getter String correlationIdField;
 	private @Getter String additionalFields;
 	private @Getter @Nonnull List<String> additionalFieldsList = List.of();
-	private @Getter AbstractJdbcListener.MessageFieldType messageFieldType= AbstractJdbcListener.MessageFieldType.STRING;
+	private @Getter MessageFieldType messageFieldType=MessageFieldType.STRING;
 	private @Getter String sqlDialect = AppConstants.getInstance().getString("jdbc.sqlDialect", null);
 
 	private @Getter String blobCharset = null;
@@ -90,6 +95,9 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 
 	private @Setter @Getter boolean trace=false;
 	private @Getter boolean peekUntransacted=true;
+
+	private Map<ProcessState, String> updateStatusQueries = new EnumMap<>(ProcessState.class);
+	private Map<ProcessState, Set<ProcessState>> targetProcessStates = new EnumMap<>(ProcessState.class);
 
 	protected Connection connection = null;
 
@@ -112,6 +120,15 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 			String convertedSelectQuery = convertQuery(getSelectQuery());
 			preparedSelectQuery = getDbmsSupport().prepareQueryTextForWorkQueueReading(1, convertedSelectQuery);
 			preparedPeekQuery = StringUtils.isNotEmpty(getPeekQuery()) ? convertQuery(getPeekQuery()) : getDbmsSupport().prepareQueryTextForWorkQueuePeeking(1, convertedSelectQuery);
+			Map<ProcessState, String> orderedUpdateStatusQueries = new LinkedHashMap<>();
+			for (ProcessState state : ProcessState.values()) {
+				if(updateStatusQueries.containsKey(state)) {
+					String convertedUpdateStatusQuery = convertQuery(updateStatusQueries.get(state));
+					orderedUpdateStatusQueries.put(state, convertedUpdateStatusQuery);
+				}
+			}
+			updateStatusQueries=orderedUpdateStatusQueries;
+			targetProcessStates = ProcessState.getTargetProcessStates(knownProcessStates());
 		} catch (JdbcException e) {
 			throw new ConfigurationException(e);
 		}
@@ -330,6 +347,16 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 		}
 	}
 
+	protected String getKeyFromRawMessage(RawMessageWrapper<M> rawMessage) {
+
+		Map<String, Object> mwContext = rawMessage.getContext();
+		String key = (String) mwContext.get(PipeLineSession.STORAGE_ID_KEY);
+		if (StringUtils.isNotEmpty(key)) {
+			return key;
+		}
+		throw new IllegalArgumentException("Cannot extract JDBC message key from raw message [" + rawMessage + "]");
+	}
+
 	@Override
 	public Message extractMessage(@Nonnull RawMessageWrapper<M> rawMessage, @Nonnull Map<String, Object> context) throws ListenerException {
 		addAdditionalQueryFieldsToSession(rawMessage, context);
@@ -349,6 +376,39 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	@Override
 	public void afterMessageProcessed(PipeLineResult processResult, RawMessageWrapper<M> rawMessage, PipeLineSession pipeLineSession) throws ListenerException {
 		// required action already done via ChangeProcessState()
+	}
+
+	@Override
+	public Set<ProcessState> knownProcessStates() {
+		return updateStatusQueries.keySet();
+	}
+
+	@Override
+	public Map<ProcessState,Set<ProcessState>> targetProcessStates() {
+		return targetProcessStates;
+	}
+
+	@Override
+	public RawMessageWrapper<M> changeProcessState(RawMessageWrapper<M> rawMessage, ProcessState toState, String reason) throws ListenerException {
+		if (!knownProcessStates().contains(toState)) {
+			return null; // if toState does not exist, the message can/will not be moved to it, so return null.
+		}
+		if (isConnectionsArePooled()) {
+			try (Connection conn = getConnection()) {
+				return changeProcessState(conn, rawMessage, toState, reason);
+			} catch (JdbcException|SQLException e) {
+				throw new ListenerException(e);
+			}
+		}
+		synchronized (connection) {
+			return changeProcessState(connection, rawMessage, toState, reason);
+		}
+	}
+
+	protected RawMessageWrapper<M> changeProcessState(Connection connection, RawMessageWrapper<M> rawMessage, ProcessState toState, String reason) throws ListenerException {
+		String query = getUpdateStatusQuery(toState);
+		String key=getKeyFromRawMessage(rawMessage);
+		return execute(connection, query, List.of(key)) ? rawMessage : null;
 	}
 
 	protected boolean execute(Connection conn, String query, List<String> parameters) throws ListenerException {
@@ -378,7 +438,19 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 		return getDbmsSupport().convertQuery(query, getSqlDialect());
 	}
 
-	public void setSelectQuery(String string) {
+	protected void setUpdateStatusQuery(ProcessState state, String query) {
+		if (StringUtils.isNotEmpty(query)) {
+			updateStatusQueries.put(state, query);
+		} else {
+			updateStatusQueries.remove(state);
+		}
+	}
+
+	public String getUpdateStatusQuery(ProcessState state) {
+		return updateStatusQueries.get(state);
+	}
+
+	protected void setSelectQuery(String string) {
 		selectQuery = string;
 	}
 
@@ -416,7 +488,7 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	 * Type of the field containing the message data
 	 * @ff.default <i>String</i>
 	 */
-	public void setMessageFieldType(AbstractJdbcListener.MessageFieldType value) {
+	public void setMessageFieldType(MessageFieldType value) {
 		messageFieldType = value;
 	}
 

--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -450,7 +450,7 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 		return updateStatusQueries.get(state);
 	}
 
-	protected void setSelectQuery(String string) {
+	public void setSelectQuery(String string) {
 		selectQuery = string;
 	}
 

--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -63,7 +63,8 @@ import org.frankframework.util.MessageUtils;
 import org.frankframework.util.StringUtil;
 
 /**
- * JdbcListener base class.
+ * JdbcListener base class. Please note that you should not use this directly but use the JdbcTableListener or MessageStoreListener. Message browsing,
+ * and error and status updates are not performed and have to be done manually.
  *
  * @param <M> MessageWrapper or key. Key is also used as messageId
  *

--- a/core/src/main/java/org/frankframework/jdbc/JdbcQueryListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcQueryListener.java
@@ -29,7 +29,7 @@ import org.frankframework.core.ProcessState;
  */
 @Deprecated(forRemoval = true, since = "7.6.0")
 @ConfigurationWarning("Please replace with JdbcTableListener for ease of configuration and improved manageability")
-public class JdbcQueryListener extends JdbcListener {
+public class JdbcQueryListener extends AbstractJdbcListener {
 
 	@Override
 	public void configure() throws ConfigurationException {

--- a/core/src/main/java/org/frankframework/jdbc/JdbcTableListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcTableListener.java
@@ -50,7 +50,7 @@ import org.frankframework.receivers.RawMessageWrapper;
  *
  * @since   4.7
  */
-public class JdbcTableListener<M> extends JdbcListener<M> implements IProvidesMessageBrowsers<M> {
+public class JdbcTableListener<M> extends AbstractJdbcListener<M> implements IProvidesMessageBrowsers<M> {
 
 	private @Getter String tableName;
 	private @Getter String tableAlias="t";

--- a/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/MessageStoreListener.java
@@ -190,7 +190,7 @@ public class MessageStoreListener extends JdbcTableListener<Serializable> {
 		// If not, then the RawMessageWrapper context still contains some info we want to retain, such as MID, CID and Storage Key.
 		// So copying it here to thread context is always the right thing.
 		context.putAll(rawMessageWrapper.getContext());
-		context.remove(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY);
+		context.remove(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY);
 		addAdditionalQueryFieldsToSession(rawMessageWrapper, context);
 
 		// Now get or create the Message

--- a/core/src/test/java/org/frankframework/jdbc/JdbcListenerTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcListenerTest.java
@@ -1,0 +1,73 @@
+/*
+   Copyright 2025 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.jdbc;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.dbms.H2DbmsSupport;
+import org.frankframework.receivers.Receiver;
+
+class JdbcListenerTest {
+
+	private JdbcListener<String> listener;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		Receiver<String> receiver = mock(Receiver.class);
+		when(receiver.isTransacted()).thenReturn(false);
+
+		listener = spy(new JdbcListener<>());
+		listener.setReceiver(receiver);
+		listener.setMessageFieldType(JdbcListener.MessageFieldType.STRING);
+		listener.setKeyField("TKEY");
+		listener.setMessageField("FM");
+		listener.setMessageIdField("MID");
+		listener.setAdditionalFields("F1, F2");
+
+		DataSource ds = mock(DataSource.class);
+		doReturn(ds).when(listener).getDatasource();
+		H2DbmsSupport dbmsSupport = new H2DbmsSupport("2.3.232 (2024-08-11)");
+		doReturn(dbmsSupport).when(listener).getDbmsSupport();
+	}
+
+	@Test
+	void testSelectQueryContainsAdditionalFields() {
+		listener.setSelectQuery("SELECT TKEY, FM, MID, F1, F2 FROM TEST_TABLE");
+
+		assertDoesNotThrow(listener::configure);
+	}
+
+	@Test
+	void testSelectQueryDoesNotContainAdditionalFields() {
+		listener.setSelectQuery("SELECT TKEY, FM, MID, EF1, F12 FROM TEST_TABLE");
+
+		ConfigurationException exception = assertThrows(ConfigurationException.class, listener::configure);
+		assertThat(exception.getMessage(), containsString("[F1, F2]"));
+	}
+}

--- a/core/src/test/java/org/frankframework/jdbc/JdbcListenerTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcListenerTest.java
@@ -44,7 +44,7 @@ class JdbcListenerTest {
 
 		listener = spy(new JdbcListener<>());
 		listener.setReceiver(receiver);
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.STRING);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.STRING);
 		listener.setKeyField("TKEY");
 		listener.setMessageField("FM");
 		listener.setMessageIdField("MID");

--- a/core/src/test/java/org/frankframework/jdbc/JdbcQueryListenerTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcQueryListenerTest.java
@@ -30,7 +30,7 @@ class JdbcQueryListenerTest {
 
 		listener = spy(new JdbcQueryListener());
 		listener.setReceiver(receiver);
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.STRING);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.STRING);
 		listener.setKeyField("TKEY");
 		listener.setMessageField("FM");
 		listener.setMessageIdField("MID");

--- a/core/src/test/java/org/frankframework/jdbc/JdbcTableListenerTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/JdbcTableListenerTest.java
@@ -351,7 +351,7 @@ public class JdbcTableListenerTest {
 	@DatabaseTest
 	public void testGetRawMessageWithMessageFieldIsClob() throws Exception {
 		listener.setMessageField("TCLOB");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.CLOB);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.CLOB);
 		listener.configure();
 		listener.start();
 
@@ -367,7 +367,7 @@ public class JdbcTableListenerTest {
 	@DatabaseTest
 	public void testGetRawMessageWithMessageFieldIsBlob() throws Exception {
 		listener.setMessageField("TBLOB");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.BLOB);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.BLOB);
 		listener.setBlobSmartGet(false);
 		listener.setBlobsCompressed(false);
 		listener.configure();
@@ -393,7 +393,7 @@ public class JdbcTableListenerTest {
 	@DatabaseTest
 	public void testGetRawMessageWithMessageFieldIsVarchar() throws Exception {
 		listener.setMessageField("TVARCHAR");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.STRING);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.STRING);
 		listener.configure();
 		listener.start();
 
@@ -934,7 +934,7 @@ public class JdbcTableListenerTest {
 		listener.setOrderField("ORDRFLD");
 		listener.setMessageIdField("tINT");
 		listener.setMessageField("tCLOB");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.CLOB);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.CLOB);
 		listener.setAdditionalFields(", tBLOB, tVARCHAR,  ");
 		listener.configure();
 
@@ -948,7 +948,7 @@ public class JdbcTableListenerTest {
 	public void testGetExtraValues() throws Exception {
 		listener.setMessageIdField("tINT");
 		listener.setMessageField("tCLOB");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.CLOB);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.CLOB);
 		listener.setAdditionalFields("tBLOB, tVARCHAR");
 		listener.setBlobsCompressed(false);
 		listener.setBlobSmartGet(false);
@@ -983,7 +983,7 @@ public class JdbcTableListenerTest {
 	public void testGetExtraValuesSameAsOtherFields() throws Exception {
 		listener.setMessageIdField("tINT");
 		listener.setMessageField("tCLOB");
-		listener.setMessageFieldType(JdbcListener.MessageFieldType.CLOB);
+		listener.setMessageFieldType(AbstractJdbcListener.MessageFieldType.CLOB);
 		listener.setAdditionalFields("tBLOB, tVARCHAR, tCLOB, tINT");
 		listener.setBlobsCompressed(false);
 		listener.setBlobSmartGet(false);
@@ -1005,7 +1005,7 @@ public class JdbcTableListenerTest {
 		RawMessageWrapper<String> rawMessage = listener.getRawMessage(threadContext);
 
 		PipeLineSession session = new PipeLineSession();
-		assertTrue(rawMessage.getContext().containsKey(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY), "RawMessage Context should contain map of additional fields");
+		assertTrue(rawMessage.getContext().containsKey(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY), "RawMessage Context should contain map of additional fields");
 
 		// Extract message, then the additional fields should be copied to the session.
 		Message message = listener.extractMessage(rawMessage, session);

--- a/core/src/test/java/org/frankframework/receivers/MessageStoreListenerTest.java
+++ b/core/src/test/java/org/frankframework/receivers/MessageStoreListenerTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.dbms.GenericDbmsSupport;
 import org.frankframework.dbms.JdbcException;
-import org.frankframework.jdbc.JdbcListener;
+import org.frankframework.jdbc.AbstractJdbcListener;
 import org.frankframework.jdbc.MessageStoreListener;
 import org.frankframework.jdbc.datasource.DataSourceFactory;
 import org.frankframework.lifecycle.LifecycleException;
@@ -57,7 +57,7 @@ public class MessageStoreListenerTest extends ListenerTestBase<Serializable, Mes
 				if (!getAdditionalFieldsList().isEmpty()) {
 					Map<String, String> additionalFields = getAdditionalFieldsList().stream()
 							.collect(Collectors.toMap(Function.identity(), Function.identity()));
-					result.getContext().put(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY, additionalFields);
+					result.getContext().put(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY, additionalFields);
 				}
 				return result;
 			}
@@ -104,7 +104,7 @@ public class MessageStoreListenerTest extends ListenerTestBase<Serializable, Mes
 		assertEquals(input, rawMessage.getRawMessage().toString(), "MessageStoreListener should not manipulate the rawMessage");
 
 		Message message = listener.extractMessage(rawMessage, session);
-		assertFalse(session.containsKey(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY));
+		assertFalse(session.containsKey(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY));
 		assertEquals(input, message.asString());
 	}
 
@@ -116,12 +116,12 @@ public class MessageStoreListenerTest extends ListenerTestBase<Serializable, Mes
 
 		String input = "test-message";
 		RawMessageWrapper<Serializable> rawMessage = getRawMessage(input);
-		assertTrue(rawMessage.getContext().containsKey(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY), "RawMessage Context should contain additional fields");
+		assertTrue(rawMessage.getContext().containsKey(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY), "RawMessage Context should contain additional fields");
 		assertEquals(input, rawMessage.getRawMessage().toString(), "MessageStoreListener should not manipulate the rawMessage");
 
 		Message message = listener.extractMessage(rawMessage, session);
 		assertEquals(input, message.asString());
-		assertFalse(session.containsKey(JdbcListener.ADDITIONAL_QUERY_FIELDS_KEY));
+		assertFalse(session.containsKey(AbstractJdbcListener.ADDITIONAL_QUERY_FIELDS_KEY));
 		assertTrue(session.containsKey("timestamp"));
 		assertEquals("timestamp", session.get("timestamp"));
 


### PR DESCRIPTION
## Changes
JdbcListener needs to be used directly. This wasn't possible with the selectQuery setter being protected.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [x] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [x] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
