### PR TITLE
Create OAuth 'private_key_jwt' Authenticator implementation

### DIFF
--- a/core/src/main/java/org/frankframework/http/AbstractHttpSession.java
+++ b/core/src/main/java/org/frankframework/http/AbstractHttpSession.java
@@ -93,6 +93,7 @@ import org.frankframework.http.authentication.IOauthAuthenticator;
 import org.frankframework.http.authentication.OAuthPreferringAuthenticationStrategy;
 import org.frankframework.http.authentication.ResourceOwnerPasswordCredentialsBasicAuth;
 import org.frankframework.http.authentication.ResourceOwnerPasswordCredentialsQueryParameters;
+import org.frankframework.http.authentication.PrivateKeyJwtAuthenticator;
 import org.frankframework.http.authentication.SamlAssertionOauth;
 import org.frankframework.lifecycle.ConfigurableLifecycle;
 import org.frankframework.statistics.FrankMeterType;
@@ -236,7 +237,15 @@ public abstract class AbstractHttpSession implements ConfigurableLifecycle, HasK
 		 * Generates a new SAML assertion, which will be exchanged for a token by the authorization server. The {@literal accessToken} is then used
 		 * in the Authorization header to authenticate against the resource server.
 		 */
-		SAML_ASSERTION;
+		SAML_ASSERTION,
+
+		/**
+		 * Requires {@literal clientId} and a private key (configured via the keystore settings).
+		 * Implements <a href="https://datatracker.ietf.org/doc/html/rfc7523#section-2.2">RFC 7523</a> {@code private_key_jwt} client authentication.
+		 * A signed JWT is sent as the {@code client_assertion} parameter to the token endpoint. Both RSA and EC keys are supported.
+		 * The {@literal accessToken} is then used in the Authorization header to authenticate against the resource server.
+		 */
+		PRIVATE_KEY_JWT;
 
 		public IOauthAuthenticator newAuthenticator(AbstractHttpSession session) throws HttpAuthenticationException {
 			return switch (this) {
@@ -245,6 +254,7 @@ public abstract class AbstractHttpSession implements ConfigurableLifecycle, HasK
 				case RESOURCE_OWNER_PASSWORD_CREDENTIALS_BASIC_AUTH -> new ResourceOwnerPasswordCredentialsBasicAuth(session);
 				case RESOURCE_OWNER_PASSWORD_CREDENTIALS_QUERY_PARAMETERS -> new ResourceOwnerPasswordCredentialsQueryParameters(session);
 				case SAML_ASSERTION -> new SamlAssertionOauth(session);
+				case PRIVATE_KEY_JWT -> new PrivateKeyJwtAuthenticator(session);
 			};
 		}
 

--- a/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
+++ b/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
@@ -56,12 +56,17 @@ import org.frankframework.http.AbstractHttpSession;
  *   <HttpSender url="..." tokenEndpoint="..."
  *     oauthAuthenticationMethod="PRIVATE_KEY_JWT"
  *     clientId="my-client-id">
- *     <keystore keystoreResource="/path/to/keystore.p12"
+ *     <Keystore keystoreResource="/path/to/keystore.p12"
  *       password="..."
  *       alias="my-key-alias"
  *       aliasPassword="..." />
  *   </HttpSender>
  * }</pre></p>
+ *
+ * <p>Please note, that with this setup you cannot have a separate key/certificate to be used for SSL. This will be addressed in the future to be able to have
+ * different certificates used for SSL and private key authentication</p>
+ *
+ * @see org.frankframework.encryption.KeystoreConfiguration
  */
 public class PrivateKeyJwtAuthenticator extends AbstractOauthAuthenticator {
 
@@ -79,8 +84,8 @@ public class PrivateKeyJwtAuthenticator extends AbstractOauthAuthenticator {
 	 */
 	private JWSAlgorithm algorithm;
 
-	public PrivateKeyJwtAuthenticator(AbstractHttpSession session) throws HttpAuthenticationException {
-		super(session);
+	public PrivateKeyJwtAuthenticator(AbstractHttpSession abstractHttpSession) throws HttpAuthenticationException {
+		super(abstractHttpSession);
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
+++ b/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
@@ -1,0 +1,162 @@
+/*
+   Copyright 2024 - 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.authentication;
+
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.message.BasicNameValuePair;
+import org.jspecify.annotations.NonNull;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.encryption.CorePkiUtil;
+import org.frankframework.encryption.EncryptionException;
+import org.frankframework.http.AbstractHttpSession;
+
+/**
+ * OAuth 2.0 authenticator using the {@code private_key_jwt} client authentication method, as defined in
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7523#section-2.2">RFC 7523</a>. Also see the <a href="https://docs.spring.io/spring-security/reference/reactive/oauth2/client/client-authentication.html#oauth2-client-authentication-jwt-bearer-private-key-jwt">
+ *     Spring docuemntation</a> on this topic.
+ *
+ * <p>A signed JWT is created using the configured private key and sent to the token endpoint as the
+ * {@code client_assertion} parameter. Both RSA and EC keys are supported.
+ *
+ * <p>You can use this in your configuration like this:
+ *
+ * <pre>{@code
+ *   <HttpSender url="..." tokenEndpoint="..."
+ *     oauthAuthenticationMethod="PRIVATE_KEY_JWT"
+ *     clientId="my-client-id">
+ *     <keystore keystoreResource="/path/to/keystore.p12"
+ *       password="..."
+ *       alias="my-key-alias"
+ *       aliasPassword="..." />
+ *   </HttpSender>
+ * }</pre></p>
+ */
+public class PrivateKeyJwtAuthenticator extends AbstractOauthAuthenticator {
+
+	private static final String JWT_BEARER_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+	/**
+	 * JWT expiry duration in milliseconds (5 minutes).
+	 */
+	private static final long JWT_EXPIRY_MS = 5 * 60 * 1000L;
+
+	private PrivateKey privateKey;
+
+	/**
+	 * Will be determined based on the type of the private key (RSA or EC) and used to sign the JWT assertion.
+	 */
+	private JWSAlgorithm algorithm;
+
+	public PrivateKeyJwtAuthenticator(AbstractHttpSession session) throws HttpAuthenticationException {
+		super(session);
+	}
+
+	@Override
+	public void configure() throws ConfigurationException {
+		if (StringUtils.isBlank(clientId)) {
+			throw new ConfigurationException("clientId is required for PrivateKeyJwtAuthenticator");
+		}
+
+		if (StringUtils.isBlank(session.getKeystore())) {
+			throw new ConfigurationException("A keystore with a private key must be configured for PrivateKeyJwtAuthenticator");
+		}
+
+		try {
+			privateKey = CorePkiUtil.getPrivateKey(session);
+		} catch (EncryptionException e) {
+			throw new ConfigurationException("Cannot load private key for PrivateKeyJwtAuthenticator", e);
+		}
+
+		if (privateKey instanceof RSAPrivateKey) {
+			algorithm = JWSAlgorithm.RS256;
+		} else if (privateKey instanceof ECPrivateKey) {
+			algorithm = JWSAlgorithm.ES256;
+		} else {
+			throw new ConfigurationException("Unsupported private key type for PrivateKeyJwtAuthenticator provided: Only RSA and EC keys are supported.");
+		}
+	}
+
+	@Override
+	protected HttpEntityEnclosingRequestBase createRequest(Credentials credentials, List<NameValuePair> parameters) throws HttpAuthenticationException {
+		parameters.add(new BasicNameValuePair("grant_type", "client_credentials"));
+		parameters.add(new BasicNameValuePair("client_id", clientId));
+		parameters.add(new BasicNameValuePair("client_assertion_type", JWT_BEARER_ASSERTION_TYPE));
+
+		if (session.getScope() != null) {
+			parameters.add(new BasicNameValuePair("scope", session.getScope().replace(',', ' ')));
+		}
+
+		try {
+			parameters.add(new BasicNameValuePair("client_assertion", createJwtAssertion()));
+		} catch (JOSEException e) {
+			throw new HttpAuthenticationException("failed to create JWT assertion for private_key_jwt", e);
+		}
+
+		return createPostRequestWithForm(authorizationEndpoint, parameters);
+	}
+
+	private String createJwtAssertion() throws JOSEException {
+		Date now = new Date();
+		Date expiry = new Date(now.getTime() + JWT_EXPIRY_MS);
+
+		// These values are set according to the RFC 7523 specification for private_key_jwt client authentication:
+		// * iss - must be the clientId
+		// * sub - must be the clientId
+		// * aud - must identify the authorization server (which is the token endpoint)
+		JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+				.issuer(clientId)
+				.subject(clientId)
+				.audience(session.getTokenEndpoint())
+				.jwtID(UUID.randomUUID().toString())
+				.issueTime(now)
+				.expirationTime(expiry)
+				.build();
+
+		JWSHeader header = new JWSHeader.Builder(algorithm).build();
+		return getSignedJWT(header, claimsSet).serialize();
+	}
+
+	private @NonNull SignedJWT getSignedJWT(JWSHeader header, JWTClaimsSet claimsSet) throws JOSEException {
+		SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+
+		if (privateKey instanceof RSAPrivateKey rsaKey) {
+			signedJWT.sign(new RSASSASigner(rsaKey));
+		} else {
+			signedJWT.sign(new ECDSASigner((ECPrivateKey) privateKey));
+		}
+
+		return signedJWT;
+	}
+}

--- a/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
+++ b/core/src/main/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticator.java
@@ -45,7 +45,7 @@ import org.frankframework.http.AbstractHttpSession;
 /**
  * OAuth 2.0 authenticator using the {@code private_key_jwt} client authentication method, as defined in
  * <a href="https://datatracker.ietf.org/doc/html/rfc7523#section-2.2">RFC 7523</a>. Also see the <a href="https://docs.spring.io/spring-security/reference/reactive/oauth2/client/client-authentication.html#oauth2-client-authentication-jwt-bearer-private-key-jwt">
- *     Spring docuemntation</a> on this topic.
+ * Spring documentation</a> on this topic.
  *
  * <p>A signed JWT is created using the configured private key and sent to the token endpoint as the
  * {@code client_assertion} parameter. Both RSA and EC keys are supported.

--- a/core/src/test/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticatorTest.java
+++ b/core/src/test/java/org/frankframework/http/authentication/PrivateKeyJwtAuthenticatorTest.java
@@ -1,0 +1,158 @@
+/*
+   Copyright 2024 - 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.http.AbstractHttpSession;
+import org.frankframework.http.HttpSender;
+import org.frankframework.util.StreamUtil;
+
+class PrivateKeyJwtAuthenticatorTest {
+
+	private static final String CLIENT_ID = "fakeClientId";
+	private static final String TOKEN_ENDPOINT = "https://token-dummy";
+
+	private HttpSender httpSender;
+
+	@BeforeEach
+	void setup() throws Exception {
+		httpSender = new HttpSender();
+		httpSender.setUrl("https://dummy");
+		httpSender.setTokenEndpoint(TOKEN_ENDPOINT);
+		httpSender.setOauthAuthenticationMethod(AbstractHttpSession.OauthAuthenticationMethod.PRIVATE_KEY_JWT);
+		httpSender.setClientId(CLIENT_ID);
+
+		httpSender.setKeystore("/Signature/saml-keystore.p12");
+		httpSender.setKeystorePassword("geheim");
+		httpSender.setKeystoreAlias("myalias");
+		httpSender.setKeystoreAliasPassword("geheim");
+	}
+
+	@Test
+	void testPrivateKeyJwtRequestContainsRequiredParameters() throws Exception {
+		httpSender.configure();
+		httpSender.start();
+
+		PrivateKeyJwtAuthenticator authenticator = (PrivateKeyJwtAuthenticator) AbstractHttpSession.OauthAuthenticationMethod.PRIVATE_KEY_JWT.newAuthenticator(httpSender);
+		authenticator.configure();
+
+		HttpEntityEnclosingRequestBase request = authenticator.createRequest(httpSender.getDomainAwareCredentials(), new ArrayList<>());
+
+		assertEquals("POST", request.getMethod());
+
+		String body = StreamUtil.streamToString(request.getEntity().getContent(), "\n", "UTF-8");
+		String decodedBody = URLDecoder.decode(body, StandardCharsets.UTF_8);
+
+		assertTrue(decodedBody.contains("grant_type=client_credentials"), "Body must contain grant_type=client_credentials");
+		assertTrue(decodedBody.contains("client_id=" + CLIENT_ID), "Body must contain client_id");
+		assertTrue(decodedBody.contains("client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"), "Body must contain client_assertion_type");
+		assertTrue(decodedBody.contains("client_assertion="), "Body must contain client_assertion");
+	}
+
+	@Test
+	void testPrivateKeyJwtAssertionIsValidJwt() throws Exception {
+		httpSender.configure();
+		httpSender.start();
+
+		PrivateKeyJwtAuthenticator authenticator = (PrivateKeyJwtAuthenticator) AbstractHttpSession.OauthAuthenticationMethod.PRIVATE_KEY_JWT.newAuthenticator(httpSender);
+		authenticator.configure();
+
+		HttpEntityEnclosingRequestBase request = authenticator.createRequest(httpSender.getDomainAwareCredentials(), new ArrayList<>());
+
+		String body = StreamUtil.streamToString(request.getEntity().getContent(), "\n", "UTF-8");
+		String decodedBody = URLDecoder.decode(body, StandardCharsets.UTF_8);
+
+		String jwtToken = extractParam(decodedBody, "client_assertion");
+		assertNotNull(jwtToken, "client_assertion must be present");
+
+		SignedJWT signedJWT = SignedJWT.parse(jwtToken);
+		JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+
+		assertEquals(CLIENT_ID, claims.getIssuer(), "JWT issuer must be clientId");
+		assertEquals(CLIENT_ID, claims.getSubject(), "JWT subject must be clientId");
+		assertTrue(claims.getAudience().contains(TOKEN_ENDPOINT), "JWT audience must contain token endpoint");
+		assertNotNull(claims.getJWTID(), "JWT must have a jti");
+		assertNotNull(claims.getIssueTime(), "JWT must have an iat");
+		assertNotNull(claims.getExpirationTime(), "JWT must have an exp");
+		assertTrue(claims.getExpirationTime().after(claims.getIssueTime()), "exp must be after iat");
+	}
+
+	@Test
+	void testPrivateKeyJwtWithScope() throws Exception {
+		httpSender.setScope("email,profile");
+		httpSender.configure();
+		httpSender.start();
+
+		PrivateKeyJwtAuthenticator authenticator = (PrivateKeyJwtAuthenticator) AbstractHttpSession.OauthAuthenticationMethod.PRIVATE_KEY_JWT.newAuthenticator(httpSender);
+		authenticator.configure();
+
+		HttpEntityEnclosingRequestBase request = authenticator.createRequest(httpSender.getDomainAwareCredentials(), new ArrayList<>());
+
+		String body = StreamUtil.streamToString(request.getEntity().getContent(), "\n", "UTF-8");
+		String decodedBody = URLDecoder.decode(body, StandardCharsets.UTF_8);
+
+		assertTrue(decodedBody.contains("scope=email profile"), "Body must contain scope with spaces instead of commas");
+	}
+
+	@Test
+	void testConfigureFailsWithoutClientId() throws Exception {
+		httpSender.setClientId(null);
+
+		assertThrows(ConfigurationException.class, () -> httpSender.configure(),
+				"Expected ConfigurationException when clientId is missing");
+	}
+
+	@Test
+	void testConfigureFailsWithoutPrivateKey() {
+		HttpSender noKeySender = new HttpSender();
+		noKeySender.setUrl("https://dummy");
+		noKeySender.setTokenEndpoint(TOKEN_ENDPOINT);
+		noKeySender.setOauthAuthenticationMethod(AbstractHttpSession.OauthAuthenticationMethod.PRIVATE_KEY_JWT);
+		noKeySender.setClientId(CLIENT_ID);
+		// No keystore configured — private key loading must fail
+
+		assertThrows(ConfigurationException.class, () -> noKeySender.configure(),
+				"Expected ConfigurationException when private key is missing");
+	}
+
+	private String extractParam(String body, String paramName) {
+		for (String part : body.split("&")) {
+			if (part.startsWith(paramName + "=")) {
+				return part.substring(paramName.length() + 1);
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Changes
Create a new Authenticator to implement the Oauth 'private_key_jwt' specification. For more information, see:
* https://oauth.net/private-key-jwt/
* https://docs.spring.io/spring-security/reference/servlet/oauth2/client/client-authentication.html#oauth2-client-authentication-jwt-bearer-private-key-jwt1

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [n/a] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [x] FF! Reference updated (user-facing behaviour/config)
- [x] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
