### PR TITLE
Ensure receiver always has a correct name

### DIFF
--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -891,15 +891,17 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 	@SuppressWarnings("java:S3457") // Cast arguments to String before invocation so that we do not have a recursive call to logger when trace-level logging is enabled
 	public void addReceiver(Receiver<?> receiver) {
 		if (StringUtils.isBlank(receiver.getName())) {
+			String newName = createReceiverName(receivers.size() + 1);
 			// This will not contain the adapter name, as it's not present at this time yet which will make debugging this very difficult.
 			// Since we do need a name for each receiver, perhaps we should log this somewhere else to improve the dev-experience?
-			ConfigurationWarnings.add(receiver, log, "receiver does not have a name, generating implicit one.");
-			receiver.setName("Receiver [%d]".formatted(receivers.size() + 1));
+			ConfigurationWarnings.add(receiver, log, "does not have a name, using: '%s'".formatted(newName));
+			receiver.setName(newName);
 		}
 
 		if (receivers.stream().map(HasName::getName).toList().contains(receiver.getName())) {
-			ConfigurationWarnings.add(receiver, log, "name must be unique!");
-			receiver.setName("Receiver [%d]".formatted(receivers.size() + 1));
+			String newName = createReceiverName(receivers.size() + 1);
+			ConfigurationWarnings.add(receiver, log, "name must be unique, using: '%s'".formatted(newName));
+			receiver.setName(newName);
 		}
 
 		receivers.add(receiver);
@@ -909,6 +911,14 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 		} else {
 			log.debug("Adapter [{}] registered receiver [{}]", this::getId, receiver::getName);
 		}
+	}
+
+	private String createReceiverName(final int i) {
+		String potentialName = "Receiver [%d]".formatted(i);
+		if (receivers.stream().map(HasName::getName).toList().contains(potentialName)) {
+			return createReceiverName(i+1);
+		}
+		return potentialName;
 	}
 
 	/**

--- a/core/src/main/java/org/frankframework/core/Adapter.java
+++ b/core/src/main/java/org/frankframework/core/Adapter.java
@@ -887,19 +887,19 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 
 	/**
 	 * Receives incoming messages. If an adapter can receive messages through multiple channels, then add a receiver for each channel.
-	 * @ff.mandatory
 	 */
 	@SuppressWarnings("java:S3457") // Cast arguments to String before invocation so that we do not have a recursive call to logger when trace-level logging is enabled
 	public void addReceiver(Receiver<?> receiver) {
 		if (StringUtils.isBlank(receiver.getName())) {
 			// This will not contain the adapter name, as it's not present at this time yet which will make debugging this very difficult.
 			// Since we do need a name for each receiver, perhaps we should log this somewhere else to improve the dev-experience?
-			log.warn("receiver does not have a name, generating implicit one.");
+			ConfigurationWarnings.add(receiver, log, "receiver does not have a name, generating implicit one.");
 			receiver.setName("Receiver [%d]".formatted(receivers.size() + 1));
 		}
 
 		if (receivers.stream().map(HasName::getName).toList().contains(receiver.getName())) {
 			ConfigurationWarnings.add(receiver, log, "name must be unique!");
+			receiver.setName("Receiver [%d]".formatted(receivers.size() + 1));
 		}
 
 		receivers.add(receiver);
@@ -907,7 +907,7 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 		if (log.isTraceEnabled()) {
 			log.trace("Adapter [{}] registered receiver [{}]", name, receiver.toString());
 		} else {
-			log.debug("Adapter [{}] registered receiver [{}]", this::getId, receiver::getName); // Receivers don't always have a name...
+			log.debug("Adapter [{}] registered receiver [{}]", this::getId, receiver::getName);
 		}
 	}
 
@@ -1118,7 +1118,7 @@ public class Adapter extends GenericApplicationContext implements ManagableLifec
 					statsUpSince = 0;
 					runState.setRunState(RunState.STOPPED);
 					log.debug("Adapter [{}] now in state STOPPED", name);
-				} catch (Throwable t) {
+				} catch (@SuppressWarnings("java:S2142") Throwable t) {
 					addErrorMessageToMessageKeeper("got error stopping Adapter", t);
 					runState.setRunState(RunState.ERROR);
 					log.warn("Adapter [{}] in state ERROR", name, t);

--- a/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
+++ b/core/src/main/java/org/frankframework/receivers/PullingListenerContainer.java
@@ -379,7 +379,7 @@ public class PullingListenerContainer<M> implements IThreadCountControllable {
 					pollToken.release();
 				}
 				threadsRunning.decrementAndGet();
-				if (listener != null) {
+				if (listener != null && threadContext != null) {
 					try {
 						listener.closeThread(threadContext);
 					} catch (ListenerException e) {

--- a/core/src/test/java/org/frankframework/core/AdapterTest.java
+++ b/core/src/test/java/org/frankframework/core/AdapterTest.java
@@ -51,19 +51,55 @@ class AdapterTest {
 	void testDuplicateReceiverNames() {
 		try (TestConfiguration config = new TestConfiguration(); Adapter adapter = config.createBean()) {
 
-			Receiver<?> receiver1 = SpringUtils.createBean(adapter);
-			receiver1.setName("testReceiver");
-
-			Receiver<?> receiver2 = SpringUtils.createBean(adapter);
-			receiver2.setName("testReceiver");
-
-			adapter.addReceiver(receiver1);
+			adapter.addReceiver(createReceiver(adapter, "testReceiver"));
 			assertEquals(0, config.getConfigurationWarnings().size());
 
-			adapter.addReceiver(receiver2);
+			adapter.addReceiver(createReceiver(adapter, "testReceiver"));
 			assertEquals(1, config.getConfigurationWarnings().size());
-			assertEquals("Receiver [testReceiver] name must be unique!", config.getConfigWarning(0));
+			assertEquals("Receiver [testReceiver] name must be unique, using: 'Receiver [2]'", config.getConfigWarning(0));
 		}
+	}
+
+	@Test
+	void testNoReceiverName() {
+		try (TestConfiguration config = new TestConfiguration(); Adapter adapter = config.createBean()) {
+
+			// Add receive with default name of the 2nd receiver
+			adapter.addReceiver(createReceiver(adapter, "Receiver [2]"));
+			assertEquals(0, config.getConfigurationWarnings().size());
+
+			// Add without name
+			adapter.addReceiver(SpringUtils.createBean(adapter));
+
+			assertEquals(1, config.getConfigurationWarnings().size());
+			assertEquals("Receiver does not have a name, using: 'Receiver [3]'", config.getConfigWarning(0));
+		}
+	}
+
+	@Test
+	void testNoReceiverNameAndDuplicateName() {
+		try (TestConfiguration config = new TestConfiguration(); Adapter adapter = config.createBean()) {
+
+			adapter.addReceiver(createReceiver(adapter, "Receiver [1]"));
+			assertEquals(0, config.getConfigurationWarnings().size());
+
+			adapter.addReceiver(createReceiver(adapter, "Receiver [1]"));
+			assertEquals(1, config.getConfigurationWarnings().size());
+			assertEquals("Receiver [Receiver [1]] name must be unique, using: 'Receiver [2]'", config.getConfigWarning(0));
+
+			// Add without name
+			adapter.addReceiver(SpringUtils.createBean(adapter));
+
+			assertEquals(2, config.getConfigurationWarnings().size());
+			assertEquals("Receiver does not have a name, using: 'Receiver [3]'", config.getConfigWarning(1));
+		}
+	}
+
+	private static Receiver<?> createReceiver(Adapter adapter, String name) {
+		Receiver<?> receiver = SpringUtils.createBean(adapter);
+		receiver.setName(name);
+
+		return receiver;
 	}
 
 	private @NonNull EchoPipe buildTestPipe(@NonNull PipeLine pipeLine) throws ConfigurationException {


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
