### PR TITLE
Fix logging to stdout in json format on kubernetes

### DIFF
--- a/core/src/main/resources/log4j2stdout.xml
+++ b/core/src/main/resources/log4j2stdout.xml
@@ -18,8 +18,8 @@
 
 		<Routing name="log-format-appender">
 			<Routes pattern="${are.we.on.k8s}">
-				<Route ref="json-stdout" key="true" />
 				<Route ref="text-stdout" key="false" />
+				<Route ref="json-stdout" />
 			</Routes>
 		</Routing>
 


### PR DESCRIPTION
When the property is not set, it resolves to false. So it routes to the text-stdout, but when it is set to a value, it resolves to a value, neither false nor true, so neither routes are used. This way if it resolves to false it takes the text-stdout route, otherwise if it has any value it resolves to the json-stdout route.