### PR TITLE
Remove FileSystem#getNumberOfFilesInFolder(...)

### DIFF
--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -181,7 +181,7 @@ public class AmazonS3FileSystem extends AbstractFileSystem<S3FileRef> implements
 	@Override
 	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		try (DirectoryStream<S3FileRef> files = list(folder, TypeFilter.FILES_ONLY)) {
-			return Math.toIntExact(StreamSupport.stream(files.spliterator(), false).count());
+			return StreamSupport.stream(files.spliterator(), false).count();
 		} catch (IOException e) {
 			throw new FileSystemException("Exception while counting number of files in [" + folder + "]. " + e.getMessage());
 		}

--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -179,7 +179,7 @@ public class AmazonS3FileSystem extends AbstractFileSystem<S3FileRef> implements
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		try (DirectoryStream<S3FileRef> files = list(folder, TypeFilter.FILES_ONLY)) {
 			return Math.toIntExact(StreamSupport.stream(files.spliterator(), false).count());
 		} catch (IOException e) {

--- a/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
+++ b/aws/src/main/java/org/frankframework/filesystem/AmazonS3FileSystem.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -176,15 +175,6 @@ public class AmazonS3FileSystem extends AbstractFileSystem<S3FileRef> implements
 	@Override
 	public S3FileRef toFile(@Nullable String folder, @Nullable String filename) {
 		return toFile(StringUtil.concatStrings(folder, FILE_DELIMITER, filename));
-	}
-
-	@Override
-	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
-		try (DirectoryStream<S3FileRef> files = list(folder, TypeFilter.FILES_ONLY)) {
-			return StreamSupport.stream(files.spliterator(), false).count();
-		} catch (IOException e) {
-			throw new FileSystemException("Exception while counting number of files in [" + folder + "]. " + e.getMessage());
-		}
 	}
 
 	@Override

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
@@ -51,11 +51,13 @@ public abstract class AbstractFileSystem<F> implements IBasicFileSystem<F> {
 	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		int count = 0;
 		int stopAt = getMaxNumberOfMessagesToList();
-		if (stopAt<0) {
+
+		if (stopAt < 0) {
 			stopAt = Integer.MAX_VALUE;
 		}
-		try(DirectoryStream<F> ds = list(folder, TypeFilter.FILES_ONLY)) {
-			for (Iterator<F> it = ds.iterator(); it.hasNext() && count<=stopAt; it.next()) {
+
+		try (DirectoryStream<F> ds = list(folder, TypeFilter.FILES_ONLY)) {
+			for (Iterator<F> it = ds.iterator(); it.hasNext() && count <= stopAt; it.next()) {
 				count++;
 			}
 		} catch (IOException e) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
@@ -15,9 +15,6 @@
  */
 package org.frankframework.filesystem;
 
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.util.Iterator;
 
 import org.frankframework.core.DestinationType;
 import org.frankframework.core.DestinationType.Type;
@@ -45,25 +42,6 @@ public abstract class AbstractFileSystem<F> implements IBasicFileSystem<F> {
 	@Override
 	public boolean isOpen() {
 		return open;
-	}
-
-	@Override
-	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
-		int count = 0;
-		int stopAt = getMaxNumberOfMessagesToList();
-
-		if (stopAt < 0) {
-			stopAt = Integer.MAX_VALUE;
-		}
-
-		try (DirectoryStream<F> ds = list(folder, TypeFilter.FILES_ONLY)) {
-			for (Iterator<F> it = ds.iterator(); it.hasNext() && count <= stopAt; it.next()) {
-				count++;
-			}
-		} catch (IOException e) {
-			throw new FileSystemException(e);
-		}
-		return count;
 	}
 
 	/**

--- a/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/AbstractFileSystem.java
@@ -48,7 +48,7 @@ public abstract class AbstractFileSystem<F> implements IBasicFileSystem<F> {
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		int count = 0;
 		int stopAt = getMaxNumberOfMessagesToList();
 		if (stopAt<0) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/IBasicFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/IBasicFileSystem.java
@@ -61,7 +61,7 @@ public interface IBasicFileSystem<F> extends HasPhysicalDestination, AutoCloseab
 		return list(actualFolder, filter);
 	}
 	DirectoryStream<F> list(F folder, TypeFilter filter) throws FileSystemException;
-	int getNumberOfFilesInFolder(String folder) throws FileSystemException;
+	long getNumberOfFilesInFolder(String folder) throws FileSystemException;
 	/**
 	 * Get a string representation of an identification of a file.
 	 * Must pair up with the implementation of {@link #toFile(String)}.

--- a/filesystem/src/main/java/org/frankframework/filesystem/IBasicFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/IBasicFileSystem.java
@@ -61,7 +61,6 @@ public interface IBasicFileSystem<F> extends HasPhysicalDestination, AutoCloseab
 		return list(actualFolder, filter);
 	}
 	DirectoryStream<F> list(F folder, TypeFilter filter) throws FileSystemException;
-	long getNumberOfFilesInFolder(String folder) throws FileSystemException;
 	/**
 	 * Get a string representation of an identification of a file.
 	 * Must pair up with the implementation of {@link #toFile(String)}.

--- a/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
@@ -224,25 +224,6 @@ public class ImapFileSystem extends AbstractMailFileSystem<Message, MimeBodyPart
 	}
 
 	@Override
-	public long getNumberOfFilesInFolder(String foldername) throws FileSystemException {
-		IMAPFolder baseFolder = getConnection();
-		boolean invalidateConnectionOnRelease = false;
-		try {
-			IMAPFolder folder = getFolder(baseFolder, foldername);
-			if (!folder.isOpen()) {
-				folder.open(Folder.READ_WRITE);
-			}
-			Message[] messages = folder.getMessages();
-			return messages.length;
-		} catch (MessagingException e) {
-			invalidateConnectionOnRelease = true;
-			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder, invalidateConnectionOnRelease);
-		}
-	}
-
-	@Override
 	public DirectoryStream<Message> list(Message foldername, TypeFilter filter) throws FileSystemException {
 		if (filter.includeFolders()) {
 			throw new FileSystemException("Filtering on folders is not supported");

--- a/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ImapFileSystem.java
@@ -224,7 +224,7 @@ public class ImapFileSystem extends AbstractMailFileSystem<Message, MimeBodyPart
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String foldername) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String foldername) throws FileSystemException {
 		IMAPFolder baseFolder = getConnection();
 		boolean invalidateConnectionOnRelease = false;
 		try {

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
@@ -251,12 +251,6 @@ public class ExchangeFileSystem extends AbstractFileSystem<MailItemId> implement
 	}
 
 	@Override
-	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
-		MailFolder f = findSubFolder(mailFolder, folder);
-		return f.getTotalItemCount();
-	}
-
-	@Override
 	public DirectoryStream<MailItemId> list(MailItemId folderName, TypeFilter filter) throws FileSystemException {
 		MailFolder folder;
 		if (folderName == null) {

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/ExchangeFileSystem.java
@@ -251,7 +251,7 @@ public class ExchangeFileSystem extends AbstractFileSystem<MailItemId> implement
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		MailFolder f = findSubFolder(mailFolder, folder);
 		return f.getTotalItemCount();
 	}

--- a/filesystem/src/main/java/org/frankframework/filesystem/exchange/MailFolder.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/exchange/MailFolder.java
@@ -27,10 +27,10 @@ public class MailFolder extends MailItemId {
 	@JsonProperty("displayName")
 	private String name;
 
-	private int childFolderCount;
-	private int unreadItemCount;
-	private int totalItemCount;
-	private int sizeInBytes;
+	private long childFolderCount;
+	private long unreadItemCount;
+	private long totalItemCount;
+	private long sizeInBytes;
 
 	@Override
 	public String toString() {

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
@@ -87,7 +87,7 @@ public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTP
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		try {
 			FTPFile[] files = ftpClient.listFiles(folder, FTPFile::isFile);
 			return files == null? 0 : files.length;

--- a/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/ftp/FtpFileSystem.java
@@ -87,16 +87,6 @@ public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTP
 	}
 
 	@Override
-	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
-		try {
-			FTPFile[] files = ftpClient.listFiles(folder, FTPFile::isFile);
-			return files == null? 0 : files.length;
-		} catch (IOException e) {
-			throw new FileSystemException(e);
-		}
-	}
-
-	@Override
 	public DirectoryStream<FTPFileRef> list(FTPFileRef folder, TypeFilter filter) throws FileSystemException {
 		try {
 			String folderName = folder != null ? getCanonicalName(folder) : null;

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -101,17 +101,6 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 	}
 
 	@Override
-	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
-		try {
-			return listFolder(folder).stream()
-					.filter(f -> !f.getAttrs().isDir())
-					.count();
-		} catch (SftpException e) {
-			throw new FileSystemException(e);
-		}
-	}
-
-	@Override
 	public DirectoryStream<SftpFileRef> list(SftpFileRef folder, TypeFilter filter) throws FileSystemException {
 		try {
 			String folderName = folder != null ? getCanonicalName(folder) : null;

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -101,7 +101,7 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folder) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		try {
 			List<LsEntry> files = listFolder(folder);
 			return (int) files.stream().filter(f -> !f.getAttrs().isDir()).count();

--- a/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/sftp/SftpFileSystem.java
@@ -103,8 +103,9 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 	@Override
 	public long getNumberOfFilesInFolder(String folder) throws FileSystemException {
 		try {
-			List<LsEntry> files = listFolder(folder);
-			return (int) files.stream().filter(f -> !f.getAttrs().isDir()).count();
+			return listFolder(folder).stream()
+					.filter(f -> !f.getAttrs().isDir())
+					.count();
 		} catch (SftpException e) {
 			throw new FileSystemException(e);
 		}
@@ -151,7 +152,6 @@ public class SftpFileSystem extends SftpSession implements IWritableFileSystem<S
 	private List<LsEntry> listFolder(SftpFileRef folder) throws SftpException {
 		return this.listFolder(getCanonicalName(folder));
 	}
-
 
 	private List<LsEntry> listFolder(String folder) throws SftpException {
 		return new ArrayList<>(ftpClient.ls(folder == null ? "*" : folder));

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -341,7 +341,6 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 			F movedFile = fileSystem.moveFile(f, dstFolder, false);
 			assertFileExistsWithContents(srcFolder, fileSystem.getName(movedFile), srcContents);
 			assertFalse(fileSystem.exists(f));
-			assertEquals(2, fileSystem.getNumberOfFilesInFolder(dstFolder));
 		}
 	}
 
@@ -584,38 +583,6 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		assertEquals(2, files.size(), "Size of set of files, should not contain folders");
 		assertEquals( 2, filenames.size(), "Size of set of filenames, should not contain folders");
 
-	}
-
-	@Test
-	public void basicFileSytemTestGetNumberOfFilesInFolder() throws Exception {
-		// arrange
-		String contents1 = "maakt niet uit";
-		String contents2 = "maakt ook niet uit";
-		String folderName = "folder_for_counting";
-
-		if (_folderExists(folderName)) {
-			_deleteFolder(folderName);
-		}
-		_createFolder(folderName);
-
-		fileSystem.configure();
-		fileSystem.open();
-
-		// act
-		long fileCount = fileSystem.getNumberOfFilesInFolder(folderName);
-
-		// assert
-		assertEquals(0, fileCount);
-
-		// arrange 2
-		createFile(folderName, FILE1, contents1);
-		createFile(folderName, FILE2, contents2);
-
-		// act 2
-		fileCount = fileSystem.getNumberOfFilesInFolder(folderName);
-
-		// assert 2
-		assertEquals(2, fileCount);
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/BasicFileSystemTest.java
@@ -602,7 +602,7 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		fileSystem.open();
 
 		// act
-		int fileCount = fileSystem.getNumberOfFilesInFolder(folderName);
+		long fileCount = fileSystem.getNumberOfFilesInFolder(folderName);
 
 		// assert
 		assertEquals(0, fileCount);

--- a/filesystem/src/test/java/org/frankframework/filesystem/exchange/MailFolderMapperTest.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/exchange/MailFolderMapperTest.java
@@ -1,0 +1,53 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.frankframework.filesystem.exchange;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class MailFolderMapperTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper()
+			.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+	/**
+	 * In issue "https://github.com/frankframework/frankframework/issues/11380" we had an issue that mapping failed with a value larger than
+	 * Integer.MAX_VALUE. This test ensures that all long fields in MailFolder can exceed Integer.MAX_VALUE.
+	 */
+	@Test
+	void testAllLongFieldsCanExceedIntegerMaxValue() throws Exception {
+		long longValue = (long) Integer.MAX_VALUE + 1;
+		String json = """
+				{
+				  "childFolderCount": %d,
+				  "unreadItemCount": %d,
+				  "totalItemCount": %d,
+				  "sizeInBytes": %d
+				}
+				""".formatted(longValue, longValue, longValue, longValue);
+
+		MailFolder folder = MAPPER.readValue(json, MailFolder.class);
+
+		assertEquals(longValue, folder.getChildFolderCount());
+		assertEquals(longValue, folder.getUnreadItemCount());
+		assertEquals(longValue, folder.getTotalItemCount());
+		assertEquals(longValue, folder.getSizeInBytes());
+	}
+}

--- a/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
@@ -173,7 +173,7 @@ public class MockFileSystem<M extends MockFile> extends MockFolder implements IW
 	}
 
 	@Override
-	public int getNumberOfFilesInFolder(String folderName) throws FileSystemException {
+	public long getNumberOfFilesInFolder(String folderName) throws FileSystemException {
 		checkOpen();
 		MockFolder folder = getMockFolder(folderName);
 		if (folder == null) {

--- a/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/mock/MockFileSystem.java
@@ -173,20 +173,6 @@ public class MockFileSystem<M extends MockFile> extends MockFolder implements IW
 	}
 
 	@Override
-	public long getNumberOfFilesInFolder(String folderName) throws FileSystemException {
-		checkOpen();
-		MockFolder folder = getMockFolder(folderName);
-		if (folder == null) {
-			throw new FileSystemException("folder [" + folderName + "] is null");
-		}
-		Map<String, MockFile> files = folder.getFiles();
-		if (files == null) {
-			throw new FileSystemException("files in folder [" + folderName + "] is null");
-		}
-		return files.size();
-	}
-
-	@Override
 	public DirectoryStream<M> list(String folder, TypeFilter filter) throws FileSystemException {
 		M actualFolder = toFile(folder, null);
 		return list(actualFolder, filter);


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Make sure MailFolder properties can contain a larger number than Integer.MAX_VALUE. A part of the fix was already made in newer versions but `getNumberOfFilesInFolder` was still casting this to an int. This should be the complete fix.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
