### PR TITLE
Bump ladybug and apply testTool.setApplication()

### DIFF
--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
+
+import org.frankframework.util.AppConstants;
+
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,6 +84,8 @@ public class LadybugDebugger implements ApplicationContextAware, ApplicationList
 	@Override
 	public void afterPropertiesSet() {
 		if(applicationContext.containsBean(LADYBUG_TESTTOOL_NAME)) {
+			String instanceName = AppConstants.getInstance().getProperty("instance.name");
+			testtool.setApplication(instanceName);
 			testtool = applicationContext.getBean(LADYBUG_TESTTOOL_NAME, TestTool.class);
 			testtool.setDebugger(this);
 			log.info("configuring debugger on TestTool [{}]", testtool);

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -21,9 +21,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
-
-import org.frankframework.util.AppConstants;
-
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +52,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.DebuggerStatusChangedEvent;
 import org.frankframework.stream.Message;
+import org.frankframework.util.AppConstants;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.MessageUtils;
 import org.frankframework.util.RunState;
@@ -84,9 +82,9 @@ public class LadybugDebugger implements ApplicationContextAware, ApplicationList
 	@Override
 	public void afterPropertiesSet() {
 		if(applicationContext.containsBean(LADYBUG_TESTTOOL_NAME)) {
+			testtool = applicationContext.getBean(LADYBUG_TESTTOOL_NAME, TestTool.class);
 			String instanceName = AppConstants.getInstance().getProperty("instance.name");
 			testtool.setApplication(instanceName);
-			testtool = applicationContext.getBean(LADYBUG_TESTTOOL_NAME, TestTool.class);
 			testtool.setDebugger(this);
 			log.info("configuring debugger on TestTool [{}]", testtool);
 		} else {

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>4.1-20260706.180124</ladybug.version>
+		<ladybug.version>4.1-20260723.104852</ladybug.version>
 	</properties>
 
 </project>


### PR DESCRIPTION
## Changes

Use the newest version of Ladybug. This version of Ladybug adds an extra column to the debug tab named Application. In combination with the Frank!Framework, the value to be shown there is `${instance.name}`. This PR passes this value to Ladybug, allowing Ladybug to show this value.

This Ladybug version also supports filter parameters in the URL used to open it. When you add a filter parameter like `filter-application=something`, then Ladybug presets a filter in the filter drawer for reports having column "Application" containing value "something". The user can clear this filter in the side drawer if he likes.

The present PR does not apply this feature of ladybug. A future PR is needed on the Frank!Framework to call Ladybug with the desired filter parameters.