### PR TITLE
Don't use URL type as Map key

### DIFF
--- a/core/src/main/java/org/frankframework/lifecycle/WebContentServlet.java
+++ b/core/src/main/java/org/frankframework/lifecycle/WebContentServlet.java
@@ -18,6 +18,8 @@ package org.frankframework.lifecycle;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -71,7 +73,7 @@ public class WebContentServlet extends AbstractHttpServlet {
 	private static final String WELCOME_FILE = "index.html";
 	private static final String CONFIGURATION_KEY = WebContentServlet.class.getCanonicalName() + ".configuration";
 	private final Map<String, MimeType> supportedMediaTypes = new HashMap<>();
-	private final Map<URL, MimeType> computedMediaTypes = new WeakHashMap<>();
+	private final Map<String, MimeType> computedMediaTypes = new WeakHashMap<>();
 	private final boolean isDtapStageLoc = "LOC".equalsIgnoreCase(AppConstants.getInstance().getProperty("dtap.stage"));
 	private Detector detector = null;
 
@@ -112,7 +114,7 @@ public class WebContentServlet extends AbstractHttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		String path = req.getPathInfo();
-		if(path == null) {
+		if (path == null) {
 			resp.sendRedirect(req.getContextPath() + SERVLET_PATH);
 			return;
 		} else if("/".equals(path)) {
@@ -127,18 +129,18 @@ public class WebContentServlet extends AbstractHttpServlet {
 
 		URL resource = findResource(req);
 
-		if(resource == null) {
+		if (resource == null) {
 			resp.sendError(404, "resource not found");
 			return;
 		}
 
 		MimeType mimeType = determineMimeType(resource);
-		if(mimeType != null) {
+		if (mimeType != null) {
 			log.debug("found MimeType [{}] for resource [{}]", mimeType, resource);
 			resp.setContentType(mimeType.toString());
 		}
 
-		try(InputStream in = resource.openStream()) {
+		try (InputStream in = resource.openStream()) {
 			IOUtils.copy(in, resp.getOutputStream());
 		} catch (IOException e) {
 			log.warn("error reading or writing resource to servlet", e);
@@ -152,7 +154,7 @@ public class WebContentServlet extends AbstractHttpServlet {
 	@Override
 	protected long getLastModified(HttpServletRequest req) {
 		String path = req.getPathInfo();
-		if(StringUtils.isNotEmpty(path) && !"/".equals(path) && findResource(req) != null) {
+		if (StringUtils.isNotEmpty(path) && !"/".equals(path) && findResource(req) != null) {
 			String configurationName = (String) req.getAttribute(CONFIGURATION_KEY);
 			return findConfiguration(configurationName).getStartupDate();
 		}
@@ -161,12 +163,12 @@ public class WebContentServlet extends AbstractHttpServlet {
 	}
 
 	private MimeType determineMimeType(URL resource) {
-		String extension = FilenameUtils.getExtension(resource.toString());
+		String extension = FilenameUtils.getExtension(resource.getPath());
 		log.debug("trying to lookup MimeType for extension [{}]", extension);
 		MimeType type = supportedMediaTypes.get(extension);
-		if(type == null) {
+		if (type == null) {
 			log.info("no default MimeType mapping found for extension [{}]", extension);
-			return computedMediaTypes.computeIfAbsent(resource, this::computeMimeType);
+			return computedMediaTypes.computeIfAbsent(resource.toExternalForm(), this::computeMimeType);
 		}
 		return type;
 	}
@@ -175,7 +177,14 @@ public class WebContentServlet extends AbstractHttpServlet {
 	 * Tries to determine the MimeType by reading the file's magic (first 16k bytes)
 	 * @return the computed MimeType or APPLICATION/OCTET_STREAM
 	 */
-	private MimeType computeMimeType(URL resource) {
+	private MimeType computeMimeType(String resourcePath) {
+		URL resource;
+		try {
+			resource = URI.create(resourcePath).toURL();
+		} catch (MalformedURLException e) {
+			log.warn("Could not create URL from path [{}]", resourcePath);
+			return MediaType.APPLICATION_OCTET_STREAM;
+		}
 		log.debug("computing MimeType for resource [{}]", resource);
 		Metadata metadata = new Metadata();
 		String name = FilenameUtils.getExtension(resource.toString());
@@ -196,7 +205,7 @@ public class WebContentServlet extends AbstractHttpServlet {
 	 */
 	private URL findResource(HttpServletRequest req) {
 		String normalizedPath = FilenameUtils.normalize(req.getPathInfo(), true);
-		if(normalizedPath.startsWith("/")) {
+		if (normalizedPath.startsWith("/")) {
 			normalizedPath = normalizedPath.substring(1);
 		}
 		String[] split = normalizedPath.split("/");

--- a/core/src/main/java/org/frankframework/lifecycle/WebContentServlet.java
+++ b/core/src/main/java/org/frankframework/lifecycle/WebContentServlet.java
@@ -73,7 +73,7 @@ public class WebContentServlet extends AbstractHttpServlet {
 	private static final String WELCOME_FILE = "index.html";
 	private static final String CONFIGURATION_KEY = WebContentServlet.class.getCanonicalName() + ".configuration";
 	private final Map<String, MimeType> supportedMediaTypes = new HashMap<>();
-	private final Map<String, MimeType> computedMediaTypes = new WeakHashMap<>();
+	private final transient Map<String, MimeType> computedMediaTypes = new WeakHashMap<>();
 	private final boolean isDtapStageLoc = "LOC".equalsIgnoreCase(AppConstants.getInstance().getProperty("dtap.stage"));
 	private Detector detector = null;
 


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
According to IntelliJ we should not use URL as Map keys:
Reports hashCode() and equals() calls on java.net.URL objects and calls that add URL objects to maps and sets.
URL's equals() and hashCode() methods can perform a DNS lookup to resolve the host name. This may cause significant delays, depending on the availability and speed of the network and the DNS server. Using java.net.URI instead of java.net.URL will avoid the DNS lookup.

Using String as the Map key results in slightly less ugly code as using the URI however, so I chose that instead.



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
