### PR TITLE
Fix circular bean creation with Ladybug

### DIFF
--- a/ladybug/common/src/main/resources/springTestToolCommon.xml
+++ b/ladybug/common/src/main/resources/springTestToolCommon.xml
@@ -10,11 +10,11 @@
 		http://www.springframework.org/schema/util    http://www.springframework.org/schema/util/spring-util.xsd
 	">
 
-	<bean name="whiteBoxView" class="org.wearefrank.ladybug.filter.View" autowire="byName">
+	<bean name="whiteBoxView" class="org.wearefrank.ladybug.filter.View">
 		<property name="name" value="White box"/>
 	</bean>
 
-	<bean name="grayBoxView" parent="whiteBoxView" autowire="byName">
+	<bean name="grayBoxView" parent="whiteBoxView">
 		<property name="name" value="Gray box"/>
 		<property name="checkpointMatchers">
 			<list>
@@ -23,7 +23,7 @@
 		</property>
 	</bean>
 
-	<bean name="blackBoxView" parent="whiteBoxView" autowire="byName">
+	<bean name="blackBoxView" parent="whiteBoxView">
 		<property name="name" value="Black box"/>
 		<property name="checkpointMatchers">
 			<list>

--- a/ladybug/debugger/src/main/resources/springIbisTestToolTibet2.xml
+++ b/ladybug/debugger/src/main/resources/springIbisTestToolTibet2.xml
@@ -72,7 +72,7 @@
 		</property>
 	</bean>
 
-	<bean name="oldSchoolView" parent="whiteBoxView" autowire="byName">
+	<bean name="oldSchoolView" parent="whiteBoxView">
 		<property name="name" value="Old school"/>
 		<property name="metadataNames">
 			<list>


### PR DESCRIPTION
## Changes

Fix starting the Frank!Framework after bumping Ladybug. Ladybug's View class now needs a reference to class TestTool while class TestTool also needs references to all View objects. Ladybug handles this circular dependency as follows. Class View has a setter for the TestTool object but this property is not autowired. Instead class TestTool iterates over all the View objects and initializes their references to TestTool.

This solution was mitigated by the Spring configuration files for Ladybug in the Frank!Framework. In file `ladybug/common/src/main/resources/springTestToolCommon.xml` for example, the View beans had attribute `autowire="byName"`. This attribute forced autowiring even though no @Autowire annotations were present in Ladybug, re-introducing the circular dependency. This PR fixes the issue.