### PR TITLE
Add a new way to dispatch webservice requests

### DIFF
--- a/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
+++ b/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
@@ -27,10 +27,12 @@ import jakarta.servlet.ServletResponse;
 import org.frankframework.http.AbstractHttpServlet;
 import org.frankframework.lifecycle.DynamicRegistration;
 import org.frankframework.lifecycle.IbisInitializer;
+import org.frankframework.util.AppConstants;
 
 @IbisInitializer
 public class SoapProviderServlet extends AbstractHttpServlet implements DynamicRegistration.ServletWithParameters {
 	private transient FrankCXFServlet servlet;
+	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", false);
 
 	@Override
 	public void init(ServletConfig config) throws ServletException {
@@ -47,6 +49,11 @@ public class SoapProviderServlet extends AbstractHttpServlet implements DynamicR
 	@Override
 	public String[] getAccessGrantingRoles() {
 		return IBIS_FULL_SERVICE_ACCESS_ROLES;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return USE_CXF;
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
+++ b/core/src/main/java/org/frankframework/http/cxf/SoapProviderServlet.java
@@ -32,7 +32,7 @@ import org.frankframework.util.AppConstants;
 @IbisInitializer
 public class SoapProviderServlet extends AbstractHttpServlet implements DynamicRegistration.ServletWithParameters {
 	private transient FrankCXFServlet servlet;
-	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", false);
+	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", true);
 
 	@Override
 	public void init(ServletConfig config) throws ServletException {

--- a/core/src/main/java/org/frankframework/http/mime/MultipartUtils.java
+++ b/core/src/main/java/org/frankframework/http/mime/MultipartUtils.java
@@ -209,14 +209,20 @@ public class MultipartUtils {
 		return null;
 	}
 
-	public record MultipartMessages(Message multipartXml, Map<String, Message> messages) {}
+	public record MultipartMessages(Message multipartXml, Message body, Map<String, Message> messages) {
+		public MultipartMessages(Message body) {
+			this(null, body, Map.of());
+		}
+	}
 
-	public static MultipartMessages parseMultipart(InputStream inputStream, String contentType) throws IOException {
+	public static MultipartMessages parseMultipart(InputStream inputStream, String contentType, String bodyName) throws IOException {
 		try (InputStream ignored = inputStream) {
 			final InputStreamDataSource dataSource = new InputStreamDataSource(contentType, inputStream); // The entire InputStream will be read here!
 			final MimeMultipart mimeMultipart = new MimeMultipart(dataSource);
 			final XmlBuilder attachments = new XmlBuilder("parts");
 			final Map<String, Message> parts = new LinkedHashMap<>();
+
+			Message body = null;
 
 			for (int i = 0; i < mimeMultipart.getCount(); i++) {
 				final BodyPart bodyPart = mimeMultipart.getBodyPart(i);
@@ -226,10 +232,20 @@ public class MultipartUtils {
 					continue;
 				}
 
+				PartMessage message = new PartMessage(bodyPart);
+				if ((body == null && bodyName == null) || fieldName.equalsIgnoreCase(bodyName)) {
+					body = message;
+					continue;
+				}
+
+				// If MTOM use attachment, else fieldName. MTOM may use the same name twice.
+				String partName = bodyPart.getHeader("Content-ID") != null ? ("attachment" + i) : fieldName;
+
 				final XmlBuilder attachment = new XmlBuilder("part");
 				attachment.addAttribute("name", fieldName);
-				PartMessage message = new PartMessage(bodyPart);
-				parts.put(fieldName, message);
+				attachment.addAttribute("sessionKey", partName);
+				parts.put(partName, message);
+
 				if (!isBinary(bodyPart)) {
 					// Process regular form field (input type="text|radio|checkbox|etc", select, etc).
 					log.trace("setting multipart formField [{}] to [{}]", fieldName, message);
@@ -243,13 +259,12 @@ public class MultipartUtils {
 					attachment.addAttribute("type", "file");
 					attachment.addAttribute("filename", fileName);
 					attachment.addAttribute("size", message.size());
-					attachment.addAttribute("sessionKey", fieldName);
 					attachment.addAttribute("mimeType", extractMimeType(bodyPart.getContentType()));
 				}
 				attachments.addSubElement(attachment);
 			}
 
-			return new MultipartMessages(attachments.asMessage(), parts);
+			return new MultipartMessages(attachments.asMessage(), body, parts);
 		} catch(MessagingException e) {
 			throw new IOException("could not read mime multipart request", e);
 		}
@@ -288,7 +303,7 @@ public class MultipartUtils {
 			}
 		}
 
-		return new MultipartMessages(attachments.asMessage(), parts);
+		return new MultipartMessages(attachments.asMessage(), null, parts);
 	}
 
 	private static String extractMimeType(String contentType) {

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -655,21 +655,13 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 		Message body = null;
 		final String multipartBodyName = listener.getMultipartBodyName();
 		try {
-			MultipartMessages parts = MultipartUtils.parseMultipart(request.getInputStream(), request.getContentType());
+			MultipartMessages parts = MultipartUtils.parseMultipart(request.getInputStream(), request.getContentType(), multipartBodyName);
+			body = parts.body();
 			for (Entry<String, Message> entry : parts.messages().entrySet()) {
 				String fieldName = entry.getKey();
 				if (!listener.isParameterAllowed(fieldName)) {
 					LOG.warn("Request contains multipart field [{}] which is not allowed", fieldName);
 					continue;
-				}
-				if ((body == null && multipartBodyName == null) || fieldName.equalsIgnoreCase(multipartBodyName)) {
-					body = entry.getValue();
-
-					Enumeration<String> names = request.getHeaderNames();
-					while (names.hasMoreElements()) {
-						String name = names.nextElement();
-						body.getContext().put(MessageContext.HEADER_PREFIX + name, request.getHeader(name));
-					}
 				}
 				pipelineSession.put(fieldName, entry.getValue());
 			}

--- a/core/src/main/java/org/frankframework/http/rpc/SoapContext.java
+++ b/core/src/main/java/org/frankframework/http/rpc/SoapContext.java
@@ -1,0 +1,144 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.rpc;
+
+import java.io.IOException;
+
+import jakarta.xml.soap.SOAPConstants;
+import jakarta.xml.soap.SOAPException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.frankframework.soap.filters.SoapAddressingMessageIdExtractor;
+import org.frankframework.soap.filters.SoapAddressingRelatesToInjector;
+import org.frankframework.soap.filters.SoapNamespaceUriExtractor;
+import org.frankframework.soap.filters.ValidateSoapMessageHandler;
+import org.springframework.util.MimeType;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.stream.Message;
+import org.frankframework.stream.MessageBuilder;
+import org.frankframework.stream.MessageContext;
+import org.frankframework.util.MessageUtils;
+import org.frankframework.util.XmlUtils;
+
+@Log4j2
+public class SoapContext {
+	/**
+	 * Get the SOAP protocol version, either SOAP 1.1 or SOAP 1.2.
+	 */
+	private final @Getter String soapProtocol;
+
+	/**
+	 * Get the SOAPAction as HEADER (SOAP 1_1), or from the content-type header (SOAP 1_2).
+	 */
+	private final @Getter String soapAction;
+
+	/**
+	 * Get the MessageID from the SOAP 'ws-addr' header element, or generate a fallback MessageID if not present.
+	 */
+	private final @Getter String messageId;
+
+	/**
+	 * Get the namespace that belongs to the first element in the SOAP body.
+	 */
+	private final @Getter String namespaceURI;
+
+	private boolean createdMessageId = false;
+
+	public SoapContext(Message body) throws SOAPException {
+		// Let's parse the entire request in order to find out the protocol, action e.d.
+		// As well as validating that it is a valid SOAP Message.
+		SoapNamespaceUriExtractor nsUriHandler = new SoapNamespaceUriExtractor(null);
+		SoapAddressingMessageIdExtractor messageIdExtractor = new SoapAddressingMessageIdExtractor(nsUriHandler);
+		ValidateSoapMessageHandler validateSoap = new ValidateSoapMessageHandler(messageIdExtractor);
+		try {
+			XmlUtils.parseXml(body.asInputSource(), validateSoap);
+		} catch (IOException | SAXException e) {
+			throw new SOAPException("invalid SOAP message", e);
+		}
+
+		soapProtocol = validateSoap.getSoapProtocol();
+		namespaceURI = nsUriHandler.getNamespaceURI();
+		soapAction = getSoapAction(body.getContext());
+
+		// Always return a MessageID, even if it's not in the message itself.
+		String inputMessageId = messageIdExtractor.getMessageId();
+		messageId = StringUtils.isNotBlank(inputMessageId) ? inputMessageId : generateMessageId();
+	}
+
+	private String generateMessageId() {
+		createdMessageId = true;
+		return MessageUtils.generateMessageId();
+	}
+
+	/**
+	 * If a MessageID was provided, ensure we return a 'RelatesTo' header conform the ws-addr specification.
+	 * If the MessageID is a FallbackID, do nothing.
+	 */
+	public Message setMessageId(Message output) throws SOAPException {
+		if (MessageUtils.isFallbackMessageId(messageId) || createdMessageId) {
+			return output;
+		}
+
+		try {
+			MessageBuilder builder = new MessageBuilder();
+			ValidateSoapMessageHandler validateSoap = new ValidateSoapMessageHandler(builder.asXmlWriter());
+			SoapAddressingRelatesToInjector soapAddr = new SoapAddressingRelatesToInjector(validateSoap);
+			soapAddr.setMessageId(messageId);
+
+			XmlUtils.parseXml(output.asInputSource(), soapAddr);
+
+			return builder.build();
+		} catch (IOException | SAXException e) {
+			throw new SOAPException("invalid SOAP message", e);
+		}
+	}
+
+	private String getSoapAction(MessageContext context) {
+		if(SOAPConstants.SOAP_1_1_PROTOCOL.equals(soapProtocol)) {
+			return (String) context.get("Header.SOAPAction");
+		} else {
+			MimeType contentType = context.getMimeType();
+			if(contentType != null) {
+				String action = findAction(contentType);
+				if(StringUtils.isNotEmpty(action)) {
+					return action;
+				}
+			}
+		}
+
+		log.warn("no SOAPAction found!");
+		return "";
+	}
+
+	protected static String findAction(MimeType mimeType) {
+		return unquote(mimeType.getParameter("action"));
+	}
+
+	private static boolean isQuotedString(String s) {
+		if (StringUtils.isEmpty(s) || s.length() < 2) {
+			return false;
+		}
+		return ((s.startsWith("\"") && s.endsWith("\"")) || (s.startsWith("'") && s.endsWith("'")));
+	}
+
+	private static String unquote(String s) {
+		return (isQuotedString(s) ? s.substring(1, s.length() - 1) : s);
+	}
+}

--- a/core/src/main/java/org/frankframework/http/rpc/SoapMessage.java
+++ b/core/src/main/java/org/frankframework/http/rpc/SoapMessage.java
@@ -1,0 +1,80 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.rpc;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.xml.soap.SOAPException;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import org.frankframework.http.mime.MultipartUtils;
+import org.frankframework.http.mime.MultipartUtils.MultipartMessages;
+import org.frankframework.stream.Message;
+import org.frankframework.util.MessageUtils;
+
+/**
+ * Wrapper calls that holds everything related to a SOAPMessage.
+ */
+public class SoapMessage {
+	private final @NonNull SoapContext context;
+	private final @NonNull MultipartMessages parts;
+
+	private SoapMessage(@NonNull Message message) throws SOAPException {
+		this(new MultipartMessages(message));
+	}
+
+	private SoapMessage(@NonNull MultipartMessages parts) throws SOAPException {
+		this.parts = parts;
+		Message body = parts.body();
+		if (Message.isEmpty(body)) {
+			throw new SOAPException("no soap body found");
+		}
+
+		context = new SoapContext(body);
+	}
+
+	public static SoapMessage from(@NonNull HttpServletRequest request) throws SOAPException {
+		try {
+			if (!MultipartUtils.isMultipart(request)) {
+				return new SoapMessage(MessageUtils.parseContentAsMessage(request));
+			}
+
+			return new SoapMessage(MultipartUtils.parseMultipart(request.getInputStream(), request.getContentType(), null));
+		} catch (IOException e) {
+			throw new SOAPException("failed to parse request", e);
+		}
+	}
+
+	public @Nullable Map<String, Message> getAttachments() {
+		return parts.messages();
+	}
+
+	public @NonNull SoapContext getSoapContext() {
+		return context;
+	}
+
+	public @Nullable Object getMultipartXml() {
+		return parts.multipartXml();
+	}
+
+	public @NonNull Message getBody() {
+		return parts.body();
+	}
+}

--- a/core/src/main/java/org/frankframework/http/rpc/WebServiceListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rpc/WebServiceListenerServlet.java
@@ -1,0 +1,316 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.http.rpc;
+
+import java.io.IOException;
+import java.util.Map.Entry;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.xml.soap.SOAPConstants;
+import jakarta.xml.soap.SOAPException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.logging.log4j.CloseableThreadContext;
+import org.apache.logging.log4j.ThreadContext;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.MediaType;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.core.ListenerException;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.core.SpringSecurityHandler;
+import org.frankframework.http.AbstractHttpServlet;
+import org.frankframework.http.HttpEntityType;
+import org.frankframework.http.WebServiceListener;
+import org.frankframework.http.mime.HttpEntityFactory;
+import org.frankframework.http.mime.MultipartUtils;
+import org.frankframework.lifecycle.DynamicRegistration;
+import org.frankframework.lifecycle.IbisInitializer;
+import org.frankframework.receivers.ServiceClient;
+import org.frankframework.receivers.ServiceDispatcher;
+import org.frankframework.stream.Message;
+import org.frankframework.stream.MessageContext;
+import org.frankframework.util.AppConstants;
+import org.frankframework.util.LogUtil;
+import org.frankframework.util.XmlBuilder;
+
+@Log4j2
+@IbisInitializer
+public class WebServiceListenerServlet extends AbstractHttpServlet implements DynamicRegistration.Servlet {
+	private static final long serialVersionUID = 1L;
+	private transient ServiceDispatcher sd;
+
+	private static final boolean BACKWARDS_COMPATIBILITY_MODE = AppConstants.getInstance().getBoolean("WebServiceListener.backwardsCompatibleMultipartNotation", false);
+	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", false);
+
+	private static final String SOAP_PROTOCOL_KEY = "soapProtocol";
+	private static final String SOAP_ACTION = "SOAPAction";
+
+	@Override
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
+		sd = ServiceDispatcher.getInstance();
+	}
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String uri = cleanseURL(request.getPathInfo());
+		final SoapMessage soapMessage;
+		WebServiceListener listener;
+
+		try {
+			if (!"rpcrouter".equals(uri)) {
+				// Address lookup, try and find the listener by name directly.
+				listener = findService(uri);
+
+				// Only parse the message if we've found a WebServiceListener
+				soapMessage = (listener != null) ? SoapMessage.from(request) : null;
+			} else {
+				// RPC Router lookup, which requires parsing the entire message.
+				// First try finding by SOAPAction.
+				soapMessage = SoapMessage.from(request);
+				SoapContext context = soapMessage.getSoapContext();
+				listener = findService(context.getSoapAction());
+
+				// If unsuccessful try namespaceURI instead.
+				if (listener == null) {
+					listener = findService(context.getNamespaceURI());
+				}
+			}
+		} catch (Exception e) {
+			log.warn("caught exception while trying to parse SOAP message", e);
+			createSoapFault(response, "Could not process SOAP message", e);
+			return ;
+		}
+
+		// Nothing was found?
+		if (listener == null) {
+			log.warn("no listener found for uri [{}], returning 404", uri);
+			createSoapFault(response, "no service found for uri");
+			return ;
+		}
+
+		try (final CloseableThreadContext.Instance ignored = CloseableThreadContext.put(LogUtil.MDC_LISTENER_KEY, listener.getName());
+			final PipeLineSession pipelineSession = new PipeLineSession()) {
+
+			pipelineSession.put(PipeLineSession.HTTP_REQUEST_KEY, request);
+			pipelineSession.put(PipeLineSession.HTTP_RESPONSE_KEY, response);
+			pipelineSession.setSecurityHandler(new SpringSecurityHandler());
+
+			Message result = processRequest(soapMessage, pipelineSession, listener);
+
+			final boolean outputWritten = writeToResponseStream(response, result, listener, pipelineSession);
+			if (!outputWritten) {
+				log.debug("No output written, set content-type header to null");
+				response.resetBuffer();
+				response.setContentType(null);
+			}
+		} catch (Exception e) {
+			log.warn("caught exception while processing message", e);
+			createSoapFault(response, "Could not process SOAP message", e);
+		} finally {
+			ThreadContext.clearAll();
+		}
+	}
+
+	@Nullable
+	private WebServiceListener findService(String serviceName) {
+		if (StringUtils.isBlank(serviceName) || sd == null) {
+			log.debug("unable to find serviceName [{}]", serviceName);
+			return null;
+		}
+		log.debug("trying to find serviceName from soapMessage [{}]", serviceName);
+
+		ServiceClient service = sd.getListener(serviceName);
+		if (!(service instanceof WebServiceListener listener)) {
+			return null;
+		}
+		return listener;
+	}
+
+	protected static Message processRequest(SoapMessage request, PipeLineSession session, WebServiceListener listener) throws SOAPException, IOException {
+		SoapContext context = request.getSoapContext();
+		String messageId = context.getMessageId();
+		PipeLineSession.updateListenerParameters(session, messageId, messageId);
+		log.debug("received message");
+
+		String soapProtocol = context.getSoapProtocol();
+		log.debug("transforming from SOAP message using protocol [{}]", soapProtocol);
+		session.put(SOAP_PROTOCOL_KEY, soapProtocol);
+
+		// Should never be empty, but does happen at times?
+		session.put(SOAP_ACTION, context.getSoapAction());
+
+		// Make attachments in request (when present) available as session keys
+		if (BACKWARDS_COMPATIBILITY_MODE) {
+			handleIncomingAttachmentsLegacy(request, session);
+		} else {
+			session.putAll(request.getAttachments());
+			session.put(MultipartUtils.MULTIPART_ATTACHMENTS_SESSION_KEY, request.getMultipartXml());
+		}
+
+		final Message output;
+		try {
+			log.debug("processing message");
+			output = listener.processRequest(request.getBody(), session);
+		} catch (ListenerException e) {
+			throw new IOException("Could not process SOAP message", e);
+		}
+
+		return context.setMessageId(output);
+	}
+
+	/**
+	 * This method uses a custom / different way to storing the multipart attachments in the PipeLineSession.
+	 */
+	private static void handleIncomingAttachmentsLegacy(SoapMessage request, PipeLineSession session) {
+		int i = 1;
+		XmlBuilder attachments = new XmlBuilder("attachments");
+		for (Entry<String, Message> string : request.getAttachments().entrySet()) {
+			Message attachmentPart = string.getValue();
+
+			XmlBuilder attachment = new XmlBuilder("attachment");
+			attachments.addSubElement(attachment);
+			XmlBuilder sessionKey = new XmlBuilder("sessionKey");
+			sessionKey.setValue("attachment" + i);
+			attachment.addSubElement(sessionKey);
+			session.put("attachment" + i, attachmentPart);
+			log.debug("adding attachment [attachment{}] to session", i);
+
+			attachment.addSubElement(getMimeHeadersXml(attachmentPart.getContext()));
+			i++;
+		}
+		session.put("attachments", attachments.asXmlString());
+	}
+
+	private static XmlBuilder getMimeHeadersXml(MessageContext messageContext) {
+		XmlBuilder xmlMimeHeaders = new XmlBuilder("mimeHeaders");
+		messageContext.entrySet().forEach(e -> {
+			String name = e.getKey();
+			if (name.startsWith(MessageContext.HEADER_PREFIX)) {
+				XmlBuilder xmlMimeHeader = new XmlBuilder("mimeHeader");
+				xmlMimeHeader.addAttribute("name", name.substring(7));
+				xmlMimeHeader.setValue("" + e.getValue());
+				xmlMimeHeaders.addSubElement(xmlMimeHeader);
+			}
+		});
+		return xmlMimeHeaders;
+	}
+
+	private static String cleanseURL(String pathInfo) {
+		if (pathInfo == null) {
+			return null;
+		}
+		String uri = pathInfo;
+
+		if (uri.endsWith("/")) {
+			uri = uri.substring(0, uri.length()-1);
+		}
+		if (uri.startsWith("/")) {
+			uri = uri.substring(1);
+		}
+		return uri;
+	}
+
+	private static boolean writeToResponseStream(HttpServletResponse response, Message result, WebServiceListener listener, PipeLineSession session) throws IOException {
+		response.resetBuffer();
+
+		String attachmentXmlSessionKey = listener.getMultipartXmlSessionKey();
+		final HttpEntityFactory entityFactory;
+		if (StringUtils.isNotEmpty(attachmentXmlSessionKey) && session.containsKey(attachmentXmlSessionKey)) {
+			log.debug("building multipart message with MultipartXmlSessionKey [{}]", attachmentXmlSessionKey);
+			entityFactory = HttpEntityFactory.Builder.create()
+					.entityType(listener.isMtomEnabled() ? HttpEntityType.MTOM : HttpEntityType.FORMDATA)
+					.firstBodyPartName("message")
+					.multipartXmlSessionKey(attachmentXmlSessionKey)
+					.build();
+		} else {
+			String soapProtocol = session.get(SOAP_PROTOCOL_KEY, SOAPConstants.SOAP_1_1_PROTOCOL);
+			ContentType contentType = SOAPConstants.SOAP_1_1_PROTOCOL.equals(soapProtocol) ? ContentType.create("text/xml") : ContentType.APPLICATION_SOAP_XML;
+			entityFactory = HttpEntityFactory.Builder.create()
+					.entityType(HttpEntityType.BINARY)
+					.contentType(contentType)
+					.build();
+		}
+
+		HttpEntity entity = entityFactory.create(result, null, session);
+
+		long contentLength = entity.getContentLength();
+		if (contentLength == 0L) {
+			log.warn("no response entity to return, result [{}]", result);
+			return false;
+		}
+		if (contentLength != Message.MESSAGE_SIZE_UNKNOWN) {
+			response.setContentLengthLong(contentLength);
+		}
+
+		// Content-type might not be same as set before if we have a form. However it might also not be set.
+		if (entity.getContentType() != null) {
+			response.setContentType(entity.getContentType().getValue());
+		}
+		entity.writeTo(response.getOutputStream());
+
+		// After reading the entire entity, we may have a more accurate value for content-length before flushing the output.
+		if (entity.getContentLength() != contentLength) {
+			response.setContentLengthLong(entity.getContentLength());
+		}
+		return true;
+	}
+
+	private void createSoapFault(HttpServletResponse response, String string) {
+		createSoapFault(response, string, null);
+	}
+
+	private void createSoapFault(HttpServletResponse response, String faultString, Exception e) {
+		response.resetBuffer();
+
+		String msg = """
+				<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+				<soap:Body><soap:Fault>
+				<faultcode>soap:Server</faultcode>
+				<faultstring>%s</faultstring>
+				</soap:Fault></soap:Body></soap:Envelope>""".formatted(faultString);
+
+		try {
+			response.setContentType(MediaType.TEXT_XML_VALUE);
+			response.getWriter().printf(msg);
+		} catch (IOException e1) {
+			e1.addSuppressed(e);
+			log.error("unable to process SOAPFault", e1);
+		}
+	}
+
+	@Override
+	public String[] getAccessGrantingRoles() {
+		return IBIS_FULL_SERVICE_ACCESS_ROLES;
+	}
+
+	@Override
+	public String getUrlMapping() {
+		return "/services/*,/servlet/*";
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return !USE_CXF;
+	}
+}

--- a/core/src/main/java/org/frankframework/http/rpc/WebServiceListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rpc/WebServiceListenerServlet.java
@@ -60,7 +60,7 @@ public class WebServiceListenerServlet extends AbstractHttpServlet implements Dy
 	private transient ServiceDispatcher sd;
 
 	private static final boolean BACKWARDS_COMPATIBILITY_MODE = AppConstants.getInstance().getBoolean("WebServiceListener.backwardsCompatibleMultipartNotation", false);
-	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", false);
+	private static final boolean USE_CXF = AppConstants.getInstance().getBoolean("WebServiceListener.cxfServlet", true);
 
 	private static final String SOAP_PROTOCOL_KEY = "soapProtocol";
 	private static final String SOAP_ACTION = "SOAPAction";

--- a/core/src/main/java/org/frankframework/soap/filters/SoapAddressingMessageIdExtractor.java
+++ b/core/src/main/java/org/frankframework/soap/filters/SoapAddressingMessageIdExtractor.java
@@ -1,0 +1,93 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.soap.filters;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.xml.FullXmlFilter;
+
+/** 
+ * SAX filter that extracts the MessageID from a SOAP message.
+ */
+@Log4j2
+public class SoapAddressingMessageIdExtractor extends FullXmlFilter {
+	private @Getter String messageId;
+
+	private static final String SOAP_ADDR_NS_DOMAIN = "//www.w3.org/";
+	private static final String SOAP_ADDR_NS_POSTFIX = "addressing";
+
+	private static final String HEADER = "Header";
+	private static final String MESSAGE_ID = "MessageID";
+
+	private final Deque<String> elementStack = new ArrayDeque<>();
+	private StringBuilder messageIdBuilder = null;
+
+	public SoapAddressingMessageIdExtractor(ContentHandler contentHandler) {
+		super(contentHandler);
+	}
+
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		final String name = StringUtils.isEmpty(localName) ? qName : localName;
+		elementStack.push(name);
+
+		if (hasSoapHeaderMessageIdElement(name) && hasSoapAddressingNamespace(uri)) {
+			messageIdBuilder = new StringBuilder();
+		}
+
+		super.startElement(uri, localName, qName, attributes);
+	}
+
+	private boolean hasSoapHeaderMessageIdElement(String name) {
+		return elementStack.size() == 3 && elementStack.contains(HEADER) && MESSAGE_ID.equals(name);
+	}
+
+	private static boolean hasSoapAddressingNamespace(String uri) {
+		return uri.contains(SOAP_ADDR_NS_DOMAIN) && uri.contains(SOAP_ADDR_NS_POSTFIX);
+	}
+
+	@Override
+	public void characters(char[] ch, int start, int length) throws SAXException {
+		if (messageIdBuilder != null) {
+			messageIdBuilder.append(ch, start, length);
+		}
+
+		super.characters(ch, start, length);
+	}
+
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		elementStack.pop();
+
+		String actual = StringUtils.isEmpty(localName) ? qName : localName;
+		if (messageIdBuilder != null && MESSAGE_ID.equals(actual)) {
+			messageId = messageIdBuilder.toString();
+			messageIdBuilder = null;
+		}
+
+		super.endElement(uri, localName, qName);
+	}
+
+}

--- a/core/src/main/java/org/frankframework/soap/filters/SoapAddressingRelatesToInjector.java
+++ b/core/src/main/java/org/frankframework/soap/filters/SoapAddressingRelatesToInjector.java
@@ -1,0 +1,169 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.soap.filters;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.xml.FullXmlFilter;
+
+/** 
+ * SAX filter that injects a SOAP:Header with a RelatesTo element containing the
+ * reply messageId if it is not already present in the SOAP message.
+ */
+@Log4j2
+public class SoapAddressingRelatesToInjector extends FullXmlFilter {
+
+	private static final String DEFAULT_SOAP_ADDR_NS = "https://www.w3.org/2006/03/addressing/ws-addr.xsd";
+	private static final String SOAP_ADDR_NS_PREFIX = "wsa";
+	private static final String SOAP_ADDR_NS_DOMAIN = "//www.w3.org/";
+	private static final String SOAP_ADDR_NS_POSTFIX = "addressing";
+
+	private static final String ENVELOPE = "Envelope";
+	private static final String HEADER = "Header";
+	private static final String RELATES_TO = "RelatesTo";
+
+	private final Deque<String> elementStack = new ArrayDeque<>();
+
+	private boolean headerSeen = false;
+	private boolean foundRelatesTo = false;
+	private boolean writtenRelatesTo = false;
+	private String messageId;
+
+	public SoapAddressingRelatesToInjector(@Nullable ContentHandler contentHandler) {
+		super(contentHandler);
+	}
+
+	public void setMessageId(String messageId) {
+		this.messageId = messageId;
+	}
+
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		final String name = StringUtils.isEmpty(localName) ? qName : localName;
+		elementStack.push(name);
+
+		// Stack is 2, either a SOAP:Header or a SOAP:Body.
+		if (elementStack.size() == 2) {
+			if (HEADER.equals(name)) {
+				headerSeen = true;
+			}
+			if (!headerSeen) {
+				// If we've not seen a SOAP:Header it must be the body without a header (valid SOAP).
+				createSoapHeader(uri, StringUtils.substringBefore(qName, ":"));
+			}
+		}
+
+		// We're looking for a RelatesTo element in the SOAP:Header, which is 3 levels deep.
+		if (hasSoapHeaderRelatesToElement(name) && hasSoapAddressingNamespace(uri)) {
+			// We've found a RelatesTo element in the SOAP:Header, no need to inject one.
+			foundRelatesTo = true;
+		}
+
+		super.startElement(uri, localName, qName, attributes);
+	}
+
+	private boolean hasSoapHeaderRelatesToElement(String name) {
+		return elementStack.size() == 3 && elementStack.contains(HEADER) && RELATES_TO.equals(name);
+	}
+
+	private static boolean hasSoapAddressingNamespace(String uri) {
+		return uri.contains(SOAP_ADDR_NS_DOMAIN) && uri.contains(SOAP_ADDR_NS_POSTFIX);
+	}
+
+	/**
+	 * Creates a SOAP:Header element with a RelatesTo child element containing the messageId.
+	 */
+	private void createSoapHeader(String soapEnvUri, String soapEnvQNamePrefix) throws SAXException {
+		// The soapEnvQNamePrefix is the prefix used in the SOAP envelope, e.g. "soapenv" or "soap".
+		// This qName must match the prefix used in the SOAP envelope, otherwise the SOAP message will be invalid.
+		String headerQName = soapEnvQNamePrefix + ":" + HEADER;
+		try {
+			// Write the SOAP:Header element.
+			super.startElement(soapEnvUri, HEADER, headerQName, new AttributesImpl());
+
+			// Write the RelatesTo element.
+			writeRelatesToElement();
+
+			// Finish off with the SOAP:Header end element.
+			super.endElement(soapEnvUri, HEADER, headerQName);
+		} catch (SAXException e) {
+			throw new SAXException("unable to inject SOAP:Header", e);
+		}
+	}
+
+	@Override
+	public void characters(char[] ch, int start, int length) throws SAXException {
+		if (foundRelatesTo && length > 0) {
+			// We may have found a RelatesTo element, but if it has no content, we still need to write the messageId to it.
+			// StAX automatically removes all whitespace characters.
+			writtenRelatesTo = true;
+		}
+		super.characters(ch, start, length);
+	}
+
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		elementStack.pop();
+		String name = StringUtils.isEmpty(localName) ? qName : localName;
+
+		// We've found a RelatesTo element, no need to do anything.
+		if (foundRelatesTo && RELATES_TO.equals(name)) {
+			// Unless no data was written to it (empty element).
+			writeRelatesToId();
+		}
+		if (!writtenRelatesTo && HEADER.equals(name) && elementStack.size() == 1 && ENVELOPE.equals(elementStack.peek())) {
+			// We're about to close the SOAP:Header and we didn't find a RelatesTo element, so we need to inject it.
+			writeRelatesToElement();
+		}
+
+		super.endElement(uri, localName, qName);
+	}
+
+	private void writeRelatesToId() throws SAXException {
+		if (!writtenRelatesTo) {
+			char[] idToWrite = messageId.toCharArray();
+			super.characters(idToWrite, 0, idToWrite.length);
+		}
+
+		writtenRelatesTo = true;
+	}
+
+	/**
+	 * Writes the {@code <RelatesTo>} element with the messageId as its content.
+	 * Uses the 'WSA' namespace prefix.
+	 */
+	private void writeRelatesToElement() throws SAXException {
+		// Use the WSA namespacePrefix
+		super.startPrefixMapping(SOAP_ADDR_NS_PREFIX, DEFAULT_SOAP_ADDR_NS);
+		super.startElement(DEFAULT_SOAP_ADDR_NS, RELATES_TO, SOAP_ADDR_NS_PREFIX+":"+RELATES_TO, new AttributesImpl());
+
+		writeRelatesToId();
+
+		super.endElement(DEFAULT_SOAP_ADDR_NS, RELATES_TO, SOAP_ADDR_NS_PREFIX+":"+RELATES_TO);
+		super.endPrefixMapping(SOAP_ADDR_NS_PREFIX);
+	}
+
+}

--- a/core/src/main/java/org/frankframework/soap/filters/SoapNamespaceUriExtractor.java
+++ b/core/src/main/java/org/frankframework/soap/filters/SoapNamespaceUriExtractor.java
@@ -1,0 +1,66 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.soap.filters;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.xml.FullXmlFilter;
+
+/** 
+ * SAX filter that extracts the namespaceURI and MessageID from a SOAP message.
+ */
+@Log4j2
+public class SoapNamespaceUriExtractor extends FullXmlFilter {
+	private @Getter String namespaceURI;
+
+	private static final String BODY = "Body";
+
+	private final Deque<String> elementStack = new ArrayDeque<>();
+
+	public SoapNamespaceUriExtractor(@Nullable ContentHandler contentHandler) {
+		super(contentHandler);
+	}
+
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		final String name = StringUtils.isEmpty(localName) ? qName : localName;
+		elementStack.push(name);
+
+		// Extract the namespace URI of the first SOAP:Body element.
+		if (elementStack.size() == 3 && elementStack.contains(BODY)) {
+			namespaceURI = uri;
+		}
+
+		super.startElement(uri, localName, qName, attributes);
+	}
+
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		elementStack.pop();
+		super.endElement(uri, localName, qName);
+	}
+
+}

--- a/core/src/main/java/org/frankframework/soap/filters/ValidateSoapMessageHandler.java
+++ b/core/src/main/java/org/frankframework/soap/filters/ValidateSoapMessageHandler.java
@@ -1,0 +1,140 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.soap.filters;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import jakarta.xml.soap.SOAPConstants;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.jspecify.annotations.Nullable;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.xml.FullXmlFilter;
+
+/** 
+ * SAX filter that validates that the SOAP message is well-formed and follows the SOAP specification.
+ */
+@Log4j2
+public class ValidateSoapMessageHandler extends FullXmlFilter {
+	private @Getter String soapProtocol;
+
+	private static final String SOAP11_NS = "//schemas.xmlsoap.org/soap/envelope";
+	private static final String SOAP12_NS = "//www.w3.org/2003/05/soap-envelope";
+
+	private static final String ENVELOPE = "Envelope";
+	private static final String HEADER = "Header";
+	private static final String BODY = "Body";
+
+	private final Deque<String> elementStack = new ArrayDeque<>();
+
+	private String soapNamespace; // Detected from Envelope
+	private boolean seenEnvelope = false;
+	private boolean seenHeader = false;
+	private boolean seenBody = false;
+
+	public ValidateSoapMessageHandler(@Nullable ContentHandler contentHandler) {
+		super(contentHandler);
+	}
+
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		final String name = StringUtils.isEmpty(localName) ? qName : localName;
+		elementStack.push(name);
+
+		// Root must be SOAP Envelope in SOAP 1.1 or 1.2 namespace
+		if (elementStack.size() == 1) {
+			if (!ENVELOPE.equals(name)) {
+				throw new SAXException("Root element must be soap:Envelope, but found: " + name);
+			}
+
+			String uriWithoutProtocolAndLastSlash = Strings.CI.removeEnd(StringUtils.substringAfter(uri, ":"), "/");
+			if (SOAP11_NS.equals(uriWithoutProtocolAndLastSlash)) {
+				soapProtocol = SOAPConstants.SOAP_1_1_PROTOCOL;
+			} else if (SOAP12_NS.equals(uriWithoutProtocolAndLastSlash)) {
+				soapProtocol = SOAPConstants.SOAP_1_2_PROTOCOL;
+			} else {
+				throw new SAXException("Envelope namespace must be SOAP 1.1 or 1.2, but found: " + uri);
+			}
+
+			soapNamespace = uri;
+			seenEnvelope = true;
+		} else if (elementStack.size() == 2) {
+			validateElementNameAndNamespace(uri, name);
+		}
+
+		super.startElement(uri, localName, qName, attributes);
+	}
+
+	// Direct child of Envelope can be Header (optional) or Body (required)
+	private void validateElementNameAndNamespace(String uri, String name) throws SAXException {
+		if (!soapNamespace.equals(uri)) {
+			throw new SAXException("Direct children of Envelope must use the same SOAP namespace: " + soapNamespace);
+		}
+
+		if (HEADER.equals(name)) {
+			if (seenHeader) {
+				throw new SAXException("SOAP Envelope can contain at most one Header.");
+			}
+			if (seenBody) {
+				throw new SAXException("SOAP Header must appear before Body.");
+			}
+			seenHeader = true;
+			return;
+		}
+
+		if (BODY.equals(name)) {
+			if (seenBody) {
+				throw new SAXException("SOAP Envelope can contain at most one Body.");
+			}
+			seenBody = true;
+			return;
+		}
+
+		throw new SAXException("Invalid element under Envelope: " + name + ". Only Header (optional) and Body (required) are allowed.");
+	}
+
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		String expected = elementStack.pop();
+		String actual = StringUtils.isEmpty(localName) ? qName : localName;
+		if (!expected.equals(actual)) {
+			throw new SAXException("Malformed XML nesting. Expected closing for " + expected + " but found " + actual);
+		}
+
+		super.endElement(uri, localName, qName);
+	}
+
+	@Override
+	public void endDocument() throws SAXException {
+		if (!seenEnvelope) {
+			throw new SAXException("Missing SOAP Envelope.");
+		}
+		if (!seenBody) {
+			throw new SAXException("Missing required SOAP Body.");
+		}
+
+		super.endDocument();
+	}
+
+}

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -810,6 +810,16 @@ loadBalancer.url=
 migration.rewriteLegacyClassNames=true
 
 ####
+#### WebServices
+
+## Handle attachments differently
+WebServiceListener.backwardsCompatibleMultipartNotation=false
+
+## Use CXF to handle SOAP traffic opposed to a custom implementation.
+WebServiceListener.cxfServlet=false
+
+
+####
 #### RestListener CORS Protection
 
 #rest.cors.allowOrigin

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -816,7 +816,7 @@ migration.rewriteLegacyClassNames=true
 WebServiceListener.backwardsCompatibleMultipartNotation=false
 
 ## Use CXF to handle SOAP traffic opposed to a custom implementation.
-WebServiceListener.cxfServlet=false
+WebServiceListener.cxfServlet=true
 
 
 ####

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -737,6 +738,7 @@ public class ApiListenerServletTest {
 		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
 		builder.addTextBody("string1", "<hallo>€ è</hallo>", ContentType.create("text/plain"));
 		builder.addTextBody("string2", "<hello>€ è</hello>", ContentType.create("text/plain", "UTF-8"));// explicitly sent as UTF-8
+		builder.addTextBody("string3", "<hello>€ è</hello>", ContentType.create("text/plain", "UTF-8"));// explicitly sent as UTF-8
 
 		URL url1 = ClassLoaderUtils.getResourceURL("/test1.xml");
 		assertNotNull(url1);
@@ -754,8 +756,8 @@ public class ApiListenerServletTest {
 		assertNotNull(multipartXml);
 		MatchUtils.assertXmlEquals("""
 				<parts>
-					<part name="string1" type="text" value="&lt;hallo&gt;? ?&lt;/hallo&gt;" />
-					<part name="string2" type="text" value="&lt;hello&gt;€ è&lt;/hello&gt;" />
+					<part name="string1" sessionKey="string1" type="text" value="&lt;hallo&gt;? ?&lt;/hallo&gt;" />
+					<part name="string3" sessionKey="string3" type="text" value="&lt;hello&gt;€ è&lt;/hello&gt;" />
 					<part name="file1" type="file" filename="file1" size="1006" sessionKey="file1" mimeType="application/xml"/>
 				</parts>\
 				""", multipartXml);
@@ -788,11 +790,10 @@ public class ApiListenerServletTest {
 		assertNotNull(multipartXml);
 		MatchUtils.assertXmlEquals("""
 				<parts>
-					<part name="string1" type="text" value="&lt;hello&gt;€ è&lt;/hello&gt;" />
-					<part name="file1" type="file" filename="file1" size="1006" sessionKey="file1" mimeType="application/xml"/>
+					<part name="file1" type="file" filename="file1" size="1006" sessionKey="attachment1" mimeType="application/xml"/>
 				</parts>\
 				""", multipartXml);
-		Message file = (Message) session.get("file1");
+		Message file = assertInstanceOf(Message.class, session.get("attachment1"));
 		assertEquals("ISO-8859-1", file.getCharset());
 	}
 

--- a/core/src/test/java/org/frankframework/http/rpc/SoapContextTest.java
+++ b/core/src/test/java/org/frankframework/http/rpc/SoapContextTest.java
@@ -1,0 +1,236 @@
+package org.frankframework.http.rpc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPConstants;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import org.frankframework.stream.Message;
+import org.frankframework.stream.UrlMessage;
+import org.frankframework.util.MessageUtils;
+
+public class SoapContextTest {
+
+	private Message getFile(String file) {
+		URL url = this.getClass().getResource(file);
+		if (url == null) {
+			fail("file not found");
+		}
+		return new UrlMessage(url);
+	}
+
+	private SoapContext createContextFromRawMessage(String filename) throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/address/test123");
+		Message rawContent = getFile("/Soap/"+filename);
+
+		try (BufferedReader reader = new BufferedReader(rawContent.asReader())) {
+			for (String line; null != (line = reader.readLine()); ) {
+				if (line.isBlank()) {
+					break;
+				}
+
+				String[] h = StringUtils.split(line, ": ", 2);
+				request.addHeader(h[0], h[1]);
+			}
+
+			Writer sw = new StringWriter();
+			reader.transferTo(sw);
+			request.setContent(sw.toString().getBytes(StandardCharsets.UTF_8));
+		}
+
+		return SoapMessage.from(request).getSoapContext();
+	}
+
+	@Test
+	public void testGetNamespaceURI() throws Exception {
+		SoapContext context = new SoapContext(getFile("/Soap/VrijeBerichten_PipelineRequest.xml"));
+		assertEquals("http://www.egem.nl/StUF/sector/zkn/0310", context.getNamespaceURI());
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"1, '/raw/soap1_1.txt'",
+			"1, '/raw/soap1_1_with_action_in_contenttype.txt'",
+			"2, '/raw/soap1_2.txt'",
+			"2, '/raw/soap1_2_with_soapaction_header.txt'"
+	})
+	public void testFindSoapAction(int version, String file) throws Exception {
+		SoapContext context = createContextFromRawMessage(file);
+
+		assertEquals("SOAP 1.%d Protocol".formatted(version), context.getSoapProtocol());
+		assertEquals("http://www.egem.nl/StUF/sector/zkn/0310", context.getSoapAction());
+	}
+
+	@Test
+	public void validXmlInvalidSoap() {
+		SOAPException e = assertThrows(SOAPException.class, () -> new SoapContext(new Message("""
+				<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+					<soapenv:Boody>
+						<hallo/>
+					</soapenv:Body>
+				</soapenv:Envelope>
+				""")));
+		assertEquals("invalid SOAP message", e.getMessage());
+	}
+
+	@Test
+	public void validXmlInvalidSoap2() {
+		SOAPException e = assertThrows(SOAPException.class, () -> new SoapContext(new Message("""
+				<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+					<soapenv:Body>
+						<hallo/>
+					</soapenv:Body>
+					<soapenv:Header />
+				</soapenv:Envelope>
+				""")));
+		assertEquals("invalid SOAP message", e.getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"/Validation/EB-XML/Soap/valid-soap-with-must-understand-attrib.xml"
+	})
+	public void validSoap(String resource) {
+		assertDoesNotThrow(() -> new SoapContext(getFile(resource)));
+	}
+
+	@Test
+	public void invalidXml() {
+		SOAPException e = assertThrows(SOAPException.class, () -> new SoapContext(new Message("""
+				<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+					<soapenv:Body>
+						<hallo>
+					</soapenv:Body>
+				</soapenv:Envelope>
+				""")));
+		assertEquals("invalid SOAP message", e.getMessage());
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"text/xml;action=tralala, tralala",
+			"application/soap+xml;charset=UTF-8;action=0310, 0310",
+			"application/soap+xml;charset=UTF-8;action=\"0310\", 0310",
+			"application/soap+xml;charset=UTF-8;action='0310', 0310",
+			"application/soap+xml;charset=UTF-8;action=\"http://www.egem.nl/StUF/sector/zkn/0310\", http://www.egem.nl/StUF/sector/zkn/0310"
+	})
+	public void findAction(String contentType, String action) {
+		MediaType mediaType = MediaType.parseMediaType(contentType);
+		assertEquals(action, SoapContext.findAction(mediaType));
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"application/soap+xml;charset=UTF-8;action=\"\"",
+			"application/soap+xml;charset=UTF-8;action=''",
+	})
+	public void emptyAction(String contentType) {
+		MediaType mediaType = MediaType.parseMediaType(contentType);
+		assertEquals("", SoapContext.findAction(mediaType));
+	}
+
+	@Test
+	public void nullAction() {
+		MediaType mediaType = MediaType.parseMediaType("application/soap+xml;charset=UTF-8;action");
+		assertNull(SoapContext.findAction(mediaType));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"soap-addressing.xml",
+			"soap-addressing-ns.xml",
+			"soap-addressing-minimal.xml",
+			"soap-addressing-ns-on-header.xml",
+			"soap-addressing-with-selfclosing-relatesto.xml",
+			"soap-addressing-with-empty-relatesto.xml"
+		})
+	public void soapAddressing(String input) throws Throwable {
+		SoapContext context = new SoapContext(getFile("/Soap/" + input));
+
+		assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", context.getMessageId());
+
+		Message responseMessage = new Message("""
+			<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+				<soapenv:Body>
+					<hallo/>
+				</soapenv:Body>
+			</soapenv:Envelope>
+			""");
+
+		Message responseWithId = context.setMessageId(responseMessage);
+
+		MessageFactory factory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
+		SOAPMessage soapMessage = factory.createMessage();
+		soapMessage.getSOAPPart().setContent(responseWithId.asSource());
+
+		NodeList nodes = soapMessage.getSOAPHeader().getElementsByTagNameNS("https://www.w3.org/2006/03/addressing/ws-addr.xsd", "RelatesTo");
+		if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
+			String relatesTo = nodes.item(0).getTextContent();
+			assertEquals("6B29FC40-CA47-1067-B31D-00DD010662DA", relatesTo);
+		} else {
+			fail("no message id found in response: " + responseWithId.asString());
+		}
+	}
+
+	@Test
+	public void soapAddressNoMid() throws Throwable {
+		SoapContext context = new SoapContext(getFile("/Soap/soap-addressing-ns-but-no-mid.xml"));
+
+		String mid = context.getMessageId();
+		assertNotNull(mid);
+		assertTrue(mid.startsWith(MessageUtils.DEFAULT_MESSAGE_ID_PREFIX));
+
+		Message responseWithId = context.setMessageId(getFile("/Soap/soapmsg1_2.xml"));
+
+		assertFalse(responseWithId.asString().contains("RelatesTo"), "response should not contain the <RelatesTo../> element.");
+	}
+
+	@Test
+	/**
+	 * We want to ensure that when somebody has manually set a relatesTo (although I cannot imagine why) we don't overwrite it.
+	 */
+	public void soapWithManualRelatesTo() throws Throwable {
+		SoapContext context = new SoapContext(getFile("/Soap/soap-addressing-with-relatesto.xml"));
+
+		Message response = getFile("/Soap/soap-addressing-with-relatesto.xml");
+		Message responseWithId = context.setMessageId(response);
+
+		MessageFactory factory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+		SOAPMessage soapMessage = factory.createMessage();
+		soapMessage.getSOAPPart().setContent(responseWithId.asSource());
+
+		NodeList nodes = soapMessage.getSOAPHeader().getElementsByTagNameNS("*", "RelatesTo");
+		if (nodes.getLength() > 0 && nodes.item(0).getNodeType() == Node.ELEMENT_NODE) {
+			String relatesTo = nodes.item(0).getTextContent();
+			assertEquals("test123", relatesTo);
+		} else {
+			fail("no message id found in response: " + responseWithId.asString());
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/http/rpc/WebServiceListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rpc/WebServiceListenerServletTest.java
@@ -1,0 +1,148 @@
+package org.frankframework.http.rpc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.net.URL;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import org.frankframework.core.IMessageHandler;
+import org.frankframework.core.PipeLineSession;
+import org.frankframework.http.WebServiceListener;
+import org.frankframework.receivers.MessageWrapper;
+import org.frankframework.receivers.ServiceClient;
+import org.frankframework.receivers.ServiceDispatcher;
+import org.frankframework.stream.Message;
+import org.frankframework.stream.UrlMessage;
+import org.frankframework.testutil.MatchUtils;
+
+class WebServiceListenerServletTest {
+	private static final ServiceDispatcher DISPATCHER = ServiceDispatcher.getInstance();
+	private WebServiceListenerServlet servlet;
+
+	@BeforeEach
+	public void setup() throws ServletException {
+		servlet = new WebServiceListenerServlet();
+		servlet.init(mock(ServletConfig.class));
+		DISPATCHER.getRegisteredListenerNames().forEach(DISPATCHER::unregisterServiceClient);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		DISPATCHER.getRegisteredListenerNames().forEach(DISPATCHER::unregisterServiceClient);
+	}
+
+	private String doPost(String filename, String requestUri) throws Exception {
+		return doPost(getFile(filename), requestUri);
+	}
+
+	private String doPost(Message content, String requestUri) throws Exception {
+		MockHttpServletRequest request = createContextFromRawMessage(content, requestUri);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		servlet.doPost(request, response);
+
+		return response.getContentAsString();
+	}
+
+	@Test
+	void doPostNoServiceRegistered() throws Exception {
+		String response = doPost("/soapmsg1_1.xml", "services/rpcrouter");
+
+		assertEquals("""
+						<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+						<soap:Body><soap:Fault>
+						<faultcode>soap:Server</faultcode>
+						<faultstring>no service found for uri</faultstring>
+						</soap:Fault></soap:Body></soap:Envelope>""", response);
+	}
+
+	@Test
+	public void testCanFindNamespaceButServiceClientOfWrongType() throws Exception {
+		ServiceClient service = mock(ServiceClient.class);
+		DISPATCHER.registerServiceClient("http://www.egem.nl/StUF/sector/zkn/0310", service);
+		String response = doPost("VrijeBerichten_PipelineRequest.xml", "services/rpcrouter");
+
+		assertEquals("""
+						<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+						<soap:Body><soap:Fault>
+						<faultcode>soap:Server</faultcode>
+						<faultstring>no service found for uri</faultstring>
+						</soap:Fault></soap:Body></soap:Envelope>""", response);
+	}
+
+	@Test
+	void doPostNotSoap() throws Exception {
+		String response = doPost(new Message("""
+				<xml>
+					<not-soap/>
+				</xml>
+				"""), "services/rpcrouter");
+
+		assertEquals("""
+						<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+						<soap:Body><soap:Fault>
+						<faultcode>soap:Server</faultcode>
+						<faultstring>Could not process SOAP message</faultstring>
+						</soap:Fault></soap:Body></soap:Envelope>""", response);
+	}
+
+	@Test
+	void doPostServiceRegistered() throws Exception {
+		Message pipelineResult = getFile("VrijeBerichten_PipelineResult.xml");
+
+		WebServiceListener listener = new WebServiceListener();
+		IMessageHandler<Message> handler = mock(IMessageHandler.class);
+		listener.setHandler(handler);
+
+		doAnswer(e -> {
+			MessageWrapper messageWrapper = e.getArgument(1);
+
+			try {
+				MatchUtils.assertXmlEquals(getFile("VrijeBerichten_PipelineRequest.xml").asString(), messageWrapper.getMessage().asString());
+				return pipelineResult;
+			} catch (IOException ex) {
+				fail("unable to read response message: " + ex.getMessage(), ex);
+				return null;
+			}
+		}).when(handler).processRequest(eq(listener), any(MessageWrapper.class), any(PipeLineSession.class));
+
+		listener.setServiceNamespaceURI("http://www.egem.nl/StUF/sector/zkn/0310");
+		listener.setSoap(false);
+		listener.configure();
+		listener.start();
+
+		String response = doPost("VrijeBerichten_PipelineRequest.xml", "services/rpcrouter");
+
+		String expected = getFile("VrijeBerichten_PipelineResult.xml").asString();
+		MatchUtils.assertXmlEquals(expected, response);
+	}
+
+	private Message getFile(String file) {
+		URL url = this.getClass().getResource("/Soap/"+file);
+		if (url == null) {
+			fail("file not found");
+		}
+		return new UrlMessage(url);
+	}
+
+	private MockHttpServletRequest createContextFromRawMessage(Message rawContent, String requestUri) throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", requestUri);
+		request.setPathInfo(StringUtils.substringAfter(requestUri, "/"));
+		request.setContent(rawContent.asByteArray());
+		return request;
+	}
+}

--- a/core/src/test/resources/Soap/VrijeBerichten_PipelineRequest.xml
+++ b/core/src/test/resources/Soap/VrijeBerichten_PipelineRequest.xml
@@ -1,11 +1,21 @@
 <soapenv:Envelope
 	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
-	<soapenv:Header />
-	<soapenv:Body>
-		<ZKN:geefZaakdocumentbewerken_Di02
+	<soapenv:Header>
+		<ZKN2:geefZaakdocumentbewerken_Di02
+			xmlns:ZKN2="http://www.egem2.nl/StUF/sector/zkn/0310"
 			xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310"
 			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			xsi:schemaLocation="http://www.egem.nl/StUF/sector/zkn/0310 zkn0310_msg_zs-dms.xsd">
+			xsi:schemaLocation="http://www.egem2.nl/StUF/sector/zkn/0310 zkn0310_msg_zs-dms.xsd
+			http://www.egem.nl/StUF/sector/zkn/0310 zkn0310_msg_zs-dms.xsd">
+		</ZKN2:geefZaakdocumentbewerken_Di02>
+	</soapenv:Header>
+	<soapenv:Body>
+		<ZKN:geefZaakdocumentbewerken_Di02
+			xmlns:ZKN2="http://www.egem2.nl/StUF/sector/zkn/0310"
+			xmlns:ZKN="http://www.egem.nl/StUF/sector/zkn/0310"
+			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			xsi:schemaLocation="http://www.egem2.nl/StUF/sector/zkn/0310 zkn0310_msg_zs-dms.xsd
+			http://www.egem.nl/StUF/sector/zkn/0310 zkn0310_msg_zs-dms.xsd">
 			<ZKN:stuurgegevens>
 				<StUF:berichtcode
 					xmlns:StUF="http://www.egem.nl/StUF/StUF0301">Di02</StUF:berichtcode>

--- a/core/src/test/resources/Soap/raw/soap1_1.txt
+++ b/core/src/test/resources/Soap/raw/soap1_1.txt
@@ -1,0 +1,8 @@
+SOAPAction: http://www.egem.nl/StUF/sector/zkn/0310
+Content-Type: text/xml; charset=UTF-8
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
+    <hallo/>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/core/src/test/resources/Soap/raw/soap1_1_with_action_in_contenttype.txt
+++ b/core/src/test/resources/Soap/raw/soap1_1_with_action_in_contenttype.txt
@@ -1,0 +1,8 @@
+SOAPAction: http://www.egem.nl/StUF/sector/zkn/0310
+Content-Type: text/xml; charset=UTF-8;action="should not be used in SOAP 1.1"
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+  <soapenv:Body>
+    <hallo/>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/core/src/test/resources/Soap/raw/soap1_2.txt
+++ b/core/src/test/resources/Soap/raw/soap1_2.txt
@@ -1,0 +1,8 @@
+SOAPAction: http://www.egem.nl/StUF/sector/zkn/0310
+Content-Type: application/soap+xml;charset=UTF-8;action="http://www.egem.nl/StUF/sector/zkn/0310"
+
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
+  <soapenv:Body>
+    <hallo/>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/core/src/test/resources/Soap/raw/soap1_2_with_soapaction_header.txt
+++ b/core/src/test/resources/Soap/raw/soap1_2_with_soapaction_header.txt
@@ -1,0 +1,8 @@
+SOAPAction: http://www.egem.nl/StUF/sector/zkn/0310
+Content-Type: application/soap+xml;charset=UTF-8;action="http://www.egem.nl/StUF/sector/zkn/0310"
+
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
+  <soapenv:Body>
+    <hallo/>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/core/src/test/resources/Soap/soap-addressing-with-empty-relatesto.xml
+++ b/core/src/test/resources/Soap/soap-addressing-with-empty-relatesto.xml
@@ -1,0 +1,10 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+		<!-- We can do this because the input is the output (of our SoapProviderStub), and the input ignores this field. -->
+		<wsa:RelatesTo> 	</wsa:RelatesTo>
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>

--- a/core/src/test/resources/Soap/soap-addressing-with-selfclosing-relatesto.xml
+++ b/core/src/test/resources/Soap/soap-addressing-with-selfclosing-relatesto.xml
@@ -1,0 +1,10 @@
+<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope">
+	<Header xmlns:wsa="http://www.w3.org/2005/08/addressing">
+		<wsa:MessageID>6B29FC40-CA47-1067-B31D-00DD010662DA</wsa:MessageID>
+		<!-- We can do this because the input is the output (of our SoapProviderStub), and the input ignores this field. -->
+		<wsa:RelatesTo />
+	</Header>
+	<Body>
+		<GetVehicleTypeDetailsREQ />
+	</Body>
+</Envelope>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

(cherry picked from commit a8b600c)

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
