### PR TITLE
Document property ibistesttool.maxStorageDays in the Frank!Doc

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -592,6 +592,9 @@ ibistesttool.reportTransformation=TestTool/xsl/Default.xsl
 ## Maximum database size. When necessary the oldest report(s) will be deleted when adding a new one (default is 100MB)
 #ibistesttool.maxStorageSize=100MB
 
+## Maximum retention time of Ladybug reports in the database storage
+#ibistesttool.maxStorageDays
+
 ## Maximum file size for debug storage (.tts) files (default is 1MB)
 #ibistesttool.maxFileSize=1MB
 
@@ -630,17 +633,6 @@ testtool.echo2.enabled=false
 #validators.disabled
 
 #ibistesttool.defaultView
-
-#ibistesttool.freeSpaceMinimum
-
-#ibistesttool.maxStorageSize
-
-#ibistesttool.maxBackupIndex
-
-#ibistesttool.maxFileSize
-
-## Maximum retention time of Ladybug reports in the database storage
-#ibistesttool.maxStorageDays
 
 ####
 #### ManageDatabase Internal Utility Adapter

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -639,6 +639,9 @@ testtool.echo2.enabled=false
 
 #ibistesttool.maxFileSize
 
+## Maximum retention time of Ladybug reports in the database storage
+#ibistesttool.maxStorageDays
+
 ####
 #### ManageDatabase Internal Utility Adapter
 

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -590,10 +590,10 @@ ibistesttool.maxMessageLength=1000000
 ibistesttool.reportTransformation=TestTool/xsl/Default.xsl
 
 ## Maximum database size. When necessary the oldest report(s) will be deleted when adding a new one (default is 100MB)
-#ibistesttool.maxStorageSize=100MB
+ibistesttool.maxStorageSize=100MB
 
 ## Maximum retention time of Ladybug reports in the database storage
-#ibistesttool.maxStorageDays
+ibistesttool.maxStorageDays=31
 
 ## Maximum file size for debug storage (.tts) files (default is 1MB)
 #ibistesttool.maxFileSize=1MB

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -593,7 +593,7 @@ ibistesttool.reportTransformation=TestTool/xsl/Default.xsl
 ibistesttool.maxStorageSize=100MB
 
 ## Maximum retention time of Ladybug reports in the database storage
-ibistesttool.maxStorageDays=31
+ibistesttool.maxStorageDays=100
 
 ## Maximum file size for debug storage (.tts) files (default is 1MB)
 #ibistesttool.maxFileSize=1MB


### PR DESCRIPTION
## Changes

Document property `ibistesttool.maxStorageDays` in the Frank!Doc. The Frank!Framework already passes this property to Ladybug. Ladybug uses it for the maximum retention time in days of Ladybug reports specifically in the database storage.

This should work because of the following code in DeploymentSpecificsBeanPostProcessor.java, method `postProcessBeforeInitialization()`:

```
			String maxStorageDays = appConstants.getProperty("ibistesttool.maxStorageDays");
			if (maxStorageDays != null) {
				long maxStorageDaysLong = OptionConverter.toFileSize(maxStorageDays, -1);
				databaseStorage.setMaxStorageDays(maxStorageDaysLong);
			}
```