### PR TITLE
Lookup of parameter values is now always case-insensitive but case-preserving

### DIFF
--- a/core/src/main/java/org/frankframework/cache/AbstractCacheAdapter.java
+++ b/core/src/main/java/org/frankframework/cache/AbstractCacheAdapter.java
@@ -213,7 +213,7 @@ public abstract class AbstractCacheAdapter<V> implements ICache<String, V>, Fran
 		if (getParameterList().hasParameter(parameterName)) {
 			try {
 				ParameterValueList parameterValueList = getParameterList().getValues(input, session);
-				ParameterValue parameterValue = parameterValueList.findParameterValue(parameterName);
+				ParameterValue parameterValue = parameterValueList.get(parameterName);
 
 				if (parameterValue != null) {
 					return parameterValue.asMessage();

--- a/core/src/main/java/org/frankframework/collection/AbstractCollectorPipe.java
+++ b/core/src/main/java/org/frankframework/collection/AbstractCollectorPipe.java
@@ -94,7 +94,7 @@ public abstract class AbstractCollectorPipe<C extends ICollector<P>, P> extends 
 		return collection;
 	}
 
-	protected ParameterValueList getParameterValueList(Message input, PipeLineSession session) throws CollectionException {
+	protected @NonNull ParameterValueList getParameterValueList(Message input, PipeLineSession session) throws CollectionException {
 		try {
 			return getParameterList().getValues(input, session);
 		} catch (ParameterException e) {

--- a/core/src/main/java/org/frankframework/compression/ZipWriter.java
+++ b/core/src/main/java/org/frankframework/compression/ZipWriter.java
@@ -82,9 +82,9 @@ public class ZipWriter implements ICollector<MessageZipEntry> {
 
 	@Override
 	public MessageZipEntry createPart(Message input, PipeLineSession session, ParameterValueList pvl) throws CollectionException {
-		String filename = ParameterValueList.getValue(pvl, PARAMETER_FILENAME, "");
+		String filename = pvl.getValue(PARAMETER_FILENAME, "");
 		try {
-			Message contents = ParameterValueList.getValue(pvl, PARAMETER_CONTENTS, input);
+			Message contents = pvl.getValue(PARAMETER_CONTENTS, input);
 			if (StringUtils.isEmpty(filename) && contents != input) {
 				filename = input.asString();
 			}

--- a/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
+++ b/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
@@ -21,7 +21,6 @@ import org.frankframework.collection.AbstractCollectorPipe;
 import org.frankframework.collection.CollectionException;
 import org.frankframework.configuration.ConfigurationException;
 import org.frankframework.core.PipeLineSession;
-import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.stream.Message;
 
 /**
@@ -54,7 +53,7 @@ public class ZipWriterPipe extends AbstractCollectorPipe<ZipWriter, MessageZipEn
 
 	@Override
 	protected ZipWriter createCollector(Message input, PipeLineSession session) throws CollectionException {
-		String filename = ParameterValueList.getValue(getParameterValueList(input, session), ZipWriter.PARAMETER_FILENAME, "");
+		String filename = getParameterValueList(input, session).getValue(ZipWriter.PARAMETER_FILENAME, "");
 		return new ZipWriter(includeFileHeaders, filename);
 	}
 

--- a/core/src/main/java/org/frankframework/ldap/LdapFindMemberPipe.java
+++ b/core/src/main/java/org/frankframework/ldap/LdapFindMemberPipe.java
@@ -56,11 +56,11 @@ public class LdapFindMemberPipe extends AbstractLdapQueryPipe {
 		} catch (ParameterException e) {
 			throw new PipeRunException(this, "exception on extracting parameters", e);
 		}
-		dnSearchIn_work = getParameterValue(pvl, "dnSearchIn");
+		dnSearchIn_work = pvl.getValue("dnSearchIn");
 		if (dnSearchIn_work == null) {
 			dnSearchIn_work = getDnSearchIn();
 		}
-		dnFind_work = getParameterValue(pvl, "dnFind");
+		dnFind_work = pvl.getValue("dnFind");
 		if (dnFind_work == null) {
 			dnFind_work = getDnFind();
 		}

--- a/core/src/main/java/org/frankframework/parameters/ParameterValueList.java
+++ b/core/src/main/java/org/frankframework/parameters/ParameterValueList.java
@@ -18,9 +18,9 @@ package org.frankframework.parameters;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
@@ -44,7 +44,7 @@ public class ParameterValueList implements Iterable<ParameterValue> {
 	public ParameterValueList() {
 		super();
 		list = new ArrayList<>();
-		map  = new LinkedHashMap<>();
+		map  = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 	}
 
 	public static ParameterValueList get(ParameterList params, Message message, PipeLineSession session) throws ParameterException {
@@ -66,22 +66,12 @@ public class ParameterValueList implements Iterable<ParameterValue> {
 	}
 
 	/** Get a specific {@link ParameterValue}, case sensitive */
-	public @Nullable ParameterValue get(String name) {
+	public @Nullable ParameterValue get(@NonNull String name) {
 		return map.get(name);
 	}
 
-	/** Find a (case insensitive) {@link ParameterValue} */
-	public @Nullable ParameterValue findParameterValue(@NonNull String name) {
-		for(Map.Entry<String, ParameterValue> entry : map.entrySet()) {
-			if(entry.getKey().equalsIgnoreCase(name)) {
-				return entry.getValue();
-			}
-		}
-		return null;
-	}
-
 	/**
-	 * Check if the parameter exists, case sensitive.
+	 * Check if the parameter exists, case-insensitive.
 	 */
 	public boolean contains(@NonNull String name) {
 		return map.containsKey(name);
@@ -113,30 +103,49 @@ public class ParameterValueList implements Iterable<ParameterValue> {
 		Map<String, ParameterValue> paramValuesMap = getParameterValueMap();
 
 		// convert map with parameterValue to map with value
-		Map<String, Object> result = LinkedHashMap.newLinkedHashMap(paramValuesMap.size());
+		Map<String, Object> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 		for (ParameterValue pv : paramValuesMap.values()) {
 			result.put(pv.getDefinition().getName(), pv.getValue());
 		}
 		return result;
 	}
 
-	public static Message getValue(ParameterValueList pvl, String name, Message defaultValue) {
-		if (pvl!=null) {
-			ParameterValue pv = pvl.get(name);
-			Message value = pv!=null ? pv.asMessage() : null;
-			if (!Message.isNull(value)) {
-				return value;
-			}
+	/**
+	 * Get the list of resolved parameter values
+	 */
+	@NonNull
+	public List<Object> getValueList() {
+		return list.stream()
+				.map(ParameterValue::getValue)
+				.toList();
+	}
+
+	public int getValue(@NonNull String parameterName, int defaultValue) {
+		ParameterValue pv = get(parameterName);
+		if (pv != null) {
+			return pv.asIntegerValue(defaultValue);
 		}
 		return defaultValue;
 	}
 
-	public static String getValue(ParameterValueList pvl, String name, String defaultValue) {
-		if (pvl != null) {
-			ParameterValue pv = pvl.get(name);
-			if (pv != null) {
-				return pv.asStringValue(defaultValue);
-			}
+	@Nullable
+	public String getValue(@NonNull String parameterName) {
+		return getValue(parameterName, (String) null);
+	}
+
+	public String getValue(@NonNull String name, @Nullable String defaultValue) {
+		ParameterValue pv = get(name);
+		if (pv != null) {
+			return pv.asStringValue(defaultValue);
+		}
+		return defaultValue;
+	}
+
+	public Message getValue(@NonNull String name, @Nullable Message defaultValue) {
+		ParameterValue pv = get(name);
+		Message value = pv!=null ? pv.asMessage() : null;
+		if (!Message.isNull(value)) {
+			return value;
 		}
 		return defaultValue;
 	}
@@ -153,7 +162,7 @@ public class ParameterValueList implements Iterable<ParameterValue> {
 	/**
 	 * @return The corresponding {@link ParameterValue}, should only be used in combination with {@link ParameterValueList#iterator()}!
 	 */
-	public ParameterValue getParameterValue(int i) {
+	public ParameterValue getValue(int i) {
 		return list.get(i);
 	}
 

--- a/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
@@ -50,7 +50,6 @@ import org.frankframework.monitoring.EventThrowing;
 import org.frankframework.parameters.IParameter;
 import org.frankframework.parameters.ParameterList;
 import org.frankframework.parameters.ParameterValue;
-import org.frankframework.parameters.ParameterValueList;
 import org.frankframework.processors.InputOutputPipeProcessor;
 import org.frankframework.stream.Message;
 import org.frankframework.util.AppConstants;
@@ -217,22 +216,6 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 		}
 
 		return forwards.stream().map(Forward::name).toList();
-	}
-
-	protected int getIntegerParameter(@NonNull ParameterValueList pvl, @NonNull String parameterName, int defaultValue) {
-		ParameterValue pv = pvl.findParameterValue(parameterName);
-		if (pv == null) {
-			return defaultValue;
-		}
-		return pv.asIntegerValue(defaultValue);
-	}
-
-	protected @Nullable String getParameterValue(@NonNull ParameterValueList pvl, String parameterName) {
-		ParameterValue pv = pvl.findParameterValue(parameterName);
-		if (pv == null) {
-			return null;
-		}
-		return pv.asStringValue(null);
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/pipes/CompareStringPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/CompareStringPipe.java
@@ -100,7 +100,7 @@ public class CompareStringPipe extends AbstractPipe {
 		} catch (ParameterException e) {
 			throw new PipeRunException(this, "exception extracting parameters", e);
 		}
-		String operand1 = getParameterValue(pvl, OPERAND1);
+		String operand1 = pvl.getValue(OPERAND1);
 		try {
 			if (operand1 == null) {
 				operand1 = message.asString();
@@ -108,7 +108,7 @@ public class CompareStringPipe extends AbstractPipe {
 		} catch (Exception e) {
 			throw new PipeRunException(this, "Exception on getting operand1 from input message", e);
 		}
-		String operand2 = getParameterValue(pvl, OPERAND2);
+		String operand2 = pvl.getValue(OPERAND2);
 		try {
 			if (operand2 == null) {
 				operand2 = message.asString();
@@ -125,7 +125,7 @@ public class CompareStringPipe extends AbstractPipe {
 			}
 		}
 
-		String ip = getParameterValue(pvl, IGNOREPATTERNS);
+		String ip = pvl.getValue(IGNOREPATTERNS);
 		if (ip != null) {
 			try {
 				Node n = XmlUtils.buildNode(ip);

--- a/core/src/main/java/org/frankframework/pipes/CompressPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/CompressPipe.java
@@ -206,7 +206,7 @@ public class CompressPipe extends FixedForwardPipe {
 
 	private String getZipEntryName(String input, PipeLineSession session) throws ParameterException {
 		ParameterValueList pvl = getParameterList().getValues(new Message(input), session);
-		String value = ParameterValueList.getValue(pvl, "zipEntryPattern", (String) null);
+		String value = pvl.getValue("zipEntryPattern", (String) null);
 		if (value != null) {
 			return value;
 		}

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -545,7 +545,8 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	}
 
 	Scope determineActualScope(@Nullable ParameterValueList pvl) {
-		ParameterValue scopeParam = pvl != null ? pvl.findParameterValue(SCOPE_PARAM_NAME) : null;
+		ParameterValue scopeParam;
+		scopeParam = pvl != null ? pvl.get(SCOPE_PARAM_NAME) : null;
 		if (scopeParam != null) {
 			return Scope.valueOf(scopeParam.asStringValue(getScope().name()));
 		}
@@ -553,7 +554,8 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	}
 
 	String determineActualTarget(@Nullable ParameterValueList pvl) {
-		ParameterValue targetParam = pvl != null ? pvl.findParameterValue(TARGET_PARAM_NAME) : null;
+		ParameterValue targetParam;
+		targetParam = pvl != null ? pvl.get(TARGET_PARAM_NAME) : null;
 		if (targetParam != null) {
 			return targetParam.asStringValue(getTarget());
 		}

--- a/core/src/main/java/org/frankframework/senders/FrankSender.java
+++ b/core/src/main/java/org/frankframework/senders/FrankSender.java
@@ -545,8 +545,7 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	}
 
 	Scope determineActualScope(@Nullable ParameterValueList pvl) {
-		ParameterValue scopeParam;
-		scopeParam = pvl != null ? pvl.get(SCOPE_PARAM_NAME) : null;
+		ParameterValue scopeParam = pvl != null ? pvl.get(SCOPE_PARAM_NAME) : null;
 		if (scopeParam != null) {
 			return Scope.valueOf(scopeParam.asStringValue(getScope().name()));
 		}
@@ -554,8 +553,7 @@ public class FrankSender extends AbstractSenderWithParameters implements HasPhys
 	}
 
 	String determineActualTarget(@Nullable ParameterValueList pvl) {
-		ParameterValue targetParam;
-		targetParam = pvl != null ? pvl.get(TARGET_PARAM_NAME) : null;
+		ParameterValue targetParam = pvl != null ? pvl.get(TARGET_PARAM_NAME) : null;
 		if (targetParam != null) {
 			return targetParam.asStringValue(getTarget());
 		}

--- a/core/src/main/java/org/frankframework/senders/JavascriptSender.java
+++ b/core/src/main/java/org/frankframework/senders/JavascriptSender.java
@@ -165,7 +165,7 @@ public class JavascriptSender extends SenderSeries {
 		// This array will contain the parameters given in the configuration
 		Object[] jsParameters = new Object[numberOfParameters];
 		for (int i = 0; i < numberOfParameters; i++) {
-			ParameterValue pv = pvl.getParameterValue(i);
+			ParameterValue pv = pvl.getValue(i);
 			Object value = pv.getValue();
 			try {
 				jsParameters[i] = value instanceof Message m ? m.asString() : value;

--- a/core/src/main/java/org/frankframework/util/JdbcUtil.java
+++ b/core/src/main/java/org/frankframework/util/JdbcUtil.java
@@ -479,7 +479,7 @@ public class JdbcUtil {
 		boolean parameterTypeMatchRequired = dbmsSupport.isParameterTypeMatchRequired();
 		if (parameters != null) {
 			for (int i = 0; i < parameters.size(); i++) {
-				ParameterValue parameterValue = parameters.getParameterValue(i);
+				ParameterValue parameterValue = parameters.getValue(i);
 				if (parameterValue.getDefinition().getMode() == Parameter.ParameterMode.OUTPUT) {
 					continue;
 				}

--- a/core/src/main/java/org/frankframework/util/stream/ReplacingParameterVariablesInputStream.java
+++ b/core/src/main/java/org/frankframework/util/stream/ReplacingParameterVariablesInputStream.java
@@ -149,7 +149,7 @@ public class ReplacingParameterVariablesInputStream extends FilterInputStream {
 				if (next == CLOSING_CURLY_BRACE) {
 					// We've fully matched the pattern '?{...}' and are returning bytes from the replacement
 					String key = readMatchingBuffer();
-					ParameterValue value = paramList.findParameterValue(key);
+					ParameterValue value = paramList.get(key);
 					if (value != null) {
 						Message paramValue = value.asMessage();
 						log.info("replaceing [{}] with value from [{}]", key, paramValue);

--- a/core/src/test/java/org/frankframework/parameters/ParameterValueListTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterValueListTest.java
@@ -25,7 +25,9 @@ public class ParameterValueListTest {
 		list.add(new ResolvedParameterValue("key3", "value3"));
 
 		assertTrue(list.contains("key1"));
+		assertTrue(list.contains("KEY1")); // Test case-insensitive presence
 		assertTrue(list.contains("key2"));
+		assertTrue(list.contains("Key2")); // Test case-insensitive presence
 		assertFalse(list.contains("doesnt-exist"));
 		assertEquals(4, list.size());
 		assertEquals("[value1, value2, value4, value3]", list.getValueList().toString()); // Preserves order of definition
@@ -41,6 +43,7 @@ public class ParameterValueListTest {
 		assertNull(list.remove("doesnt-exist"));
 
 		assertEquals("value3", list.get("key3").getValue());
+		assertEquals("value3", list.get("KEY3").getValue()); // Test case-insensitive retrieval
 		assertEquals("value1", list.getValue(0).getValue());
 		assertEquals("value4", list.getValue(1).getValue());
 		assertEquals("value3", list.getValue(2).getValue());

--- a/core/src/test/java/org/frankframework/parameters/ParameterValueListTest.java
+++ b/core/src/test/java/org/frankframework/parameters/ParameterValueListTest.java
@@ -28,21 +28,22 @@ public class ParameterValueListTest {
 		assertTrue(list.contains("key2"));
 		assertFalse(list.contains("doesnt-exist"));
 		assertEquals(4, list.size());
-		assertEquals("[value1, value2, value4, value3]", list.getValueMap().values().toString());
+		assertEquals("[value1, value2, value4, value3]", list.getValueList().toString()); // Preserves order of definition
+		assertEquals("[value1, value2, value3, value4]", list.getValueMap().values().toString()); // Alphabetical order of keys, case-insensitive
 
-		List<String> sortedList2 = new ArrayList<>();
+		List<String> listOfKeys = new ArrayList<>();
 		for (ParameterValue param : list) {
-			sortedList2.add(param.getName());
+			listOfKeys.add(param.getName());
 		}
-		assertEquals("[key1, key2, key4, key3]", sortedList2.toString());
+		assertEquals("[key1, key2, key4, key3]", listOfKeys.toString());
 
 		assertSame(key2, list.remove("key2"));
 		assertNull(list.remove("doesnt-exist"));
 
 		assertEquals("value3", list.get("key3").getValue());
-		assertEquals("value1", list.getParameterValue(0).getValue());
-		assertEquals("value4", list.getParameterValue(1).getValue());
-		assertEquals("value3", list.getParameterValue(2).getValue());
+		assertEquals("value1", list.getValue(0).getValue());
+		assertEquals("value4", list.getValue(1).getValue());
+		assertEquals("value3", list.getValue(2).getValue());
 	}
 
 	public static class ResolvedParameterValue extends ParameterValue {

--- a/core/src/test/java/org/frankframework/pipes/ParameterValueTestPipe.java
+++ b/core/src/test/java/org/frankframework/pipes/ParameterValueTestPipe.java
@@ -22,8 +22,8 @@ public class ParameterValueTestPipe extends FixedForwardPipe {
 			throw new PipeRunException(this, "exception on extracting parameters", e);
 		}
 
-		String param1 = getParameterValue(pvl, "param1");
-		String param2 = pvl.contains("param2") ? getParameterValue(pvl, "param2") : getParameterValue(pvl, "param1");
+		String param1 = pvl.getValue("param1");
+		String param2 = pvl.contains("param2") ? pvl.getValue("param2") : pvl.getValue("param1");
 
 		if(StringUtils.isNotEmpty(param1)) {
 			return new PipeRunResult(getSuccessForward(), param1);

--- a/core/src/test/java/org/frankframework/testutil/JdbcTestUtil.java
+++ b/core/src/test/java/org/frankframework/testutil/JdbcTestUtil.java
@@ -108,7 +108,7 @@ public class JdbcTestUtil {
 		for (int i = 0; i < parameterValues.size(); i++) {
 			sb.append("param").append(i)
 					.append(" [")
-					.append(parameterValues.getParameterValue(i).getValue())
+					.append(parameterValues.getValue(i).getValue())
 					.append("]");
 		}
 		return sb.toString();

--- a/nn-specials/src/main/java/org/frankframework/extensions/esb/DirectWrapperPipe.java
+++ b/nn-specials/src/main/java/org/frankframework/extensions/esb/DirectWrapperPipe.java
@@ -50,9 +50,9 @@ public class DirectWrapperPipe extends FixedForwardPipe {
 			throw new PipeRunException(this, "exception extracting parameters", e);
 		}
 
-		String destination = getParameterValue(pvl, DESTINATION);
-		String cmhVersion = getParameterValue(pvl, CMHVERSION);
-		String addOutputNamespace = getParameterValue(pvl, ADDOUTPUTNAMESPACE);
+		String destination = pvl.getValue(DESTINATION);
+		String cmhVersion = pvl.getValue(CMHVERSION);
+		String addOutputNamespace = pvl.getValue(ADDOUTPUTNAMESPACE);
 
 		EsbSoapWrapperPipe eswPipe = SpringUtils.createBean(getApplicationContext());
 		if (addOutputNamespace != null && "on".equalsIgnoreCase(addOutputNamespace)) {

--- a/test/src/main/java/org/frankframework/pipes/LargeBlockTesterPipe.java
+++ b/test/src/main/java/org/frankframework/pipes/LargeBlockTesterPipe.java
@@ -66,8 +66,8 @@ public class LargeBlockTesterPipe extends FixedForwardPipe {
 		} catch (ParameterException e) {
 			throw new PipeRunException(this, "Cannot get parameter values", e);
 		}
-		int nrOfBlocks = getIntegerParameter(pvl, "blockCount", blockCount);
-		int bytesPerBlock = getIntegerParameter(pvl, "blockSize", blockSize);
+		int nrOfBlocks = pvl.getValue("blockCount", blockCount);
+		int bytesPerBlock = pvl.getValue("blockSize", blockSize);
 		if (direction==Direction.PRODUCE) {
 			// Pass supplier to large stream, so that it is actually served dynamically instead of all produced on creation of the message
 			result = Message.asMessage(buildInputStreamSupplier(nrOfBlocks, bytesPerBlock));

--- a/tibco/src/main/java/org/frankframework/extensions/tibco/GetTibcoQueues.java
+++ b/tibco/src/main/java/org/frankframework/extensions/tibco/GetTibcoQueues.java
@@ -136,19 +136,19 @@ public class GetTibcoQueues extends TimeoutGuardPipe {
 			throw new PipeRunException(this, "exception on extracting parameters", e);
 		}
 
-		urlWork = getParameterValue(pvl, "url");
+		urlWork = pvl.getValue("url");
 		if (urlWork == null) {
 			urlWork = getUrl();
 		}
-		authAliasWork = getParameterValue(pvl, "authAlias");
+		authAliasWork = pvl.getValue("authAlias");
 		if (authAliasWork == null) {
 			authAliasWork = getAuthAlias();
 		}
-		userNameWork = pvl.contains("username") ? getParameterValue(pvl, "username") : getParameterValue(pvl, "userName");
+		userNameWork = pvl.contains("username") ? pvl.getValue("username") : pvl.getValue("userName");
 		if (userNameWork == null) {
 			userNameWork = getUsername();
 		}
-		passwordWork = getParameterValue(pvl, "password");
+		passwordWork = pvl.getValue("password");
 		if (passwordWork == null) {
 			passwordWork = getPassword();
 		}
@@ -162,15 +162,15 @@ public class GetTibcoQueues extends TimeoutGuardPipe {
 				throw new PipeRunException(this, "could not find an active server");
 			}
 
-			String ldapUrl = getParameterValue(pvl, "ldapUrl");
+			String ldapUrl = pvl.getValue("ldapUrl");
 			LdapSender ldapSender = null;
 			if (StringUtils.isNotEmpty(ldapUrl)) {
 				ldapSender = retrieveLdapSender(ldapUrl, cf);
 			}
 
-			queueNameWork = getParameterValue(pvl, "queueName");
+			queueNameWork = pvl.getValue("queueName");
 			if (StringUtils.isNotEmpty(queueNameWork)) {
-				String countOnlyStr = getParameterValue(pvl, "countOnly");
+				String countOnlyStr = pvl.getValue("countOnly");
 				boolean countOnly = "true".equalsIgnoreCase(countOnlyStr);
 				if (countOnly) {
 					return new PipeRunResult(getSuccessForward(), getQueueMessageCountOnly(admin, queueNameWork));
@@ -182,7 +182,7 @@ public class GetTibcoQueues extends TimeoutGuardPipe {
 				 Session jSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
 
 				if (StringUtils.isNotEmpty(queueNameWork)) {
-					String queueItemStr = getParameterValue(pvl, "queueItem");
+					String queueItemStr = pvl.getValue("queueItem");
 					int qi;
 					if (StringUtils.isNumeric(queueItemStr)) {
 						qi = Integer.parseInt(queueItemStr);
@@ -191,7 +191,7 @@ public class GetTibcoQueues extends TimeoutGuardPipe {
 					}
 					result = getQueueMessage(jSession, admin, queueNameWork, qi, ldapSender);
 				} else {
-					String showAgeStr = getParameterValue(pvl, "showAge");
+					String showAgeStr = pvl.getValue("showAge");
 					boolean showAge = "true".equalsIgnoreCase(showAgeStr);
 					result = getQueuesInfo(jSession, admin, showAge, ldapSender);
 				}

--- a/tibco/src/main/java/org/frankframework/extensions/tibco/SendTibcoMessage.java
+++ b/tibco/src/main/java/org/frankframework/extensions/tibco/SendTibcoMessage.java
@@ -129,37 +129,37 @@ public class SendTibcoMessage extends TimeoutGuardPipe {
 			throw new PipeRunException(this, "exception on extracting parameters", e);
 		}
 
-		urlWork = getParameterValue(pvl, "url");
+		urlWork = pvl.getValue("url");
 		if (urlWork == null) {
 			urlWork = getUrl();
 		}
-		authAliasWork = getParameterValue(pvl, "authAlias");
+		authAliasWork = pvl.getValue("authAlias");
 		if (authAliasWork == null) {
 			authAliasWork = getAuthAlias();
 		}
-		userNameWork = pvl.contains("username") ? getParameterValue(pvl, "username") : getParameterValue(pvl, "userName");
+		userNameWork = pvl.contains("username") ? pvl.getValue("username") : pvl.getValue("userName");
 		if (userNameWork == null) {
 			userNameWork = getUsername();
 		}
-		passwordWork = getParameterValue(pvl, "password");
+		passwordWork = pvl.getValue("password");
 		if (passwordWork == null) {
 			passwordWork = getPassword();
 		}
-		queueNameWork = getParameterValue(pvl, "queueName");
+		queueNameWork = pvl.getValue("queueName");
 		if (queueNameWork == null) {
 			queueNameWork = getQueueName();
 		}
-		String protocolParam = getParameterValue(pvl, "messageProtocol");
+		String protocolParam = pvl.getValue("messageProtocol");
 		if (protocolParam != null) {
 			protocol = EnumUtils.parse(MessageProtocol.class, protocolParam);
 		}
-		String replyTimeoutStr = getParameterValue(pvl, "replyTimeout");
+		String replyTimeoutStr = pvl.getValue("replyTimeout");
 		if (replyTimeoutStr == null) {
 			replyTimeoutWork = getReplyTimeout();
 		} else {
 			replyTimeoutWork = Integer.parseInt(replyTimeoutStr);
 		}
-		soapActionWork = getParameterValue(pvl, "soapAction");
+		soapActionWork = pvl.getValue("soapAction");
 		if (soapActionWork == null)
 			soapActionWork = getSoapAction();
 

--- a/tibco/src/main/java/org/frankframework/pipes/TimeoutGuardPipe.java
+++ b/tibco/src/main/java/org/frankframework/pipes/TimeoutGuardPipe.java
@@ -48,7 +48,7 @@ public abstract class TimeoutGuardPipe extends FixedForwardPipe {
 		} catch (ParameterException e) {
 			throw new PipeRunException(this, "exception on extracting parameters", e);
 		}
-		String paramValue = getParameterValue(pvl, "timeout");
+		String paramValue = pvl.getValue("timeout");
 		int guardTimeout = paramValue == null ? getTimeout() : Integer.valueOf(paramValue);
 		log.debug("setting timeout of [{}] s", guardTimeout);
 


### PR DESCRIPTION
## Changes
Closes #11263

- Lookup of parameter values in the ParameterValueList / Map is now always case-insensitive
- This means that in Configuration files you do not need to use the exact same case of parameter names as in code
- Some parameter lookup methods have been moved from class AbstractPipe to ParameterValueList to make them more generic
- Some static methods have been made into instance methods since the instance is always available now
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
