### PR TITLE
Redelivery Backoff-Delay Issues

### DIFF
--- a/core/src/main/java/org/frankframework/core/IKnowsDeliveryCount.java
+++ b/core/src/main/java/org/frankframework/core/IKnowsDeliveryCount.java
@@ -26,7 +26,7 @@ import org.frankframework.receivers.RawMessageWrapper;
  * @author  Gerrit van Brakel
  * @since	4.9
  */
-public interface IKnowsDeliveryCount<M> extends IListener<M> {
+public interface IKnowsDeliveryCount<M> extends IListener<M>, IRedeliveringListener<M> {
 
 	int getDeliveryCount(@NonNull RawMessageWrapper<M> rawMessage);
 

--- a/core/src/main/java/org/frankframework/core/IKnowsDeliveryCount.java
+++ b/core/src/main/java/org/frankframework/core/IKnowsDeliveryCount.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2023-2024 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2023-2026 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 */
 package org.frankframework.core;
 
+import org.jspecify.annotations.NonNull;
+
 import org.frankframework.receivers.RawMessageWrapper;
 
 /**
@@ -26,6 +28,6 @@ import org.frankframework.receivers.RawMessageWrapper;
  */
 public interface IKnowsDeliveryCount<M> extends IListener<M> {
 
-	int getDeliveryCount(RawMessageWrapper<M> rawMessage);
+	int getDeliveryCount(@NonNull RawMessageWrapper<M> rawMessage);
 
 }

--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -45,6 +45,7 @@ import lombok.Setter;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.IHasProcessState;
 import org.frankframework.core.IPeekableListener;
+import org.frankframework.core.IRedeliveringListener;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
@@ -71,7 +72,7 @@ import org.frankframework.util.StringUtil;
  * @since   4.7
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
-public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>, IHasProcessState<M>, ReceiverAware<M> {
+public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>, IHasProcessState<M>, IRedeliveringListener<M>, ReceiverAware<M> {
 
 	public static final String ADDITIONAL_QUERY_FIELDS_KEY = "ADDITIONAL_QUERY_FIELDS";
 
@@ -182,6 +183,11 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	@Override
 	public void closeThread(@NonNull Map<String, Object> threadContext) throws ListenerException {
 		// nothing special
+	}
+
+	@Override
+	public boolean messageWillBeRedeliveredOnExitStateError() {
+		return true;
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/org/frankframework/jdbc/JdbcListener.java
@@ -187,7 +187,7 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 
 	@Override
 	public boolean messageWillBeRedeliveredOnExitStateError() {
-		return true;
+		return knownProcessStates().contains(ProcessState.INPROCESS);
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -233,16 +233,17 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 
 	public static final String RCV_MESSAGE_LOG_COMMENTS = "log";
 
+	public static final long START_BACKOFF_DELAY_MS = 125L;
 	public static final int CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY = AppConstants.getInstance().getInt("receiver.consecutiveErrorsBeforeBackoffDelay", 10);
-	public static final int RCV_SUSPENSION_MESSAGE_THRESHOLD=60;
+	public static final int RCV_SUSPENSION_MESSAGE_THRESHOLD = 60;
 	public static final String DEFAULT_MAX_BACKOFF_DELAY_KEY = "receiver.defaultMaxBackoffDelay";
 	/**
 	 * Should be smaller than the transaction timeout as the delay takes place
 	 * within the transaction. WebSphere default transaction timeout is 120.
 	 */
-	public static final int DEFAULT_MAX_BACKOFF_DELAY = 60;
+	public static final int DEFAULT_MAX_BACKOFF_DELAY_SECONDS = 60;
 	public static final String RETRY_FLAG_SESSION_KEY = "retry"; // a session variable with this key will be set "true" if the message is manually retried, is redelivered, or it's messageid has been seen before
-	private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
+	private final @NonNull AtomicInteger consecutiveErrors = new AtomicInteger(0);
 
 	public enum OnError {
 		/** Don't stop the receiver when an error occurs.*/
@@ -266,17 +267,17 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	private @Getter int numThreads = 1;
 	// the number of threads that are actively polling for messages (concurrently, only for pulling listeners)
 	private @Getter int numThreadsPolling = 1;
-	private @Getter int pollInterval=10;
-	private @Getter int startTimeout=60;
-	private @Getter int stopTimeout=60;
+	private @Getter int pollInterval = 10;
+	private @Getter int startTimeout = 60;
+	private @Getter int stopTimeout = 60;
 
 	private @Getter boolean forceRetryFlag = false;
-	private @Getter boolean checkForDuplicates=false;
+	private @Getter boolean checkForDuplicates = false;
 	public enum CheckForDuplicatesMethod { MESSAGEID, CORRELATIONID }
 
-	private @Getter CheckForDuplicatesMethod checkForDuplicatesMethod=CheckForDuplicatesMethod.MESSAGEID;
-	private @Getter Integer maxRetries = null;
-	private Integer maxBackoffDelay = null;
+	private @Getter @NonNull CheckForDuplicatesMethod checkForDuplicatesMethod=CheckForDuplicatesMethod.MESSAGEID;
+	private @Getter @Nullable Integer maxRetries = null;
+	private @Getter @Nullable Long maxBackoffDelayMs = null;
 	private @Getter int processResultCacheSize = 100;
 
 	/**
@@ -284,34 +285,34 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	 * configured with process state {@link ProcessState#INPROCESS}.
 	 * In all other circumstances, it is {@code false}.
 	 */
-	private @Getter boolean supportProgrammaticRetry=false;
+	private @Getter boolean supportProgrammaticRetry = false;
 
-	private @Getter String correlationIDXPath;
-	private @Getter String correlationIDNamespaceDefs;
-	private @Getter String correlationIDStyleSheet;
+	private @Getter @Nullable String correlationIDXPath;
+	private @Getter @Nullable String correlationIDNamespaceDefs;
+	private @Getter @Nullable String correlationIDStyleSheet;
 
-	private @Getter String labelXPath;
-	private @Getter String labelNamespaceDefs;
-	private @Getter String labelStyleSheet;
+	private @Getter @Nullable String labelXPath;
+	private @Getter @Nullable String labelNamespaceDefs;
+	private @Getter @Nullable String labelStyleSheet;
 
-	private @Getter String chompCharSize = null;
-	private @Getter String elementToMove = null;
-	private @Getter String elementToMoveSessionKey = null;
-	private @Getter String elementToMoveChain = null;
+	private @Getter @Nullable String chompCharSize = null;
+	private @Getter @Nullable String elementToMove = null;
+	private @Getter @Nullable String elementToMoveSessionKey = null;
+	private @Getter @Nullable String elementToMoveChain = null;
 	private @Getter boolean removeCompactMsgNamespaces = true;
 
-	private @Getter String hideRegex = null;
-	private Pattern hideRegexPattern = null;
-	private @Getter HideMethod hideMethod = HideMethod.ALL;
-	private @Getter String hiddenInputSessionKeys=null;
+	private @Getter @Nullable String hideRegex = null;
+	private @Nullable Pattern hideRegexPattern = null;
+	private @Getter @NonNull HideMethod hideMethod = HideMethod.ALL;
+	private @Getter @Nullable String hiddenInputSessionKeys = null;
 
-	private final AtomicInteger numberOfExceptionsCaughtWithoutMessageBeingReceived = new AtomicInteger();
+	private final @NonNull AtomicInteger numberOfExceptionsCaughtWithoutMessageBeingReceived = new AtomicInteger();
 	private int numberOfExceptionsCaughtWithoutMessageBeingReceivedThreshold = 5;
 	private @Getter boolean numberOfExceptionsCaughtWithoutMessageBeingReceivedThresholdReached=false;
 
-	private int currentBackoffDelay = 1;
+	private @Getter long currentBackoffDelayMs = START_BACKOFF_DELAY_MS;
 
-	private boolean suspensionMessagePending=false;
+	private boolean suspensionMessagePending = false;
 	private @Getter boolean isConfigured = false;
 
 	protected final RunStateManager runState = new RunStateManager();
@@ -339,8 +340,8 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	private @Getter ICorrelatedSender sender = null; // reply-sender
 	private final Map<ProcessState,IMessageBrowser<?>> messageBrowsers = new EnumMap<>(ProcessState.class);
 
-	private TransformerPool correlationIDTp=null;
-	private TransformerPool labelTp=null;
+	private @Nullable TransformerPool correlationIDTp = null;
+	private @Nullable TransformerPool labelTp = null;
 
 	private @Setter MetricsInitializer configurationMetrics;
 
@@ -688,7 +689,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 					maxRetries = 1;
 				}
 			}
-			maxBackoffDelay = calculateAdjustedMaxBackoffDelay(maxBackoffDelay);
+			maxBackoffDelayMs = calculateAdjustedMaxBackoffDelay(maxBackoffDelayMs);
 		} catch (Throwable t) {
 			ConfigurationException e;
 			if (t instanceof ConfigurationException exception) {
@@ -705,14 +706,14 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 		throwEvent(RCV_CONFIGURED_MONITOR_EVENT);
 		isConfigured = true;
 
-		if(isInRunState(RunState.ERROR)) { // if the adapter was previously in state ERROR, after a successful configure, reset it's state
+		if (isInRunState(RunState.ERROR)) { // if the adapter was previously in state ERROR, after a successful configure, reset it's state
 			runState.setRunState(RunState.STOPPED);
 		}
 	}
 
-	protected int calculateAdjustedMaxBackoffDelay(Integer configuredMaxBackoffDelay) {
-		int backoffDelay = configuredMaxBackoffDelay != null ? configuredMaxBackoffDelay : AppConstants.getInstance(configurationClassLoader).getInt(DEFAULT_MAX_BACKOFF_DELAY_KEY, DEFAULT_MAX_BACKOFF_DELAY);
-		int transactionTimeoutCap = getActualTransactionTimeout() / 2;
+	protected long calculateAdjustedMaxBackoffDelay(Long configuredMaxBackoffDelay) {
+		long backoffDelay = configuredMaxBackoffDelay != null ? configuredMaxBackoffDelay : (1000L * AppConstants.getInstance(configurationClassLoader).getLong(DEFAULT_MAX_BACKOFF_DELAY_KEY, DEFAULT_MAX_BACKOFF_DELAY_SECONDS));
+		long transactionTimeoutCap = (getActualTransactionTimeout() / 2) * 1000L;
 		if (backoffDelay > transactionTimeoutCap) {
 			ConfigurationWarnings.add(this.getAdapter(), log, "Maximum backoff delay reduced to %d from %d to avoid the delay causing transaction timeouts".formatted(transactionTimeoutCap, backoffDelay), SuppressKeys.CONFIGURATION_VALIDATION);
 			return transactionTimeoutCap;
@@ -1731,7 +1732,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	public void exceptionThrown(String errorMessage, Throwable t) {
 		switch (getOnError()) {
 			case CONTINUE:
-				if(numberOfExceptionsCaughtWithoutMessageBeingReceived.incrementAndGet() > numberOfExceptionsCaughtWithoutMessageBeingReceivedThreshold) {
+				if (numberOfExceptionsCaughtWithoutMessageBeingReceived.incrementAndGet() > numberOfExceptionsCaughtWithoutMessageBeingReceivedThreshold) {
 					numberOfExceptionsCaughtWithoutMessageBeingReceivedThresholdReached=true;
 					log.warn("number of exceptions caught without message being received threshold is reached; changing the adapter status to 'warning'");
 				}
@@ -1769,31 +1770,31 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 				suspensionMessagePending=false;
 				throwEvent(RCV_RESUMED_MONITOR_EVENT);
 			}
-			if (currentBackoffDelay > 1) {
-				log.info("Resetting retry-delay from {} seconds to 1 second", currentBackoffDelay);
-				currentBackoffDelay = 1;
+			if (currentBackoffDelayMs > 1) {
+				log.info("Resetting retry-delay from {} seconds to 125 milliseconds", currentBackoffDelayMs);
+				currentBackoffDelayMs = START_BACKOFF_DELAY_MS;
 			}
 		}
 	}
 
 	public void increaseBackoffIntervalAndWait(@Nullable Throwable t, @NonNull String description) {
 		// Only delay if there are multiple consecutive errors
-		if (consecutiveErrors.get() < CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY || maxBackoffDelay == 0) {
+		if (consecutiveErrors.get() <= CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY || maxBackoffDelayMs == 0L) {
 			error(description, t);
 			return;
 		}
-		int currentDelay;
+		long currentDelay;
 		synchronized (this) {
-			currentDelay = currentBackoffDelay;
-			currentBackoffDelay = currentBackoffDelay * 2;
-			if (currentBackoffDelay > maxBackoffDelay) {
-				currentBackoffDelay = maxBackoffDelay;
+			currentDelay = currentBackoffDelayMs;
+			currentBackoffDelayMs = currentBackoffDelayMs * 2;
+			if (currentBackoffDelayMs > maxBackoffDelayMs) {
+				currentBackoffDelayMs = maxBackoffDelayMs;
 			}
 		}
-		if (currentDelay > 1) {
-			error(description+", will continue retrieving messages in [" + currentDelay + "] seconds", t);
+		if (currentDelay > 1L) {
+			error(description+", will continue retrieving messages in [" + currentDelay + "] milliseconds", t);
 		} else {
-			log.info("{}, no delay in retrieving messages. Details: {}", description, currentDelay, t != null ? t.getMessage() : "NA");
+			log.info("{}, no delay in retrieving messages. Details: {}", description, t != null ? t.getMessage() : "NA");
 		}
 		synchronized (this) {
 			if (currentDelay * 2 > RCV_SUSPENSION_MESSAGE_THRESHOLD && !suspensionMessagePending) {
@@ -1823,19 +1824,16 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	}
 
 	/**
-	 * Suspend the receiver for {@code delayTimeInSeconds} seconds
-	 * @param delayTimeInSeconds Number of seconds the receiver thread should be suspended from processing new messages.
+	 * Suspend the receiver for {@code delayTimeInMs} milliseconds
+	 * @param delayTimeInMs Number of milliseconds the receiver thread should be suspended from processing new messages.
 	 */
-	public void suspendReceiverThread(int delayTimeInSeconds) {
-		int currentInterval = delayTimeInSeconds;
-		while (isInRunState(RunState.STARTED) && currentInterval-- > 0) {
+	public void suspendReceiverThread(long delayTimeInMs) {
+		if (isInRunState(RunState.STARTED) && delayTimeInMs > 0) {
 			try {
-				Thread.sleep(1000L);
+				Thread.sleep(delayTimeInMs);
 			} catch (InterruptedException e) {
 				error("sleep interrupted", e);
-//				stop();?????????????
 				Thread.currentThread().interrupt();
-				break;
 			}
 		}
 	}
@@ -2026,9 +2024,9 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	}
 
 	public void resetNumberOfExceptionsCaughtWithoutMessageBeingReceived() {
-		if(log.isDebugEnabled()) log.debug("resetting [numberOfExceptionsCaughtWithoutMessageBeingReceived] to 0");
+		if (log.isDebugEnabled()) log.debug("resetting [numberOfExceptionsCaughtWithoutMessageBeingReceived] to 0");
 		numberOfExceptionsCaughtWithoutMessageBeingReceived.set(0);
-		numberOfExceptionsCaughtWithoutMessageBeingReceivedThresholdReached=false;
+		numberOfExceptionsCaughtWithoutMessageBeingReceivedThresholdReached = false;
 	}
 
 	/**
@@ -2298,7 +2296,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	 * </p>
 	 * @param maxBackoffDelaySeconds Maximum backoff-time in seconds before retrying a message, after an error occurred during processing.
 	 */
-	public void setMaxBackoffDelay(Integer maxBackoffDelaySeconds) {
-		this.maxBackoffDelay = maxBackoffDelaySeconds;
+	public void setMaxBackoffDelay(Long maxBackoffDelaySeconds) {
+		this.maxBackoffDelayMs = maxBackoffDelaySeconds == null ? null : maxBackoffDelaySeconds * 1000L;
 	}
 }

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -678,7 +678,10 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 				}
 			}
 
-			if (maxRetries == null) {
+			if (!(getListener() instanceof IRedeliveringListener<M>)) {
+				log.debug("Listener [{}:{}] does not support message redelivery, maxRetries set to 0", () -> getListener().getClass().getSimpleName(), () -> getListener().getName());
+				maxRetries = 0;
+			} else if (maxRetries == null) {
 				if (getListener() instanceof IKnowsDeliveryCount<M>) {
 					maxRetries = 3;
 				} else {
@@ -1391,7 +1394,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 						} else if (messageInError && !retryStatusAlreadyChecked) {
 							// Only do this if history has not already been checked previously by the caller.
 							// If it has, then the caller is also responsible for handling the retry-interval.
-							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] is in status error: [" + statusMessage + "]");
+							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] is in status error, no (more) retries: [" + statusMessage + "]");
 						}
 					}
 				}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -53,6 +53,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.xml.sax.SAXException;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import lombok.Getter;
 import lombok.Setter;
@@ -232,6 +233,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 
 	public static final String RCV_MESSAGE_LOG_COMMENTS = "log";
 
+	public static final int CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY = AppConstants.getInstance().getInt("receiver.consecutiveErrorsBeforeBackoffDelay", 2);
 	public static final int RCV_SUSPENSION_MESSAGE_THRESHOLD=60;
 	public static final String DEFAULT_MAX_BACKOFF_DELAY_KEY = "receiver.defaultMaxBackoffDelay";
 	/**
@@ -240,6 +242,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	 */
 	public static final int DEFAULT_MAX_BACKOFF_DELAY = 60;
 	public static final String RETRY_FLAG_SESSION_KEY = "retry"; // a session variable with this key will be set "true" if the message is manually retried, is redelivered, or it's messageid has been seen before
+	private final AtomicInteger consecutiveErrors = new AtomicInteger(0);
 
 	public enum OnError {
 		/** Don't stop the receiver when an error occurs.*/
@@ -306,7 +309,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	private int numberOfExceptionsCaughtWithoutMessageBeingReceivedThreshold = 5;
 	private @Getter boolean numberOfExceptionsCaughtWithoutMessageBeingReceivedThresholdReached=false;
 
-	private int currentBackoffDelay =1;
+	private int currentBackoffDelay = 1;
 
 	private boolean suspensionMessagePending=false;
 	private @Getter boolean isConfigured = false;
@@ -319,9 +322,9 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	private long lastMessageDate = 0;
 
 	// number of messages received
-	private io.micrometer.core.instrument.Counter numReceived;
-	private io.micrometer.core.instrument.Counter numRetried;
-	private io.micrometer.core.instrument.Counter numRejected;
+	private Counter numReceived;
+	private Counter numRetried;
+	private Counter numRejected;
 
 	private final List<DistributionSummary> processStatistics = new ArrayList<>();
 
@@ -1374,13 +1377,17 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 							throw new ListenerException(logPrefix +msg);
 						}
 					} finally {
+						if (messageInError) {
+							consecutiveErrors.incrementAndGet();
+						} else {
+							consecutiveErrors.set(0);
+							resetBackoffDelay();
+						}
 						getAdapter().logToMessageLogWithMessageContentsOrSize(Level.INFO, "Adapter "+(!messageInError ? "Success" : "Error"), "result", result);
 						if (messageInError && !retryStatusAlreadyChecked && !isDeliveryRetryLimitExceededAfterMessageProcessed(messageWrapper)) {
 							// Only do this if history has not already been checked previously by the caller.
 							// If it has, then the caller is also responsible for handling the retry-interval.
-							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] has already been received [" + prci.receiveCount + "] times; maxRetries=[" + getMaxRetries() + "]; error in procesing: [" + statusMessage + "]");
-						} else if (!messageInError) {
-							resetBackoffDelay();
+							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] has already been received [" + prci.receiveCount + "] times; maxRetries=[" + getMaxRetries() + "]; error in processing: [" + statusMessage + "]");
 						}
 					}
 				}
@@ -1636,6 +1643,8 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 	 * @return {@code true} if message should no longer be retried, {@code false} if it should.
 	 */
 	protected boolean isDeliveryRetryLimitExceededAfterMessageProcessed(@NonNull final RawMessageWrapper<M> messageWrapper) {
+		if (!(getListener() instanceof IRedeliveringListener<M>))
+			return true; // No redelivery supported by listener so always treat as if the limit has already been exceeded.
 		if (getMaxRetries() < 0) {
 			log.debug("{} Receiver has no retry limit so message will be retried", this::getLogPrefix);
 			return false;
@@ -1760,7 +1769,11 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 		}
 	}
 
-	public void increaseBackoffIntervalAndWait(Throwable t, String description) {
+	public void increaseBackoffIntervalAndWait(@Nullable Throwable t, @Nullable String description) {
+		// Only delay if there are multiple consecutive errors
+		if (consecutiveErrors.get() < CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY) {
+			return;
+		}
 		int currentDelay;
 		synchronized (this) {
 			currentDelay = currentBackoffDelay;
@@ -1775,7 +1788,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 			log.info("{}, will continue retrieving messages in [{}] seconds. Details: {}", description, currentDelay, t != null ? t.getMessage() : "NA");
 		}
 		synchronized (this) {
-			if (currentDelay*2 > RCV_SUSPENSION_MESSAGE_THRESHOLD && !suspensionMessagePending) {
+			if (currentDelay* 2 > RCV_SUSPENSION_MESSAGE_THRESHOLD && !suspensionMessagePending) {
 				suspensionMessagePending=true;
 				throwEvent(RCV_SUSPENDED_MONITOR_EVENT);
 			}
@@ -1812,7 +1825,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 				Thread.sleep(1000L);
 			} catch (Exception e2) {
 				error("sleep interrupted", e2);
-				stop();
+//				stop();?????????????
 				Thread.currentThread().interrupt();
 			}
 		}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -1388,7 +1388,9 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 							// Only do this if history has not already been checked previously by the caller.
 							// If it has, then the caller is also responsible for handling the retry-interval.
 							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] has already been received [" + prci.receiveCount + "] times; maxRetries=[" + getMaxRetries() + "]; error in processing: [" + statusMessage + "]");
-						} else if (messageInError) {
+						} else if (messageInError && !retryStatusAlreadyChecked) {
+							// Only do this if history has not already been checked previously by the caller.
+							// If it has, then the caller is also responsible for handling the retry-interval.
 							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] is in status error: [" + statusMessage + "]");
 						}
 					}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -233,7 +233,7 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 
 	public static final String RCV_MESSAGE_LOG_COMMENTS = "log";
 
-	public static final int CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY = AppConstants.getInstance().getInt("receiver.consecutiveErrorsBeforeBackoffDelay", 2);
+	public static final int CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY = AppConstants.getInstance().getInt("receiver.consecutiveErrorsBeforeBackoffDelay", 10);
 	public static final int RCV_SUSPENSION_MESSAGE_THRESHOLD=60;
 	public static final String DEFAULT_MAX_BACKOFF_DELAY_KEY = "receiver.defaultMaxBackoffDelay";
 	/**

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -1388,6 +1388,8 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 							// Only do this if history has not already been checked previously by the caller.
 							// If it has, then the caller is also responsible for handling the retry-interval.
 							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] has already been received [" + prci.receiveCount + "] times; maxRetries=[" + getMaxRetries() + "]; error in processing: [" + statusMessage + "]");
+						} else if (messageInError) {
+							increaseBackoffIntervalAndWait(null, getLogPrefix() + "message with messageId [" + messageId + "] is in status error: [" + statusMessage + "]");
 						}
 					}
 				}
@@ -1783,13 +1785,13 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 				currentBackoffDelay = maxBackoffDelay;
 			}
 		}
-		if (currentDelay>1) {
+		if (currentDelay > 1) {
 			error(description+", will continue retrieving messages in [" + currentDelay + "] seconds", t);
 		} else {
-			log.info("{}, will continue retrieving messages in [{}] seconds. Details: {}", description, currentDelay, t != null ? t.getMessage() : "NA");
+			log.info("{}, no delay in retrieving messages. Details: {}", description, currentDelay, t != null ? t.getMessage() : "NA");
 		}
 		synchronized (this) {
-			if (currentDelay* 2 > RCV_SUSPENSION_MESSAGE_THRESHOLD && !suspensionMessagePending) {
+			if (currentDelay * 2 > RCV_SUSPENSION_MESSAGE_THRESHOLD && !suspensionMessagePending) {
 				suspensionMessagePending=true;
 				throwEvent(RCV_SUSPENDED_MONITOR_EVENT);
 			}
@@ -1824,10 +1826,11 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 		while (isInRunState(RunState.STARTED) && currentInterval-- > 0) {
 			try {
 				Thread.sleep(1000L);
-			} catch (Exception e2) {
-				error("sleep interrupted", e2);
+			} catch (InterruptedException e) {
+				error("sleep interrupted", e);
 //				stop();?????????????
 				Thread.currentThread().interrupt();
+				break;
 			}
 		}
 	}

--- a/core/src/main/java/org/frankframework/receivers/Receiver.java
+++ b/core/src/main/java/org/frankframework/receivers/Receiver.java
@@ -1769,9 +1769,10 @@ public class Receiver<M> extends TransactionAttributes implements ManagableLifec
 		}
 	}
 
-	public void increaseBackoffIntervalAndWait(@Nullable Throwable t, @Nullable String description) {
+	public void increaseBackoffIntervalAndWait(@Nullable Throwable t, @NonNull String description) {
 		// Only delay if there are multiple consecutive errors
-		if (consecutiveErrors.get() < CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY) {
+		if (consecutiveErrors.get() < CONSECUTIVE_ERRORS_BEFORE_BACKOFF_DELAY || maxBackoffDelay == 0) {
+			error(description, t);
 			return;
 		}
 		int currentDelay;

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -131,7 +131,7 @@ browse.errors.order = ASC
 #### Receiver
 
 ## When a receiver has repeated errors, it can slow down processing until errors are resolved. This slowdown follows an exponential backoff algorithm, capped by
-## the maxBackoffDelay. The default for that is set here, and can be overridden per received. The value is in seconds.
+## the maxBackoffDelay. The default for that is set here, and can be overridden per receiver. The value is in seconds.
 receiver.defaultMaxBackoffDelay=60
 ## This setting configures the maximum number of consecutive messages in error before the exponential backoff hits.
 receiver.consecutiveErrorsBeforeBackoffDelay=10

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -130,7 +130,11 @@ browse.errors.order = ASC
 ####
 #### Receiver
 
+## When a receiver has repeated errors, it can slow down processing until errors are resolved. This slowdown follows an exponential backoff algorithm, capped by
+## the maxBackoffDelay. The default for that is set here, and can be overridden per received. The value is in seconds.
 receiver.defaultMaxBackoffDelay=60
+## This setting configures the maximum number of consecutive messages in error before the exponential backoff hits.
+receiver.consecutiveErrorsBeforeBackoffDelay=10
 ## cron pattern to be used by recover adapters
 recover.adapters.interval=300000
 

--- a/core/src/test/java/org/frankframework/receivers/MockPullingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/MockPullingListener.java
@@ -9,9 +9,10 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import org.frankframework.core.IPullingListener;
+import org.frankframework.core.IRedeliveringListener;
 import org.frankframework.core.ListenerException;
 
-public class MockPullingListener extends MockListenerBase implements IPullingListener<String> {
+public class MockPullingListener extends MockListenerBase implements IPullingListener<String>, IRedeliveringListener<String> {
 	private final BlockingQueue<String> value = new ArrayBlockingQueue<>(5);
 
 	@NonNull
@@ -42,4 +43,8 @@ public class MockPullingListener extends MockListenerBase implements IPullingLis
 		return null;
 	}
 
+	@Override
+	public boolean messageWillBeRedeliveredOnExitStateError() {
+		return true;
+	}
 }

--- a/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
@@ -1,5 +1,7 @@
 package org.frankframework.receivers;
 
+import org.jspecify.annotations.NonNull;
+
 import lombok.Setter;
 
 import org.frankframework.core.IKnowsDeliveryCount;
@@ -33,7 +35,7 @@ public class MockPushingListener extends MockListenerBase implements IPushingLis
 	}
 
 	@Override
-	public int getDeliveryCount(RawMessageWrapper<String> rawMessage) {
+	public int getDeliveryCount(@NonNull RawMessageWrapper<String> rawMessage) {
 		return mockedDeliveryCount;
 	}
 }

--- a/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
+++ b/core/src/test/java/org/frankframework/receivers/MockPushingListener.java
@@ -35,6 +35,11 @@ public class MockPushingListener extends MockListenerBase implements IPushingLis
 	}
 
 	@Override
+	public boolean messageWillBeRedeliveredOnExitStateError() {
+		return true;
+	}
+
+	@Override
 	public int getDeliveryCount(@NonNull RawMessageWrapper<String> rawMessage) {
 		return mockedDeliveryCount;
 	}

--- a/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
+++ b/core/src/test/java/org/frankframework/receivers/ReceiverTest.java
@@ -31,9 +31,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -120,6 +122,7 @@ import org.frankframework.testutil.TestAssertions;
 import org.frankframework.testutil.TestConfiguration;
 import org.frankframework.testutil.TransactionManagerType;
 import org.frankframework.testutil.mock.DataSourceFactoryMock;
+import org.frankframework.util.MessageUtils;
 import org.frankframework.util.RunState;
 import org.frankframework.util.SpringUtils;
 
@@ -175,7 +178,7 @@ public class ReceiverTest {
 		receiver.setStartTimeout(2);
 		receiver.setStopTimeout(2);
 		// To speed up test, we don't actually sleep
-		doNothing().when(receiver).suspendReceiverThread(anyInt());
+		doNothing().when(receiver).suspendReceiverThread(anyLong());
 		DummySender sender = SpringUtils.createBean(adapter);
 		receiver.setSender(sender);
 
@@ -183,11 +186,11 @@ public class ReceiverTest {
 		return receiver;
 	}
 
-	public <M> Adapter setupAdapter() throws Exception {
+	public Adapter setupAdapter() throws Exception {
 		return setupAdapter(ExitState.SUCCESS);
 	}
 
-	public <M> Adapter setupAdapter(ExitState exitState) throws Exception {
+	public Adapter setupAdapter(ExitState exitState) throws Exception {
 		Adapter adapter = spy(configuration.createBean(Adapter.class));
 		adapter.setName(adapterName);
 
@@ -214,7 +217,7 @@ public class ReceiverTest {
 		return adapter;
 	}
 
-	public Receiver<Serializable> setupReceiverWithListener(Adapter adapter, IListener listener, ITransactionalStorage<Serializable> errorStorage) {
+	public Receiver<Serializable> setupReceiverWithListener(Adapter adapter, IListener<Serializable> listener, ITransactionalStorage<Serializable> errorStorage) {
 		@SuppressWarnings("unchecked")
 		Receiver<Serializable> receiver = spy(SpringUtils.createBean(adapter, Receiver.class));
 		receiver.setApplicationContext(adapter); // Required because we have to spy the Adapter
@@ -225,7 +228,7 @@ public class ReceiverTest {
 		receiver.setErrorStorage(errorStorage);
 		receiver.setNumThreads(2);
 		// To speed up test, we don't actually sleep
-		doNothing().when(receiver).suspendReceiverThread(anyInt());
+		doNothing().when(receiver).suspendReceiverThread(anyLong());
 		adapter.addReceiver(receiver);
 		return receiver;
 	}
@@ -246,8 +249,8 @@ public class ReceiverTest {
 		return listener;
 	}
 
-	public JavaListener setupJavaListener() throws Exception {
-		JavaListener listener = spy(new JavaListener());
+	public JavaListener<Serializable> setupJavaListener() throws Exception {
+		JavaListener<Serializable> listener = spy(new JavaListener<>());
 		listener.setName("javaListener");
 
 		doReturn("dummy-destination").when(listener).getPhysicalDestinationName();
@@ -1152,7 +1155,7 @@ public class ReceiverTest {
 		// Arrange
 		configuration = buildNarayanaTransactionManagerConfiguration();
 		ITransactionalStorage<Serializable> errorStorage = setupErrorStorage();
-		JavaListener listener = setupJavaListener();
+		JavaListener<Serializable> listener = setupJavaListener();
 		Adapter adapter = setupAdapter();
 		Receiver<Serializable> receiver = setupReceiverWithListener(adapter, listener, errorStorage);
 
@@ -1188,11 +1191,11 @@ public class ReceiverTest {
 
 	@ParameterizedTest
 	@CsvSource({
-			"500, 50, true",
-			"50, 50, false",
-			"40, 40, false"
+			"500, 50000, true",
+			" 50, 50000, false",
+			" 40, 40000, false"
 	})
-	public void testMaxBackoffDelayAdjustment(Integer maxBackoffDelay, int expectedBackoffDelay, boolean expectConfigWarning) {
+	public void testMaxBackoffDelayAdjustment(Long maxBackoffDelaySeconds, int expectedBackoffDelayMs, boolean expectConfigWarning) {
 		// Arrange
 		configuration = buildDataSourceTransactionManagerConfiguration();
 		Adapter adapter = configuration.createBean();
@@ -1201,20 +1204,89 @@ public class ReceiverTest {
 
 		Receiver<String> receiver = SpringUtils.createBean(adapter);
 
-		receiver.setMaxBackoffDelay(maxBackoffDelay);
+		receiver.setMaxBackoffDelay(maxBackoffDelaySeconds);
 		receiver.setTransactionTimeout(100);
 
 		// Act
-		int actualBackoffDelay = receiver.calculateAdjustedMaxBackoffDelay(maxBackoffDelay);
+		long actualBackoffDelay = receiver.calculateAdjustedMaxBackoffDelay(receiver.getMaxBackoffDelayMs());
 
 		// Assert
-		assertEquals(expectedBackoffDelay, actualBackoffDelay);
+		assertEquals(expectedBackoffDelayMs, actualBackoffDelay);
 		if (expectConfigWarning) {
 			assertEquals(1, configWarnings.size(), "There should have been exactly 1 config warning");
 			assertThat(configWarnings.get(0), containsString("Maximum backoff delay reduced"));
 		} else {
 			assertTrue(configWarnings.isEmpty(), "There should not have been any config warnings");
 		}
+	}
+
+	@Test
+	void testMessageDeliveryDelay() throws Exception {
+		// Arrange
+		configuration = buildDataSourceTransactionManagerConfiguration();
+		ITransactionalStorage<Serializable> errorStorage = setupErrorStorage();
+		JavaListener<Serializable> listener = setupJavaListener();
+		Adapter adapter = setupAdapter();
+		Receiver<Serializable> receiver = setupReceiverWithListener(adapter, listener, errorStorage);
+
+		receiver.setMaxBackoffDelay(5L);
+
+		// Don't actually delay, but should be possible to verify
+		doNothing().when(receiver).suspendReceiverThread(anyLong());
+
+		doThrow(new ListenerException("forced error")).when(adapter).processMessageWithExceptions(startsWith("error-"), any(), any());
+		PipeLineResult successResult = new PipeLineResult();
+		successResult.setState(ExitState.SUCCESS);
+		doReturn(successResult).when(adapter).processMessageWithExceptions(startsWith("success-"), any(), any());
+
+		configuration.configure();
+		configuration.start();
+		waitForState(receiver, RunState.STARTED);
+
+		// Act
+		for (int i = 0; i < 20; ++i) {
+			assertThrows(ListenerException.class, () -> receiver.processRequest(listener, new MessageWrapper<>(Message.nullMessage(), MessageUtils.generateMessageId("error-"), MessageUtils.generateMessageId()), new PipeLineSession()));
+		}
+
+		// Assert
+		assertEquals(5_000L, receiver.getMaxBackoffDelayMs());
+		assertEquals(5_000L, receiver.getCurrentBackoffDelayMs());
+		verify(receiver, times(10)).suspendReceiverThread(anyLong());
+		verify(receiver, times(1)).suspendReceiverThread(125L);
+		verify(receiver, times(1)).suspendReceiverThread(250L);
+		verify(receiver, times(1)).suspendReceiverThread(500L);
+		verify(receiver, times(1)).suspendReceiverThread(1_000L);
+		verify(receiver, times(1)).suspendReceiverThread(2_000L);
+		verify(receiver, times(1)).suspendReceiverThread(4_000L);
+		verify(receiver, times(4)).suspendReceiverThread(5_000L);
+
+		reset(receiver);
+
+		// Act
+		receiver.processRequest(listener, new MessageWrapper<>(Message.nullMessage(), MessageUtils.generateMessageId("success-"), MessageUtils.generateMessageId()), new PipeLineSession());
+
+		// Assert
+		// Verify that the backoff-delay has been reset after a successful request
+		assertEquals(125L, receiver.getCurrentBackoffDelayMs());
+		verify(receiver, never()).suspendReceiverThread(anyLong());
+
+		// Repeat the errors and verify error behaviour occurs again after errors
+		// Act
+		for (int i = 0; i < 20; ++i) {
+			assertThrows(ListenerException.class, () -> receiver.processRequest(listener, new MessageWrapper<>(Message.nullMessage(), MessageUtils.generateMessageId("error-"), MessageUtils.generateMessageId()), new PipeLineSession()));
+		}
+
+		// Assert
+		assertEquals(5_000L, receiver.getMaxBackoffDelayMs());
+		assertEquals(5_000L, receiver.getCurrentBackoffDelayMs());
+		verify(receiver, times(10)).suspendReceiverThread(anyLong());
+		verify(receiver, times(1)).suspendReceiverThread(125L);
+		verify(receiver, times(1)).suspendReceiverThread(250L);
+		verify(receiver, times(1)).suspendReceiverThread(500L);
+		verify(receiver, times(1)).suspendReceiverThread(1_000L);
+		verify(receiver, times(1)).suspendReceiverThread(2_000L);
+		verify(receiver, times(1)).suspendReceiverThread(4_000L);
+		verify(receiver, times(4)).suspendReceiverThread(5_000L);
 	}
 
 	@ParameterizedTest

--- a/core/src/test/java/org/frankframework/receivers/TestReceiverOnError.java
+++ b/core/src/test/java/org/frankframework/receivers/TestReceiverOnError.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -86,7 +86,7 @@ public class TestReceiverOnError {
 		@SuppressWarnings("unchecked")
 		Receiver<String> receiver = spy(SpringUtils.createBean(adapter, Receiver.class));
 		receiver.setApplicationContext(adapter); // Required because we have to spy the Adapter
-		doNothing().when(receiver).suspendReceiverThread(anyInt());
+		doNothing().when(receiver).suspendReceiverThread(anyLong());
 		receiver.setListener(listener);
 		receiver.setName("receiver");
 		receiver.setStartTimeout(2);

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
@@ -169,7 +169,7 @@ public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<
 
 	@Override
 	public boolean messageWillBeRedeliveredOnExitStateError() {
-		return true;
+		return knownProcessStates().contains(ProcessState.INPROCESS);
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystemListener.java
@@ -43,6 +43,7 @@ import org.frankframework.core.HasPhysicalDestination;
 import org.frankframework.core.IMessageBrowser;
 import org.frankframework.core.IProvidesMessageBrowsers;
 import org.frankframework.core.IPullingListener;
+import org.frankframework.core.IRedeliveringListener;
 import org.frankframework.core.ListenerException;
 import org.frankframework.core.PipeLineResult;
 import org.frankframework.core.PipeLineSession;
@@ -75,7 +76,7 @@ import org.frankframework.xml.XmlWriter;
  */
 @Log4j2
 @DestinationType(DestinationType.Type.FILE_SYSTEM)
-public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<F>> implements IPullingListener<F>, HasPhysicalDestination, IProvidesMessageBrowsers<F> {
+public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<F>> implements IPullingListener<F>, HasPhysicalDestination, IProvidesMessageBrowsers<F>, IRedeliveringListener<F> {
 	private final @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
 
@@ -164,6 +165,11 @@ public abstract class AbstractFileSystemListener<F, FS extends IBasicFileSystem<
 		if (!knownProcessStates.contains(ProcessState.INPROCESS) && isFileTimeSensitive()) {
 			ConfigurationWarnings.add(this, log, "Configuring 'fileTimeSensitive' has no effect when no 'In Process' folder is configured.");
 		}
+	}
+
+	@Override
+	public boolean messageWillBeRedeliveredOnExitStateError() {
+		return true;
 	}
 
 	@Override

--- a/messaging/src/main/java/org/frankframework/jms/PushingJmsListener.java
+++ b/messaging/src/main/java/org/frankframework/jms/PushingJmsListener.java
@@ -21,6 +21,7 @@ import jakarta.jms.Destination;
 import jakarta.jms.Message;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.NonNull;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -189,7 +190,7 @@ public class PushingJmsListener extends AbstractJmsListener implements IPortConn
 	}
 
 	@Override
-	public int getDeliveryCount(RawMessageWrapper<Message> rawMessage) {
+	public int getDeliveryCount(@NonNull RawMessageWrapper<Message> rawMessage) {
 		try {
 			Message message=rawMessage.getRawMessage();
 			// Note: Tibco doesn't set the JMSXDeliveryCount for messages

--- a/messaging/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
+++ b/messaging/src/test/java/org/frankframework/jms/PushingJmsListenerTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -106,7 +106,7 @@ public class PushingJmsListenerTest {
 		receiver.setStartTimeout(2);
 		receiver.setStopTimeout(2);
 		// To speed up test, we don't actually sleep
-		doNothing().when(receiver).suspendReceiverThread(anyInt());
+		doNothing().when(receiver).suspendReceiverThread(anyLong());
 		adapter.addReceiver(receiver);
 		return receiver;
 	}

--- a/test/src/main/java/org/frankframework/listeners/CustomHighDeliveryCountEsbJmsListener.java
+++ b/test/src/main/java/org/frankframework/listeners/CustomHighDeliveryCountEsbJmsListener.java
@@ -19,6 +19,8 @@ import java.lang.reflect.Field;
 
 import jakarta.jms.Message;
 
+import org.jspecify.annotations.NonNull;
+
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.extensions.esb.EsbJmsListener;
 import org.frankframework.jta.narayana.NarayanaTransactionHelper;
@@ -51,7 +53,7 @@ public class CustomHighDeliveryCountEsbJmsListener extends EsbJmsListener {
 	}
 
 	@Override
-	public int getDeliveryCount(RawMessageWrapper<Message> rawMessage) {
+	public int getDeliveryCount(@NonNull RawMessageWrapper<Message> rawMessage) {
 		return 100;
 	}
 }


### PR DESCRIPTION
## Changes
Try to reduce impact of backoff-delay on errors. Still WIP.

<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
