### PR TITLE
Don't show sun.misc.Unsafe warnings

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -8,3 +8,4 @@
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--sun-misc-unsafe-memory-access=allow


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Modified a jvm setting which makes sure certain warnings aren't logged

This is triggered by hazelcast. According to https://github.com/hazelcast/hazelcast/issues/26608 it can be suppressed.
