### PR TITLE
Fix TestPipeline passing `no-content` to Adapter when message was empty

### DIFF
--- a/console/backend/src/main/java/org/frankframework/console/controllers/TestPipeline.java
+++ b/console/backend/src/main/java/org/frankframework/console/controllers/TestPipeline.java
@@ -38,7 +38,6 @@ import org.frankframework.console.ApiException;
 import org.frankframework.console.Description;
 import org.frankframework.console.Relation;
 import org.frankframework.console.util.RequestUtils;
-import org.frankframework.console.util.ResponseUtils;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
@@ -103,7 +102,7 @@ public class TestPipeline {
 		builder.setPayload(inputMessage);
 		Message<?> response = frankApiService.sendSyncMessage(builder);
 		String state = BusMessageUtils.getHeader(response, AbstractMessage.STATE_KEY);
-		return testPipelineResponse(ResponseUtils.parseAsString(response), state, inputMessage);
+		return testPipelineResponse(BusMessageUtils.getPayloadAsString(response), state, inputMessage);
 	}
 
 	private ResponseEntity<TestPipeLineResponse> testPipelineResponse(String payload) {

--- a/console/backend/src/main/java/org/frankframework/console/controllers/socket/FrankApiWebSocketBase.java
+++ b/console/backend/src/main/java/org/frankframework/console/controllers/socket/FrankApiWebSocketBase.java
@@ -43,8 +43,8 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
-import org.frankframework.console.util.ResponseUtils;
 import org.frankframework.management.bus.BusException;
+import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.OutboundGateway;
 import org.frankframework.management.bus.OutboundGateway.ClusterMember;
 import org.frankframework.management.bus.message.RequestMessageBuilder;
@@ -103,7 +103,7 @@ public class FrankApiWebSocketBase implements InitializingBean, ApplicationListe
 			return null;
 		}
 
-		String stringResponse = ResponseUtils.parseAsString(response);
+		String stringResponse = BusMessageUtils.getPayloadAsString(response);
 		if (stringResponse == null) {
 			throw new IllegalStateException("no response payload found");
 		}

--- a/console/backend/src/main/java/org/frankframework/console/util/ResponseUtils.java
+++ b/console/backend/src/main/java/org/frankframework/console/util/ResponseUtils.java
@@ -15,11 +15,8 @@
 */
 package org.frankframework.console.util;
 
-import java.io.IOException;
 import java.io.InputStream;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -29,11 +26,8 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 
 import lombok.NoArgsConstructor;
 
-import org.frankframework.console.ApiException;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.message.AbstractMessage;
-import org.frankframework.management.bus.message.EmptyMessage;
-import org.frankframework.util.StreamUtil;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class ResponseUtils {
@@ -73,7 +67,7 @@ public class ResponseUtils {
 
 		responseEntity.headers(httpHeaders);
 
-		if (hasPayload(status)) {
+		if (BusMessageUtils.hasPayload(status)) {
 			if (response != null) {
 				return responseEntity.body(response);
 			}
@@ -81,47 +75,5 @@ public class ResponseUtils {
 		}
 
 		return responseEntity.build();
-	}
-
-	/**
-	 * Extracted method so it's in one place.
-	 * See {@link EmptyMessage} for more info.
-	 */
-	private static boolean hasPayload(int status) {
-		return (status == 200 || status > 204);
-	}
-
-	@Nullable
-	public static String parseAsString(Message<?> message) {
-		int status = BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 200);
-		if (!hasPayload(status)) {
-			return null;
-		}
-
-		String mimeType = BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY, null);
-		if (mimeType != null) {
-			MediaType mime = MediaType.valueOf(mimeType);
-			if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(mime) || MediaType.TEXT_PLAIN.equalsTypeAndSubtype(mime)) {
-				return (String) message.getPayload();
-			}
-		}
-		return convertPayload(message.getPayload());
-	}
-
-	@NonNull
-	public static String convertPayload(Object payload) {
-		if (payload instanceof String string) {
-			return string;
-		} else if (payload instanceof byte[] bytes) {
-			return new String(bytes);
-		} else if (payload instanceof InputStream stream) {
-			try {
-				// Convert line endings to \n to show them in the browser as real line feeds
-				return StreamUtil.streamToString(stream, "\n", false);
-			} catch (IOException e) {
-				throw new ApiException("unable to read response payload", e);
-			}
-		}
-		throw new ApiException("unexpected response payload type [" + payload.getClass().getCanonicalName() + "]");
 	}
 }

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
@@ -29,6 +29,7 @@ import jakarta.annotation.security.RolesAllowed;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.messaging.Message;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -89,7 +90,7 @@ public class TestPipeline extends BusEndpointBase {
 
 	@ActionSelector(BusAction.UPLOAD)
 	@RolesAllowed("IbisTester")
-	public AbstractMessage<?> runTestPipeline(Message<?> message) {
+	public @Nullable AbstractMessage<?> runTestPipeline(@NonNull Message<?> message) {
 		String configurationName = BusMessageUtils.getHeader(message, "configuration");
 		String adapterName = BusMessageUtils.getHeader(message, "adapter");
 		Adapter adapter = getAdapterByName(configurationName, adapterName);
@@ -114,15 +115,12 @@ public class TestPipeline extends BusEndpointBase {
 	}
 
 	// Does not support async requests because receiver requests are synchronous
-	private AbstractMessage<?> processMessage(Adapter adapter, String payload, Map<String, String> threadContext, boolean expectsReply) {
+	private @Nullable AbstractMessage<?> processMessage(@NonNull Adapter adapter, @Nullable String payload, @NonNull Map<String, String> threadContext, boolean expectsReply) {
 		String messageId = MessageUtils.generateMessageId("testmessage");
 		try (PipeLineSession pls = new PipeLineSession()) {
 			// Make sure the pipeline session has a security handler
 			pls.setSecurityHandler(new SpringSecurityHandler());
-
-			if(threadContext != null) {
-				pls.putAll(threadContext);
-			}
+			pls.putAll(threadContext);
 
 			String correlationId = null;
 			if (!pls.containsKey(PipeLineSession.CORRELATION_ID_KEY)) {
@@ -134,14 +132,8 @@ public class TestPipeline extends BusEndpointBase {
 			secLog.info("testing pipeline of adapter [{}] {}", adapter.getName(), (writeSecurityLogMessage ? "message [" + payload + "]" : ""));
 
 			try {
-				org.frankframework.stream.Message message;
-				if (StringUtils.isNotEmpty(payload)) {
-					message = new org.frankframework.stream.Message(payload);
-				} else {
-					message = org.frankframework.stream.Message.nullMessage();
-				}
 
-				PipeLineResult plr = adapter.processMessageDirect(messageId, message, pls);
+				PipeLineResult plr = adapter.processMessageDirect(messageId, getMessage(payload), pls);
 
 				// Only send a reply if we expect one, else it's wasted traffic...
 				return expectsReply ? convertPipelineResult(plr) : null;
@@ -149,6 +141,13 @@ public class TestPipeline extends BusEndpointBase {
 				throw new BusException("an exception occurred while processing the message", e);
 			}
 		}
+	}
+
+	private static org.frankframework.stream.@NonNull Message getMessage(@Nullable String payload) {
+		if (StringUtils.isNotEmpty(payload)) {
+			return new org.frankframework.stream.Message(payload);
+		}
+		return org.frankframework.stream.Message.nullMessage();
 	}
 
 	private AbstractMessage<?> convertPipelineResult(PipeLineResult plr) throws IOException {

--- a/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
+++ b/core/src/main/java/org/frankframework/management/bus/endpoints/TestPipeline.java
@@ -107,7 +107,7 @@ public class TestPipeline extends BusEndpointBase {
 			threadContext.putAll(getSessionKeysFromHeader(sessionKeys));
 		}
 
-		String payload = (String) message.getPayload();
+		String payload = BusMessageUtils.getPayloadAsString(message);
 		threadContext.putAll(getSessionKeysFromPayload(payload));
 
 		return processMessage(adapter, payload, threadContext, expectsReply);
@@ -134,9 +134,11 @@ public class TestPipeline extends BusEndpointBase {
 			secLog.info("testing pipeline of adapter [{}] {}", adapter.getName(), (writeSecurityLogMessage ? "message [" + payload + "]" : ""));
 
 			try {
-				org.frankframework.stream.Message message = org.frankframework.stream.Message.nullMessage();
+				org.frankframework.stream.Message message;
 				if (StringUtils.isNotEmpty(payload)) {
 					message = new org.frankframework.stream.Message(payload);
+				} else {
+					message = org.frankframework.stream.Message.nullMessage();
 				}
 
 				PipeLineResult plr = adapter.processMessageDirect(messageId, message, pls);

--- a/management-gateway/src/main/java/org/frankframework/management/bus/BusMessageUtils.java
+++ b/management-gateway/src/main/java/org/frankframework/management/bus/BusMessageUtils.java
@@ -15,6 +15,8 @@
 */
 package org.frankframework.management.bus;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -23,13 +25,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.http.MediaType;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import org.frankframework.management.bus.message.AbstractMessage;
+import org.frankframework.management.bus.message.EmptyMessage;
 import org.frankframework.util.ClassUtils;
+import org.frankframework.util.StreamUtil;
 
 public class BusMessageUtils {
 	public static final String HEADER_DATASOURCE_NAME_KEY = "datasourceName";
@@ -80,6 +86,48 @@ public class BusMessageUtils {
 
 	public static boolean containsHeader(Message<?> message, String headerName) {
 		return contains(message.getHeaders(), headerName);
+	}
+
+	public static @Nullable String getPayloadAsString(Message<?> message) {
+		int status = BusMessageUtils.getIntHeader(message, AbstractMessage.STATUS_KEY, 200);
+		if (!hasPayload(status)) {
+			return null;
+		}
+
+		String mimeType = BusMessageUtils.getHeader(message, AbstractMessage.MIMETYPE_KEY, (String)null);
+		if (mimeType != null) {
+			MediaType mime = MediaType.valueOf(mimeType);
+			if (MediaType.APPLICATION_JSON.equalsTypeAndSubtype(mime) || MediaType.TEXT_PLAIN.equalsTypeAndSubtype(mime)) {
+				return (String) message.getPayload();
+			}
+		}
+		return convertPayload(message.getPayload());
+	}
+
+
+	@NonNull
+	public static String convertPayload(Object payload) {
+		if (payload instanceof String string) {
+			return string;
+		} else if (payload instanceof byte[] bytes) {
+			return new String(bytes);
+		} else if (payload instanceof InputStream stream) {
+			try {
+				// Convert line endings to \n to show them in the browser as real line feeds
+				return StreamUtil.streamToString(stream, "\n", false);
+			} catch (IOException e) {
+				throw new BusException("unable to read message payload", e);
+			}
+		}
+		throw new BusException("unexpected message payload type [" + payload.getClass().getCanonicalName() + "]");
+	}
+
+	/**
+	 * Extracted method so it's in one place.
+	 * See {@link EmptyMessage} for more info.
+	 */
+	public static boolean hasPayload(int status) {
+		return (status == 200 || status > 204);
 	}
 
 	public static @Nullable String getHeader(Message<?> message, String headerName) {

--- a/test/src/test/java/org/frankframework/runner/PluginTest.java
+++ b/test/src/test/java/org/frankframework/runner/PluginTest.java
@@ -22,7 +22,6 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 
-import org.frankframework.console.util.ResponseUtils;
 import org.frankframework.management.bus.BusAction;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.BusTopic;
@@ -89,6 +88,6 @@ class PluginTest {
 		Message<Object> response = gateway.sendSyncMessage(builder.build(null));
 
 		assertEquals("SUCCESS", BusMessageUtils.getHeader(response, AbstractMessage.STATE_KEY));
-		assertEquals("Niels was here!", ResponseUtils.parseAsString(response));
+		assertEquals("Niels was here!", BusMessageUtils.getPayloadAsString(response));
 	}
 }


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
