### PR TITLE
Add end-to-end tests for combobox interactions and improve pipeline

### DIFF
--- a/console/frontend/src/main/frontend/cypress/e2e/general/combobox.cy.ts
+++ b/console/frontend/src/main/frontend/cypress/e2e/general/combobox.cy.ts
@@ -1,0 +1,82 @@
+describe('Combobox', () => {
+  const combobox = '[data-cy=test-pipeline__config__input]';
+  const comboboxInput = `${combobox} input`;
+  const options = '.combobox__options';
+  const optionLabels = '.combobox__list-item__label';
+  const selectedOption = '.combobox__list-item--selected';
+  const clearButton = '.combobox__list-item--clear';
+
+  beforeEach(() => {
+    cy.visit('/#/test-pipeline');
+    cy.get(comboboxInput).should('not.be.disabled');
+  });
+
+  it('open the suggestions, navigate and select with keyboard', () => {
+    cy.get(comboboxInput).focus();
+    cy.get(options).should('be.visible');
+
+    cy.get(comboboxInput).type('{downArrow}');
+    cy.get(selectedOption).should('exist');
+
+    cy.get(comboboxInput).type('{enter}');
+    cy.get(options).should('not.exist');
+    cy.get(comboboxInput).should('not.have.value', '');
+  });
+
+  it('select and option by typing it out', () => {
+    cy.get(comboboxInput).type('HTTP');
+    cy.get(optionLabels).should('contain.text', 'HTTP');
+
+    cy.get(comboboxInput).type('{enter}');
+    cy.get(comboboxInput).should('have.value', 'HTTP');
+    cy.get(options).should('not.exist');
+  });
+
+  it('select and option by typing it partially and clicking with mouse', () => {
+    cy.get(comboboxInput).type('HTT');
+    cy.get(optionLabels).should('contain.text', 'HTTP');
+
+    cy.contains('.combobox__list-item', 'HTTP').click();
+    cy.get(comboboxInput).should('have.value', 'HTTP');
+    cy.get(options).should('not.exist');
+  });
+
+  it('check if the suggestions are getting filtered correctly', () => {
+    cy.get(comboboxInput).click();
+    cy.get(optionLabels)
+      .its('length')
+      .then((totalCount) => {
+        cy.get(comboboxInput).type('HTTP');
+
+        cy.get(optionLabels).each(($label) => {
+          expect($label.text().toLowerCase()).to.contain('http');
+        });
+
+        cy.get(optionLabels).its('length').should('be.lte', totalCount);
+      });
+  });
+
+  it('resets the selection using the clear button', () => {
+    cy.get(comboboxInput).type('HTTP{enter}');
+    cy.get(comboboxInput).should('have.value', 'HTTP');
+
+    cy.get(comboboxInput).type('{downArrow}');
+    cy.get(options).should('be.visible');
+    cy.get(clearButton).should('be.visible').click();
+
+    cy.get(comboboxInput).should('have.value', '');
+  });
+
+  xit('resets the selection by clicking the input after losing focus', () => {
+    cy.get(comboboxInput).type('HTTP{enter}');
+    cy.get(comboboxInput).should('have.value', 'HTTP');
+
+    cy.get(comboboxInput).blur();
+    cy.get(options).should('not.exist');
+
+    cy.get(comboboxInput).click();
+    cy.get(comboboxInput).should('have.value', '');
+    cy.get(options).should('be.visible');
+    cy.get(optionLabels).should('have.length.greaterThan', 0);
+  });
+});

--- a/console/frontend/src/main/frontend/cypress/e2e/views/test-pipeline.cy.ts
+++ b/console/frontend/src/main/frontend/cypress/e2e/views/test-pipeline.cy.ts
@@ -1,22 +1,27 @@
 describe('Test a Pipeline', () => {
   beforeEach(() => {
     cy.visit('/#/test-pipeline');
+    cy.get('[data-cy=test-pipeline__config__input] input').should('not.be.disabled');
+    cy.get('[data-cy=test-pipeline__config__input]').type('HTTP{enter}');
   });
 
-  it('Test a Pipeline', () => {
-    cy.get('[data-cy=test-pipeline__config__input]').type('HTTP{enter}');
+  it('runs the ApiListener_SimpleGet adapter successfully', () => {
     cy.get('[data-cy=test-pipeline__adapter__input]').type('ApiListener_SimpleGet{enter}{ctrl}{enter}');
     cy.get('[data-cy=test-pipeline__alert]').should('have.text', 'SUCCESS');
     cy.get('[data-cy=test-pipeline__result]').should('have.text', '<success/>');
-    cy.get('[data-cy=test-pipeline__adapter__input]').click();
-    cy.get('[data-cy=test-pipeline__adapter__input] input').clear();
+  });
 
+  it('runs the WebServiceListener adapter successfully without a result', () => {
     cy.get('[data-cy=test-pipeline__adapter__input]').type('WebServiceListener{enter}{ctrl}{enter}');
     cy.get('[data-cy=test-pipeline__alert]').should('have.text', 'SUCCESS');
     cy.get('[data-cy=test-pipeline__result]').should('not.exist');
+  });
 
-    cy.get('[data-cy=test-pipeline__message__input] .monaco-editor').click();
-    cy.get('[data-cy=test-pipeline__message__input] .monaco-editor').type("I've Played These Games Before!{ctrl}{enter}");
+  it('echoes the message back when running the WebServiceListener adapter', () => {
+    cy.get('[data-cy=test-pipeline__adapter__input]').type('WebServiceListener{enter}');
+
+    cy.setMonacoValue("I've Played These Games Before!");
+    cy.get('[data-cy-test-pipeline=send]').click();
     cy.get('[data-cy=test-pipeline__result]').should('have.text', "I've Played These Games Before!");
     cy.get('[data-cy=test-pipeline__alert]').should('have.text', 'SUCCESS');
   });

--- a/console/frontend/src/main/frontend/cypress/support/commands.ts
+++ b/console/frontend/src/main/frontend/cypress/support/commands.ts
@@ -1,37 +1,37 @@
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+
+Cypress.Commands.add('setMonacoValue', (value: string, modelIndex = 0) => {
+  setMonacoValue(value, modelIndex);
+});
+
+type MonacoEditorModel = {
+  setValue(value: string): void;
+};
+
+type MonacoInstance = {
+  editor: {
+    getModels(): MonacoEditorModel[];
+  };
+};
+
+type MonacoWindow = Window & { monaco?: MonacoInstance };
+
+function setMonacoValue(value: string, modelIndex = 0): void {
+  cy.window().then((autWindow) => {
+    const monacoWindow = autWindow as MonacoWindow;
+    const framedWindow = autWindow.frames[0] as MonacoWindow | undefined;
+    const monacoInstance = monacoWindow.monaco ?? framedWindow?.monaco ?? null;
+
+    if (!monacoInstance) {
+      throw new Error('Monaco editor not found on the window or frames[0]');
+    }
+
+    const model = monacoInstance.editor.getModels()[modelIndex];
+
+    if (!model) {
+      throw new Error(`Monaco editor model at index ${modelIndex} not found`);
+    }
+
+    model.setValue(value);
+  });
+}

--- a/console/frontend/src/main/frontend/cypress/support/e2e.ts
+++ b/console/frontend/src/main/frontend/cypress/support/e2e.ts
@@ -1,25 +1,9 @@
-// ***********************************************************
-// This example support/e2e.ts is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
-// ***********************************************************
+import './commands';
 
-// When a command from ./commands is ready to use, import with `import './commands'` syntax
-// import './commands';
-
-Cypress.on('uncaught:exception', (err, runnable) => {
-  // ignore monaco-editor uncaught exceptions (thanks microsoft)
-  if (err.name === 'TypeError' && err.message === 'Property descriptor must be an object, got undefined') {
+Cypress.on('uncaught:exception', (error, _runnable) => {
+  // Ignore monaco-editor uncaught exceptions (thanks Microsoft)
+  if (error.name === 'TypeError' && error.message === 'Property descriptor must be an object, got undefined') {
     return false;
   }
   return;
-})
+});

--- a/console/frontend/src/main/frontend/cypress/support/index.d.ts
+++ b/console/frontend/src/main/frontend/cypress/support/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace Cypress {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- interface required for Cypress declaration merging
+  interface Chainable {
+    setMonacoValue(value: string, modelIndex?: number): Chainable<void>;
+  }
+}


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

The combobox test was never wrong, but I forgot the test-a-pipeline test, that also uses the combobox ;_; ... That is fixed now.

Along the way I also fixed the monaco editor not being able to be filled locally. I hope this fix also works in the CI.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [x] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
