### PR TITLE
Small log improvements

### DIFF
--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -737,10 +737,15 @@ public class Message implements Serializable {
 		toStringPrefix(result);
 		result.append(getObjectId());
 
-		if (request != null) {
-			result.append(": [").append(request).append("]");
+		if (LOG.isDebugEnabled()) {
+			if (request != null) {
+				result.append(" content [").append(request).append("]");
+			} else {
+				result.append(" no-content");
+			}
 		}
 
+		result.append(" size [").append(size()).append("]");
 
 		return result.toString();
 	}

--- a/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
+++ b/core/src/main/java/org/frankframework/stream/SerializableFileReference.java
@@ -252,7 +252,7 @@ public class SerializableFileReference implements Serializable, AutoCloseable {
 	 */
 	private static Path copyToTempFile(InputStream in, long maxBytes) throws IOException {
 		Path tmpMessagesFolder = TemporaryDirectoryUtils.getTempDirectory(TEMP_MESSAGE_DIRECTORY);
-		Path destination = Files.createTempFile(tmpMessagesFolder, "msg", ".dat");
+		Path destination = Files.createTempFile(tmpMessagesFolder, "msg-", ".dat");
 		try (OutputStream fileOutputStream = Files.newOutputStream(destination)) {
 			StreamUtil.copyPartialStream(in, fileOutputStream, maxBytes, 16384);
 		}

--- a/core/src/main/java/org/frankframework/util/ProcessUtil.java
+++ b/core/src/main/java/org/frankframework/util/ProcessUtil.java
@@ -102,7 +102,7 @@ public class ProcessUtil {
 	@SuppressWarnings("java:S2142") // Don't re-interrupt
 	private static Path executeCommandInternal(List<String> command, int timeout) throws IOException, TimeoutException {
 		Path tempDir = TemporaryDirectoryUtils.getTempDirectory(SerializableFileReference.TEMP_MESSAGE_DIRECTORY);
-		Path stdoutFile = Files.createTempFile(tempDir, "msg", "dat");
+		Path stdoutFile = Files.createTempFile(tempDir, "msg-", ".dat");
 
 		final Process process;
 		try {

--- a/core/src/test/java/org/frankframework/stream/MessageTest.java
+++ b/core/src/test/java/org/frankframework/stream/MessageTest.java
@@ -167,7 +167,7 @@ public class MessageTest {
 		// remove the toStringPrefix(), if it is present
 		String valuePart = actual.contains("value:\n") ? actual.split("value:\n")[1] : actual;
 		valuePart = valuePart.replaceAll(".*Message\\[[a-fA-F0-9]+:", ""); // Strip 'Message[abcd1234:'
-		assertEquals(clazz.getSimpleName(), valuePart.substring(0, valuePart.indexOf("]: ")));
+		assertEquals(clazz.getSimpleName(), valuePart.substring(0, valuePart.indexOf("] ")));
 		if (wrapperClass == null) {
 			assertEquals(clazz.getSimpleName(), adapter.getRequestClass());
 		} else {

--- a/management-gateway/src/main/java/org/frankframework/management/gateway/SerializableInputStream.java
+++ b/management-gateway/src/main/java/org/frankframework/management/gateway/SerializableInputStream.java
@@ -62,7 +62,7 @@ public class SerializableInputStream extends InputStream implements Externalizab
 				Files.createDirectory(tmpDir);
 			}
 
-			tmpFile = Files.createTempFile(tmpDir, "msg", ".dat");
+			tmpFile = Files.createTempFile(tmpDir, "msg-", ".dat");
 			LOG.trace("determined temporary file location [{}]", tmpFile);
 		} catch (IOException e) {
 			throw new IllegalStateException("unable to create temp file to de-serialize stream", e);

--- a/test/src/test/testtool/Receivers/NonTransacted/common/result-error.xml
+++ b/test/src/test/testtool/Receivers/NonTransacted/common/result-error.xml
@@ -16,7 +16,7 @@
             <field name="TKEY">57440</field>
             <field name="TCHAR">E</field>
             <field name="TTIMESTAMP">2022-01-20 17:49:03</field>
-            <field name="TVARCHAR">exitState [ERROR], result [Message[HASHCODE:String]: [&lt;root forward="error"/&gt;]]</field>
+            <field name="TVARCHAR">exitState [ERROR], result [Message[HASHCODE:String] size [23]]</field>
           </row>
           <row number="1">
             <field name="TKEY">57441</field>

--- a/test/src/test/testtool/Receivers/Transacted/common/result-error-2.xml
+++ b/test/src/test/testtool/Receivers/Transacted/common/result-error-2.xml
@@ -16,7 +16,7 @@
             <field name="TKEY">57466</field>
             <field name="TCHAR">E</field>
             <field name="TTIMESTAMP">2022-01-20 17:49:44</field>
-            <field name="TVARCHAR">too many retries; exitState [ERROR], result [Message[HASHCODE:String]: [&lt;root forward="error"/&gt;]]</field>
+            <field name="TVARCHAR">too many retries; exitState [ERROR], result [Message[HASHCODE:String] size [23]]</field>
           </row>
           <row number="1">
             <field name="TKEY">57467</field>


### PR DESCRIPTION
(cherry picked from commit 29be4bcf12e95d49b2bf1b94cdbac47da7aee30b)

## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
