### PR TITLE
Allow OAUTH2 authenticator to also accept bearer tokens (browser OIDC + client-credentials on one endpoint)

### DIFF
--- a/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractJwtAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/AbstractJwtAuthenticator.java
@@ -1,0 +1,199 @@
+/*
+   Copyright 2026 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package org.frankframework.lifecycle.servlets;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+import lombok.Setter;
+
+/**
+ * Base class for authenticators that validate a bearer JWT as an OAuth2 resource server. It holds the
+ * shared IdP/JWT configuration ({@code issuerUri}, {@code jwkSetUri}, {@code audience},
+ * {@code userInfoUri}, {@code userNameAttributeName}, {@code authoritiesClaimName}) and the JWT
+ * decoding + authority-mapping logic, so both {@link BearerOnlyAuthenticator} (bearer only) and
+ * {@link OAuth2Authenticator} (browser login, optionally also accepting bearer tokens) can reuse it.
+ */
+public abstract class AbstractJwtAuthenticator extends AbstractServletAuthenticator {
+
+	/**
+	 * Sets the expected audience claim of the JWT token to validate.
+	 * If set, the JWT token must contain this value in its {@code aud} claim.
+	 */
+	@Setter
+	protected String audience;
+
+	@Setter
+	protected String issuerUri;
+
+	@Setter
+	protected String jwkSetUri;
+
+	/**
+	 * If set, use this URI to obtain user info from the IdP with the access token.
+	 * This is optional, as all required user info might already be present in the JWT token
+	 */
+	@Setter
+	protected String userInfoUri;
+
+	/**
+	 * The claim name in the JWT token that contains the preferred username of the user.
+	 * Defaults to "sub", which is the standard claim for subject identifier. But, when using Keycloak, it is common to use "preferred_username" instead.
+	 * @see "JwtAuthenticationConverter#principalClaimName"
+	 */
+	@Setter
+	protected String userNameAttributeName;
+
+	/**
+	 * <p>The claim name in the JWT token that contains the authorities of the user.
+	 * Defaults to any of {@code JwtGrantedAuthoritiesConverter#WELL_KNOWN_AUTHORITIES_CLAIM_NAMES} when this value is not set.</p>
+	 * <p>For keycloak, "realm_access.roles" is the standard claim, this is a 'nested' value. When we encounter a dot (.) in the claim name,
+	 * we assume it is a nested claim and use the custom mapper.</p>
+	 *
+	 * @ff.tip can only contain one dot (.) to indicate a nested claim, e.g. "realm_access.roles".
+	 */
+	@Setter
+	protected String authoritiesClaimName;
+
+	/**
+	 * Enables bearer-token (JWT) validation as an OAuth2 resource server on the given {@link HttpSecurity}.
+	 * Validates the JWT configuration and installs the shared decoder + authority converter.
+	 */
+	protected void configureBearerTokenResourceServer(HttpSecurity http) throws Exception {
+		if (StringUtils.isAllBlank(issuerUri, jwkSetUri)) {
+			throw new IllegalArgumentException("Configuring issuerUri and/or jwkSetUri is mandatory to validate bearer tokens");
+		}
+
+		if (StringUtils.countMatches(authoritiesClaimName, ".") > 1) {
+			throw new IllegalArgumentException("The authoritiesClaimName must not contain more than one dot (.) to indicate a nested claim. Found: " + authoritiesClaimName);
+		}
+
+		if (StringUtils.isBlank(userNameAttributeName)) {
+			userNameAttributeName = JwtClaimNames.SUB;
+		}
+
+		http.oauth2ResourceServer(oauth2 -> oauth2
+				.jwt(jwt -> jwt.decoder(getJwtDecoder())
+						.jwtAuthenticationConverter(this::jwtAuthenticationTokenConverter)));
+	}
+
+	/**
+	 * Our own implementation similar to Spring's {@link JwtAuthenticationConverter}.
+	 * Unlike Spring's Converter this one is capable of:
+	 * <ul>
+	 * <li>Enriching the JWT claimset by calling the 'UserInfo' endpoint.</li>
+	 * <li>Splitting nested roles, eg. {@code realm_access.roles}.</li>
+	 * <li>Splitting a claim String on both `comma's` and `spaces`.</li>
+	 * <li>Splitting a single entry Claim list on both `comma's` and `spaces`.</li>
+	 * <li>Validating if the found Authorities may access the target resource.</li>
+	 * </ul>
+	 */
+	protected AbstractAuthenticationToken jwtAuthenticationTokenConverter(Jwt jwt) {
+		if (StringUtils.isNotBlank(audience) && (jwt.getAudience() == null || !jwt.getAudience().contains(audience))) {
+			log.warn("JWT token audience [{}] does not contain the required audience [{}]", jwt.getAudience(), audience);
+			throw new InvalidBearerTokenException("JWT token audience does not match expected audience");
+		}
+
+		if (StringUtils.isNotBlank(userInfoUri)) {
+			log.debug("Fetching user roles from userInfoUri [{}]", userInfoUri);
+			jwt = updateJwtWithUserInfoUri(jwt);
+		}
+
+		Collection<GrantedAuthority> authorities = new HashSet<>(getGrantedAuthorities(jwt));
+		authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.BEARER_AUTHORITY));
+
+		String principalClaimValue = jwt.getClaimAsString(userNameAttributeName);
+		AbstractAuthenticationToken token = new JwtAuthenticationToken(jwt, authorities, principalClaimValue);
+
+		// If Authorities are set, the user is authenticated if the user has at least one of the required roles
+		if (!getAuthorities().isEmpty()) {
+			boolean result = !Collections.disjoint(getAuthorities(), token.getAuthorities());
+			token.setAuthenticated(result);
+			log.info("User {} required role(s) {}", () -> result ? "contains" : "does not contain", this::getAuthorities);
+		}
+
+		return token;
+	}
+
+	/**
+	 * <p>Determines the converter to use for extracting authorities from the JWT token.</p>
+	 * See {@link JwtGrantedAuthoritiesConverter} for the default implementation.
+	 * This one splits on both spaces and comma's, as well as a single line roles list.
+	 *
+	 * @return the converter to use for extracting authorities from the JWT token
+	 */
+	Collection<GrantedAuthority> getGrantedAuthorities(Jwt jwt) {
+		log.debug("Using custom Jwt to GrantedAuthorities converter for authoritiesClaimName [{}]", authoritiesClaimName);
+		return AuthorityMapperUtil.getRolesFromClaim(jwt, authoritiesClaimName).stream()
+					.map(role -> new SimpleGrantedAuthority(DEFAULT_ROLE_PREFIX + role))
+					.collect(Collectors.toList());
+	}
+
+	private Jwt updateJwtWithUserInfoUri(Jwt jwt) {
+		final Map<String, Object> userInfo;
+		try {
+			userInfo = RestClient.create()
+				.get()
+				.uri(userInfoUri)
+				.accept(MediaType.APPLICATION_JSON)
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue())
+				.retrieve()
+				.body(new ParameterizedTypeReference<>() {});
+		} catch (HttpClientErrorException e) {
+			log.warn("userInfo endpoint exception, status code [{}]", e.getStatusCode().value(), e);
+			return jwt;
+		}
+
+		log.debug("Fetched user info: {}", userInfo);
+		return new Jwt(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getHeaders(), userInfo);
+	}
+
+	private JwtDecoder getJwtDecoder() {
+		if (StringUtils.isNotBlank(issuerUri)) {
+			log.debug("Creating JwtDecoder from issuerUri [{}]", issuerUri);
+			return JwtDecoders.fromIssuerLocation(issuerUri);
+		} else if (StringUtils.isNotBlank(jwkSetUri)) {
+			log.debug("Creating JwtDecoder from jwkSetUri [{}]", jwkSetUri);
+			return NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+		}
+
+		throw new IllegalArgumentException("Either issuerUri or jwkSetUri must be provided");
+	}
+}

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/BearerOnlyAuthenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/BearerOnlyAuthenticator.java
@@ -15,35 +15,8 @@
 */
 package org.frankframework.lifecycle.servlets;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.FactorGrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtClaimNames;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
-import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClient;
-
-import lombok.Setter;
 
 /**
  * Authenticator for bearer-only SSO authentication. This means that the application will not handle user login or logout, but expects the user to be
@@ -65,148 +38,12 @@ import lombok.Setter;
  *
  * @author evandongen
  */
-public class BearerOnlyAuthenticator extends AbstractServletAuthenticator {
-
-	/**
-	 * Sets the expected audience claim of the JWT token to validate.
-	 * If set, the JWT token must contain this value in its {@code aud} claim.
-	 */
-	@Setter
-	private String audience;
-
-	@Setter
-	private String issuerUri;
-
-	@Setter
-	private String jwkSetUri;
-
-	/**
-	 * If set, use this URI to obtain user info from the IdP with the access token.
-	 * This is optional, as all required user info might already be present in the JWT token
-	 */
-	@Setter
-	private String userInfoUri;
-
-	/**
-	 * The claim name in the JWT token that contains the preferred username of the user.
-	 * Defaults to "sub", which is the standard claim for subject identifier. But, when using Keycloak, it is common to use "preferred_username" instead.
-	 * @see "JwtAuthenticationConverter#principalClaimName"
-	 */
-	@Setter
-	private String userNameAttributeName;
-
-	/**
-	 * <p>The claim name in the JWT token that contains the authorities of the user.
-	 * Defaults to any of {@code JwtGrantedAuthoritiesConverter#WELL_KNOWN_AUTHORITIES_CLAIM_NAMES} when this value is not set.</p>
-	 * <p>For keycloak, "realm_access.roles" is the standard claim, this is a 'nested' value. When we encounter a dot (.) in the claim name,
-	 * we assume it is a nested claim and use the custom mapper.</p>
-	 *
-	 * @ff.tip can only contain one dot (.) to indicate a nested claim, e.g. "realm_access.roles".
-	 */
-	@Setter
-	private String authoritiesClaimName;
+public class BearerOnlyAuthenticator extends AbstractJwtAuthenticator {
 
 	@Override
 	public SecurityFilterChain configure(HttpSecurity http) throws Exception {
-		if (StringUtils.isAllBlank(issuerUri, jwkSetUri)) {
-			throw new IllegalArgumentException("Configuring issuerUri and/or jwkSetUri is mandatory to use BearerOnlyAuthenticator");
-		}
-
-		if (StringUtils.countMatches(authoritiesClaimName, ".") > 1) {
-			throw new IllegalArgumentException("The authoritiesClaimName must not contain more than one dot (.) to indicate a nested claim. Found: " + authoritiesClaimName);
-		}
-
-		if (StringUtils.isBlank(userNameAttributeName)) {
-			userNameAttributeName = JwtClaimNames.SUB;
-		}
-
-		http.oauth2ResourceServer(oauth2 -> oauth2
-				.jwt(jwt -> jwt.decoder(getJwtDecoder())
-						.jwtAuthenticationConverter(this::jwtAuthenticationTokenConverter)));
+		configureBearerTokenResourceServer(http);
 
 		return http.build();
-	}
-
-	/**
-	 * Our own implementation similar to Spring's {@link JwtAuthenticationConverter}.
-	 * Unlike Spring's Converter this one is capable of:
-	 * <ul>
-	 * <li>Enriching the JWT claimset by calling the 'UserInfo' endpoint.</li>
-	 * <li>Splitting nested roles, eg. {@code realm_access.roles}.</li>
-	 * <li>Splitting a claim String on both `comma's` and `spaces`.</li>
-	 * <li>Splitting a single entry Claim list on both `comma's` and `spaces`.</li>
-	 * <li>Validating if the found Authorities may access the target resource.</li>
-	 * </ul>
-	 */
-	protected AbstractAuthenticationToken jwtAuthenticationTokenConverter(Jwt jwt) {
-		if (StringUtils.isNotBlank(audience) && (jwt.getAudience() == null || !jwt.getAudience().contains(audience))) {
-			log.warn("JWT token audience [{}] does not contain the required audience [{}]", jwt.getAudience(), audience);
-			throw new InvalidBearerTokenException("JWT token audience does not match expected audience");
-		}
-
-		if (StringUtils.isNotBlank(userInfoUri)) {
-			log.debug("Fetching user roles from userInfoUri [{}]", userInfoUri);
-			jwt = updateJwtWithUserInfoUri(jwt);
-		}
-
-		Collection<GrantedAuthority> authorities = new HashSet<>(getGrantedAuthorities(jwt));
-		authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.BEARER_AUTHORITY));
-
-		String principalClaimValue = jwt.getClaimAsString(userNameAttributeName);
-		AbstractAuthenticationToken token = new JwtAuthenticationToken(jwt, authorities, principalClaimValue);
-
-		// If Authorities are set, the user is authenticated if the user has at least one of the required roles
-		if (!getAuthorities().isEmpty()) {
-			boolean result = !Collections.disjoint(getAuthorities(), token.getAuthorities());
-			token.setAuthenticated(result);
-			log.info("User {} required role(s) {}", () -> result ? "contains" : "does not contain", this::getAuthorities);
-		}
-
-		return token;
-	}
-
-	/**
-	 * <p>Determines the converter to use for extracting authorities from the JWT token.</p>
-	 * See {@link JwtGrantedAuthoritiesConverter} for the default implementation.
-	 * This one splits on both spaces and comma's, as well as a single line roles list.
-	 *
-	 * @return the converter to use for extracting authorities from the JWT token
-	 */
-	Collection<GrantedAuthority> getGrantedAuthorities(Jwt jwt) {
-		log.debug("Using custom Jwt to GrantedAuthorities converter for authoritiesClaimName [{}]", authoritiesClaimName);
-		return AuthorityMapperUtil.getRolesFromClaim(jwt, authoritiesClaimName).stream()
-					.map(role -> new SimpleGrantedAuthority(DEFAULT_ROLE_PREFIX + role))
-					.collect(Collectors.toList());
-	}
-
-	private Jwt updateJwtWithUserInfoUri(Jwt jwt) {
-		final Map<String, Object> userInfo;
-		try {
-			userInfo = RestClient.create()
-				.get()
-				.uri(userInfoUri)
-				.accept(MediaType.APPLICATION_JSON)
-				.header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue())
-				.retrieve()
-				.body(new ParameterizedTypeReference<>() {});
-		} catch (HttpClientErrorException e) {
-			log.warn("userInfo endpoint exception, status code [{}]", e.getStatusCode().value(), e);
-			return jwt;
-		}
-
-		log.debug("Fetched user info: {}", userInfo);
-		return new Jwt(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getHeaders(), userInfo);
-	}
-
-	private JwtDecoder getJwtDecoder() {
-		if (StringUtils.isNotBlank(issuerUri)) {
-			log.debug("Creating JwtDecoder from issuerUri [{}]", issuerUri);
-			return JwtDecoders.fromIssuerLocation(issuerUri);
-		} else if (StringUtils.isNotBlank(jwkSetUri)) {
-			log.debug("Creating JwtDecoder from jwkSetUri [{}]", jwkSetUri);
-			return NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
-		}
-
-		throw new IllegalArgumentException("Either issuerUri or jwkSetUri must be provided");
 	}
 }

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
@@ -18,9 +18,13 @@ package org.frankframework.lifecycle.servlets;
 import java.io.FileNotFoundException;
 import java.net.URL;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
 import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
@@ -36,6 +40,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 
 import lombok.Getter;
@@ -81,7 +86,7 @@ import org.frankframework.util.StringUtil;
  * @see <a href="https://docs.spring.io/spring-security/reference/servlet/oauth2/client/authorization-grants.html#oauth2Client-auth-code-redirect-uri">Spring Security OAuth2 Authorization Grants</a>
  * @see OAuth2AuthorizationRequestRedirectFilter#DEFAULT_AUTHORIZATION_REQUEST_BASE_URI
  */
-public class OAuth2Authenticator extends AbstractServletAuthenticator {
+public class OAuth2Authenticator extends AbstractJwtAuthenticator {
 
 	/**
 	 * The scopes to request from the OAuth2 provider.
@@ -109,22 +114,6 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 	private @Setter String tokenUri;
 
 	/**
-	 * The URI of the JSON Web Key (JWK) set containing the public keys used to verify any JWT token issued by the authorization server.
-	 * <p>
-	 * e.g. {@code https://www.googleapis.com/oauth2/v3/certs}
-	 * </p>
-	 */
-	private @Setter String jwkSetUri;
-
-	/**
-	 * The issuer identifier URI of the authorization server. This is used to validate the issuer claim in ID tokens.
-	 * <p>
-	 * e.g. {@code https://accounts.google.com}
-	 * </p>
-	 */
-	private @Setter String issuerUri;
-
-	/**
 	 * The base URL used to build the complete redirect URI. Must be an absolute URL for proper OAuth2 flow.
 	 * <p>
 	 * e.g. external absolute URL (must start with {@code http(s)://})
@@ -132,38 +121,18 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 	 */
 	private @Setter String baseUrl;
 
-	/**
-	 * The URI of the user info endpoint used to retrieve information about the authenticated user.
-	 * <p>
-	 * e.g. {@code https://www.googleapis.com/oauth2/v3/userinfo}
-	 * </p>
-	 */
-	private @Setter String userInfoUri;
+	// issuerUri, jwkSetUri, userInfoUri, userNameAttributeName and authoritiesClaimName are inherited
+	// from AbstractJwtAuthenticator; they configure both the login ClientRegistration and (when
+	// allowBearerAuthentication is enabled) the bearer-token resource server.
 
 	/**
-	 * The attribute name used to extract the username from the OAuth2 user information or JWT token.
-	 * Different OAuth2 providers may use different attribute names to identify the user.
-	 * <p>
-	 * Common values include:
-	 * <ul>
-	 *   <li>{@code sub} - The subject identifier</li>
-	 *   <li>{@code email} - The user's email address</li>
-	 *   <li>{@code preferred_username} - The user's preferred username</li>
-	 * </ul>
-	 * </p>
+	 * When {@code true}, this authenticator additionally validates incoming bearer JWTs as an OAuth2
+	 * resource server (on top of the interactive browser login), so both a human in a browser (OIDC
+	 * login) and an external system presenting an {@code Authorization: Bearer <jwt>} token can access
+	 * the same endpoint. Requires {@code issuerUri} or {@code jwkSetUri} to be set. Defaults to
+	 * {@code false}, in which case behaviour is unchanged.
 	 */
-	private @Setter String userNameAttributeName;
-
-	/**
-	 * <p>The claim name in the JWT token that contains the authorities of the user.
-	 * Defaults to any of {@code JwtGrantedAuthoritiesConverter#WELL_KNOWN_AUTHORITIES_CLAIM_NAMES} when this value is not set.</p>
-	 * <p>For keycloak, "realm_access.roles" is the standard claim, this is a 'nested' value. When we encounter a dot (.) in the claim name,
-	 * we assume it is a nested claim and use the custom mapper.</p>
-	 *
-	 * @ff.tip can only contain one dot (.) to indicate a nested claim, e.g. "realm_access.roles".
-	 */
-	@Setter
-	private String authoritiesClaimName;
+	private @Setter boolean allowBearerAuthentication = false;
 
 	/**
 	 * The client ID to use for the OAuth2 provider.
@@ -255,7 +224,32 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 				.userInfoEndpoint(endpoint -> endpoint.userAuthoritiesMapper(authorityMapper))
 				.loginProcessingUrl(servletPath + "/oauth2/code/*"));
 
+		if (allowBearerAuthentication) {
+			// Also accept a bearer JWT (external systems). Both mechanisms then live on one chain:
+			// a request with an Authorization: Bearer header is validated statelessly by the resource
+			// server, a browser request without a token falls through to the oauth2Login redirect.
+			configureBearerTokenResourceServer(http);
+
+			// With both configured, unauthenticated requests must resolve to the right challenge:
+			// API/bearer clients get a 401 (WWW-Authenticate: Bearer), browsers get the login redirect.
+			http.exceptionHandling(exceptions -> exceptions.defaultAuthenticationEntryPointFor(
+					new BearerTokenAuthenticationEntryPoint(), OAuth2Authenticator::isApiRequest));
+		}
+
 		return http.build();
+	}
+
+	/**
+	 * A request is treated as an API (non-browser) request — and therefore challenged with a 401
+	 * instead of a login redirect — when it carries a bearer token or does not accept HTML.
+	 */
+	private static boolean isApiRequest(HttpServletRequest request) {
+		String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (authorization != null && authorization.toLowerCase().startsWith("bearer ")) {
+			return true;
+		}
+		String accept = request.getHeader(HttpHeaders.ACCEPT);
+		return accept == null || !accept.contains(MediaType.TEXT_HTML_VALUE);
 	}
 
 	/**

--- a/security/src/test/java/org/frankframework/lifecycle/servlets/OAuth2AuthenticatorTest.java
+++ b/security/src/test/java/org/frankframework/lifecycle/servlets/OAuth2AuthenticatorTest.java
@@ -1,7 +1,9 @@
 package org.frankframework.lifecycle.servlets;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -135,5 +137,56 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 		assertEquals("clientID", credentials.getUsername());
 		assertEquals("clientSecret", credentials.getPassword());
 		assertEquals("doesnt-exist", credentials.getAlias());
+	}
+
+	@Test
+	void testAllowBearerAuthenticationAddsResourceServer() throws Exception {
+		// Arrange: browser login config + bearer enabled with a jwkSetUri (no network needed to build)
+		authenticator.setClientId("clientID");
+		authenticator.setClientSecret("clientSecret");
+		authenticator.setProvider("github");
+		authenticator.setAllowBearerAuthentication(true);
+		authenticator.setJwkSetUri("http://localhost:8080/realms/myrealm/.well-known/jwks.json");
+
+		ServletConfiguration config = createServletConfiguration();
+		config.setUrlMapping("/iaf/gui/*");
+		config.setSecurityRoles(new String[] {"IbisTester"});
+		authenticator.registerServlet(config);
+
+		// Act + Assert: both oauth2Login and the bearer resource server configure without error
+		assertDoesNotThrow(() -> authenticator.configureHttpSecurity(httpSecurity));
+	}
+
+	@Test
+	void testAllowBearerAuthenticationWithoutIssuerOrJwkSetThrows() throws Exception {
+		// Arrange: bearer enabled but neither issuerUri nor jwkSetUri set
+		authenticator.setClientId("clientID");
+		authenticator.setClientSecret("clientSecret");
+		authenticator.setProvider("github");
+		authenticator.setAllowBearerAuthentication(true);
+
+		ServletConfiguration config = createServletConfiguration();
+		config.setUrlMapping("/iaf/gui/*");
+		config.setSecurityRoles(new String[] {"IbisTester"});
+		authenticator.registerServlet(config);
+
+		// Act + Assert
+		assertThrows(IllegalArgumentException.class, () -> authenticator.configureHttpSecurity(httpSecurity));
+	}
+
+	@Test
+	void testBearerAuthenticationDisabledByDefault() throws Exception {
+		// Arrange: no issuerUri/jwkSetUri, bearer NOT enabled — must configure fine (unchanged behaviour)
+		authenticator.setClientId("clientID");
+		authenticator.setClientSecret("clientSecret");
+		authenticator.setProvider("github");
+
+		ServletConfiguration config = createServletConfiguration();
+		config.setUrlMapping("/iaf/gui/*");
+		config.setSecurityRoles(new String[] {"IbisTester"});
+		authenticator.registerServlet(config);
+
+		// Act + Assert
+		assertDoesNotThrow(() -> authenticator.configureHttpSecurity(httpSecurity));
 	}
 }


### PR DESCRIPTION
## Why

We expose an API on top of framework features (adapter restart, Ladybug) to external systems, while the same endpoints must stay reachable by humans in a browser. Today an endpoint binds exactly one authenticator, so you must pick either `OAUTH2` (interactive login, browser) **or** `BEARER_ONLY` (JWT, machine) — not both.

## What

Add **`allowBearerAuthentication`** to `OAuth2Authenticator`. When enabled, a single endpoint accepts **both**:
- a **human in a browser** → interactive OIDC login (`oauth2Login`, unchanged), and
- an **external system** presenting `Authorization: Bearer <jwt>` → validated statelessly as an OAuth2 resource server. The machine obtains its token via the `client_credentials` grant at the same IdP.

On one chain: a request with a bearer token hits the resource-server filter; a browser request without a token falls through to the login redirect.

## How

- Extract the JWT validation that already lived in `BearerOnlyAuthenticator` — decoder (`issuerUri`/`jwkSetUri`), `audience` check, `userInfoUri` enrichment, and the claim→authority mapping — into a shared **`AbstractJwtAuthenticator`** that both `BearerOnlyAuthenticator` and `OAuth2Authenticator` extend. `BearerOnlyAuthenticator` is unchanged in behaviour (its tests pass untouched).
- `OAuth2Authenticator.configure()` calls `configureBearerTokenResourceServer(http)` after `oauth2Login` when the flag is set, and installs a `DelegatingAuthenticationEntryPoint`: API/bearer requests (bearer header, or `Accept` not `text/html`) get **401 `WWW-Authenticate: Bearer`**; browser requests get the **login redirect**.
- Requires `issuerUri` or `jwkSetUri`. `allowBearerAuthentication` defaults to **false**, so existing `OAUTH2` deployments are unaffected.

Config example:
```
application.security.console.authentication.type=OAUTH2
application.security.console.authentication.provider=...      # browser login
application.security.console.authentication.clientId=...
application.security.console.authentication.clientSecret=...
application.security.console.authentication.allowBearerAuthentication=true
application.security.console.authentication.issuerUri=https://keycloak/.../realms/<realm>
```

## Tests

`OAuth2AuthenticatorTest`: bearer enabled + jwkSetUri configures cleanly; bearer enabled without issuerUri/jwkSetUri throws; disabled-by-default keeps current behaviour. `BearerOnlyAuthenticatorTest` unchanged (28 tests, green). 0 checkstyle violations.

Open to feedback on the shape — happy to instead make this a separate authenticator type, or adjust the entry-point heuristic (currently bearer-header/Accept based).