### PR TITLE
Skip shade plugin during Maven builds

### DIFF
--- a/build-templates/pom.xml
+++ b/build-templates/pom.xml
@@ -497,6 +497,13 @@
 							<skipAssembly>true</skipAssembly>
 						</configuration>
 					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

When we build the artifacts don't run the `shade` and `assembly` plugins.