### PR TITLE
Add HttpHeaderUtils to validate Content-Disposition header filenames

### DIFF
--- a/core/src/main/java/org/frankframework/http/HttpHeaderUtils.java
+++ b/core/src/main/java/org/frankframework/http/HttpHeaderUtils.java
@@ -1,0 +1,74 @@
+/*
+  Copyright 2026 WeAreFrank!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.frankframework.http;
+
+import java.net.URLDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class HttpHeaderUtils {
+	private static final CharsetEncoder ISO_8859_1_ENCODER = StandardCharsets.ISO_8859_1.newEncoder();
+
+	/**
+	 * Matches the plain {@code filename=} parameter in a Content-Disposition header (case-insensitive), but NOT the extended {@code filename*=}
+	 * variant (RFC 5987), whose value is always percent-encoded and therefore safe.
+	 * <br />
+	 * Captures the filename value in group 1 (quoted) or group 2 (unquoted).
+	 */
+	private static final Pattern FILENAME_PARAM_PATTERN = Pattern.compile(
+			"(?:^|;)\\s*filename\\s*=\\s*(?:\"([^\"]*)\"|([^;\\s]*))",
+			Pattern.CASE_INSENSITIVE
+	);
+
+	/**
+	 * Guards that the 'filename=' parameter of a Content-Disposition header value can be encoded in ISO-8859-1, as defined in
+	 * <a href="https://www.rfc-editor.org/info/rfc6266/#section-4.3">RFC 6266</a>.
+	 * The extended 'filename*=' parameter (RFC 5987) is not checked because its value uses percent-encoding and is always safe.
+	 */
+	public static void checkContentDispositionValueForValidFilename(@NonNull String contentDispositionHeader) {
+		Matcher matcher = FILENAME_PARAM_PATTERN.matcher(contentDispositionHeader);
+		while (matcher.find()) {
+			String filename = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+
+			if (filename == null) {
+				continue;
+			}
+
+			if (!ISO_8859_1_ENCODER.canEncode(getStringToCheck(filename))) {
+				throw new IllegalArgumentException("Content-Disposition 'filename' parameter contains characters that cannot be encoded in ISO-8859-1: " + filename);
+			}
+		}
+	}
+
+	/**
+	 * Decode the filename value so that sequences like %e2%82%ac (€ in UTF-8) are evaluated as their intended characters (U+20ac, which is Unicode for the
+	 * euro sign)
+	 */
+	@Nullable
+	private static String getStringToCheck(String filename) {
+		try {
+			return URLDecoder.decode(filename, StandardCharsets.UTF_8);
+		} catch (IllegalArgumentException e) {
+			// Malformed percent-encoding: fall back to checking the raw value. For example: file%.txt
+			return filename;
+		}
+	}
+}

--- a/core/src/main/java/org/frankframework/http/RestListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/RestListenerServlet.java
@@ -147,11 +147,12 @@ public class RestListenerServlet extends AbstractHttpServlet {
 					if (StringUtils.isNotEmpty(contentType)) {
 						response.setHeader("Content-Type", contentType);
 					}
-					String contentDisposition=(String)messageContext.get("contentDisposition");
+					String contentDisposition = (String) messageContext.get("contentDisposition");
 					if (StringUtils.isNotEmpty(contentDisposition)) {
+						HttpHeaderUtils.checkContentDispositionValueForValidFilename(contentDisposition);
 						response.setHeader("Content-Disposition", contentDisposition);
 					}
-					String allowedMethods=(String)messageContext.get("allowedMethods");
+					String allowedMethods = (String) messageContext.get("allowedMethods");
 					if (StringUtils.isNotEmpty(allowedMethods)) {
 						response.setHeader("Allow", allowedMethods);
 					}

--- a/core/src/main/java/org/frankframework/http/mime/MultipartEntityBuilder.java
+++ b/core/src/main/java/org/frankframework/http/mime/MultipartEntityBuilder.java
@@ -34,6 +34,7 @@ import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.Args;
 
+import org.frankframework.http.HttpHeaderUtils;
 import org.frankframework.stream.Message;
 
 /**
@@ -107,22 +108,27 @@ public class MultipartEntityBuilder {
 			this.bodyParts = new ArrayList<>();
 		}
 
-		if(mtom) {
+		if (mtom) {
 			Header header = bodyPart.getHeader();
 			String contentID;
 			String fileName = bodyPart.getBody().getFilename();
 			header.removeFields("Content-Disposition");
-			if(fileName == null) {
+
+			if (fileName == null) {
 				contentID = "<"+bodyPart.getName()+">";
-			}
-			else {
-				bodyPart.addField("Content-Disposition", "attachment; name=\""+bodyPart.getName()+"\"; filename=\""+fileName+"\"");
+			} else {
+				String value = "attachment; name=\"" + bodyPart.getName() + "\"; filename=\"" + fileName + "\"";
+				HttpHeaderUtils.checkContentDispositionValueForValidFilename(value);
+
+				bodyPart.addField("Content-Disposition", value);
 				contentID = "<"+fileName+">";
 			}
+
 			bodyPart.addField("Content-ID", contentID);
 
-			if(firstPart == null)
+			if (firstPart == null) {
 				firstPart = contentID;
+			}
 		}
 
 		this.bodyParts.add(bodyPart);

--- a/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/org/frankframework/http/rest/ApiListenerServlet.java
@@ -52,6 +52,7 @@ import com.nimbusds.jose.util.JSONObjectUtils;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.core.SpringSecurityHandler;
 import org.frankframework.http.AbstractHttpServlet;
+import org.frankframework.http.HttpHeaderUtils;
 import org.frankframework.http.mime.MultipartUtils;
 import org.frankframework.http.mime.MultipartUtils.MultipartMessages;
 import org.frankframework.jwt.AuthorizationException;
@@ -593,9 +594,12 @@ public class ApiListenerServlet extends AbstractHttpServlet {
 					}
 				}
 
-				if(StringUtils.isNotEmpty(listener.getContentDispositionHeaderSessionKey())) {
+				if (StringUtils.isNotEmpty(listener.getContentDispositionHeaderSessionKey())) {
 					String contentDisposition = pipelineSession.getString(listener.getContentDispositionHeaderSessionKey());
-					if(StringUtils.isNotEmpty(contentDisposition)) {
+
+					if (StringUtils.isNotEmpty(contentDisposition)) {
+						HttpHeaderUtils.checkContentDispositionValueForValidFilename(contentDisposition);
+
 						LOG.debug("Setting Content-Disposition header to [{}]", contentDisposition);
 						response.setHeader("Content-Disposition", contentDisposition);
 					}

--- a/core/src/test/java/org/frankframework/http/HttpHeaderUtilsTest.java
+++ b/core/src/test/java/org/frankframework/http/HttpHeaderUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+  Copyright 2026 WeAreFrank!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.frankframework.http;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class HttpHeaderUtilsTest {
+
+	// Test the examples as given in RFC 6266 section 4.3, which are valid Content-Disposition headers that can be encoded in ISO-8859-1
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"attachment; filename=example.html",
+			"INLINE; FILENAME= \"an example.html\"",
+			"attachment; filename*= UTF-8''%e2%82%ac%20rates",
+			"attachment; filename=\"EURO rates\"; filename*=utf-8''%e2%82%ac%20rates"
+	})
+	void willNotThrowForValidValues(String contentDispositionHeader) {
+		assertDoesNotThrow(() -> HttpHeaderUtils.checkContentDispositionValueForValidFilename(contentDispositionHeader));
+	}
+
+	// Test some invalid Content-Disposition headers that contain characters that cannot be encoded in ISO-8859-1
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"INLINE; FILENAME= \"€ rates\"",
+			"INLINE; FILENAME=€_rates.doc",
+			"attachment; filename= UTF-8''%e2%82%ac%20rates",
+			"attachment; filename=utf-8''%e2%82%ac%20rates"
+	})
+	void willThrowForInvalidValues(String contentDispositionHeader) {
+		assertThrows(IllegalArgumentException.class, () -> HttpHeaderUtils.checkContentDispositionValueForValidFilename(contentDispositionHeader));
+	}
+}

--- a/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/org/frankframework/http/rest/ApiListenerServletTest.java
@@ -129,7 +129,7 @@ public class ApiListenerServletTest {
 	private static final String PAYLOAD="{\"sub\":\"UnitTest\",\"aud\":\"Framework\",\"iss\":\"JWTPipeTest\",\"jti\":\"1234\"}";
 
 	enum AuthMethods {
-		COOKIE,HEADER,AUTHROLE
+		COOKIE, HEADER, AUTHROLE
 	}
 
 	private ApiListenerServlet servlet;
@@ -2026,6 +2026,24 @@ public class ApiListenerServletTest {
 		assertEquals("localhost", result.getContentAsString());
 	}
 
+	@Test
+	public void testContentDispositionHeaderWithNonIso88591CharactersReturns500() throws Exception {
+		// Arrange
+		String uri = "/request/with/invalid/contentDisposition";
+		new ApiListenerBuilder(uri, List.of(HttpMethod.GET))
+				.withResponseContent("body")
+				.withResultSessionKey("contentDisposition", "attachment; filename=\"\u4e2d\u6587.txt\"") // contains non-ISO-8859-1 Chinese characters
+				.setContentDispositionHeaderSessionKey("contentDisposition")
+				.build();
+
+		// Act
+		Response result = service(createRequest(uri, HttpMethod.GET));
+
+		// Assert - checkContentDispositionValue on line 395 of ApiListenerServlet throws IllegalArgumentException,
+		// which the servlet catches and converts to status 500
+		assertEquals(500, result.getStatus());
+	}
+
 	private String createJWT() throws Exception {
 		JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
 
@@ -2377,6 +2395,11 @@ public class ApiListenerServletTest {
 
 		public ApiListenerBuilder withAllowAllParams(boolean allowAllParams) {
 			listener.setAllowAllParams(allowAllParams);
+			return this;
+		}
+
+		public ApiListenerBuilder setContentDispositionHeaderSessionKey(String sessionKey) {
+			listener.setContentDispositionHeaderSessionKey(sessionKey);
 			return this;
 		}
 


### PR DESCRIPTION
Add HttpHeaderUtils to validate Content-Disposition header filenames (#11430)

(cherry picked from commit 72cbbcfce1e0436100bfb2ebabd818f238170e41)