### PR TITLE
Update ladybug on 9.4 so that it supports instance dropdown

### DIFF
--- a/console/frontend/src/main/frontend/src/app/app.service.ts
+++ b/console/frontend/src/main/frontend/src/app/app.service.ts
@@ -352,7 +352,7 @@ export class AppService {
 
   updateAdapterSummary(configurationName: string, changedConfiguration: boolean): void {
     const updated = Date.now();
-    if (updated - 3000 < this.lastUpdated && !changedConfiguration) {
+    if (!changedConfiguration && updated - 3000 < this.lastUpdated) {
       //3 seconds
       clearTimeout(this.timeout);
       this.timeout = globalThis.setTimeout(() => {

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-custom-view/iframe-custom-view.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-custom-view/iframe-custom-view.component.ts
@@ -11,11 +11,10 @@ import { Subscription } from 'rxjs';
   imports: [TitleCasePipe],
 })
 export class IframeCustomViewComponent extends BaseIframeComponent implements OnInit, OnDestroy {
+  private routeSubscription: Subscription | null = null;
   private readonly router: Router = inject(Router);
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
   private readonly location: LocationStrategy = inject(LocationStrategy);
-  private readonly window: Window = inject(Window);
-  private routeSubscription: Subscription | null = null;
 
   override ngOnInit(): void {
     super.ngOnInit();
@@ -40,18 +39,13 @@ export class IframeCustomViewComponent extends BaseIframeComponent implements On
 
     const view = routeState['view'];
 
-    if (view['url'].includes('http')) {
-      this.window.open(view['url'], view['name']);
-      this.redirectURL = view['url'];
-      this.url = '';
-    } else {
-      this.url = this.appService.getServerPath() + view['url'];
-    }
+    const url = view['url'].startsWith('/') ? view['url'] : this.appService.getServerPath() + view['url'];
+    this.url.set(url);
 
-    this.iframeSrc = this.sanitizer.bypassSecurityTrustResourceUrl(this.url);
+    this.iframeSrc = this.sanitizer.bypassSecurityTrustResourceUrl(url);
     setTimeout(() => {
       // run after router events have passed
-      this.setIframeSource(this.url, view['name']);
+      this.setIframeSource(url, view['name']);
     }, 50);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
@@ -11,6 +11,10 @@ import { TitleCasePipe } from '@angular/common';
 export class IframeLadybugComponent extends BaseIframeComponent implements OnInit, OnDestroy {
   override ngOnInit(): void {
     super.ngOnInit();
-    this.setFFIframeSource('ladybug');
+
+    const instanceName = this.appService.instanceName();
+    const ladybugIframeSource =
+      instanceName === '-' ? 'ladybug' : `ladybug?filter-application=${encodeURIComponent(instanceName)}`;
+    this.setFFIframeSource(ladybugIframeSource);
   }
 }

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe-ladybug/iframe-ladybug.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, effect } from '@angular/core';
 import { BaseIframeComponent } from '../iframe.base';
 import { TitleCasePipe } from '@angular/common';
 
@@ -9,10 +9,15 @@ import { TitleCasePipe } from '@angular/common';
   imports: [TitleCasePipe],
 })
 export class IframeLadybugComponent extends BaseIframeComponent implements OnInit, OnDestroy {
-  override ngOnInit(): void {
-    super.ngOnInit();
+  constructor() {
+    super();
+    effect(() => {
+      const instanceName = this.appService.instanceName();
+      this.setLadybugSource(instanceName);
+    });
+  }
 
-    const instanceName = this.appService.instanceName();
+  private setLadybugSource(instanceName: string): void {
     const ladybugIframeSource =
       instanceName === '-' ? 'ladybug' : `ladybug?filter-application=${encodeURIComponent(instanceName)}`;
     this.setFFIframeSource(ladybugIframeSource);

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe.base.ts
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe.base.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostListener, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { AppService } from 'src/app/app.service';
 import { HttpClient } from '@angular/common/http';
@@ -7,11 +7,10 @@ import { HttpClient } from '@angular/common/http';
   template: '',
 })
 export abstract class BaseIframeComponent implements OnInit, OnDestroy {
-  protected url = '';
+  protected url = signal('');
   protected iframeState: 'loading' | 'show' | 'error' = 'loading';
   protected iframeName = 'custom page';
   protected iframeSrc?: SafeResourceUrl;
-  protected redirectURL?: string;
 
   protected readonly sanitizer = inject(DomSanitizer);
   protected readonly appService = inject(AppService);
@@ -38,15 +37,16 @@ export abstract class BaseIframeComponent implements OnInit, OnDestroy {
   }
 
   protected setFFIframeSource(ffPage: string): void {
-    this.url = `${this.appService.getServerPath()}iaf/${ffPage}`;
-    this.setIframeSource(this.url, ffPage);
+    const url = `${this.appService.getServerPath()}iaf/${ffPage}`;
+    this.url.set(url);
+    this.setIframeSource(url, ffPage);
   }
 
   protected setIframeSource(url: string, pageName: string): void {
     this.appService.iframePopoutUrl.set(url);
     this.iframeSrc = this.sanitizer.bypassSecurityTrustResourceUrl(url);
     this.iframeName = pageName;
-    this.checkIframeUrl(this.url);
+    this.checkIframeUrl(url);
   }
 
   protected checkIframeUrl(url: string): void {

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe.component.html
@@ -22,21 +22,8 @@
       </div>
     }
   }
-}
-
-@if (redirectURL && redirectURL.length > 0) {
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="wrapper wrapper-content">
-        <div class="text-center animated fadeInRightBig" style="margin-top: 140px">
-          <h3 class="font-bold">Automated redirect to - {{ redirectURL }}</h3>
-          <p>
-            <a target="_blank" rel="noopener noreferrer" [href]="redirectURL"
-              >Click here if you have not automatically been redirected to '{{ redirectURL }}'</a
-            >
-          </p>
-        </div>
-      </div>
-    </div>
+} @else {
+  <div class="text-center animated fadeInRightBig" style="margin-top: 140px">
+    <p>View {{ iframeName | titlecase }} is not configured correctly!</p>
   </div>
 }

--- a/console/frontend/src/main/frontend/src/app/views/iframe/iframe.component.html
+++ b/console/frontend/src/main/frontend/src/app/views/iframe/iframe.component.html
@@ -1,4 +1,4 @@
-@if (url.length > 0) {
+@if (url().length > 0) {
   @switch (iframeState) {
     @case ('show') {
       <div class="iframe-wrapper" [style]="`height: calc(100% - ${getTopBarHeight()}px);`">

--- a/console/frontend/src/main/frontend/src/proxy.conf.json
+++ b/console/frontend/src/main/frontend/src/proxy.conf.json
@@ -1,5 +1,5 @@
 {
-  "/iaf/api": {
+  "/iaf/**": {
     "target": "http://localhost:8080/",
     "secure": false,
     "ws": true

--- a/ladybug/common/src/main/resources/springTestToolCommon.xml
+++ b/ladybug/common/src/main/resources/springTestToolCommon.xml
@@ -10,11 +10,11 @@
 		http://www.springframework.org/schema/util    http://www.springframework.org/schema/util/spring-util.xsd
 	">
 
-	<bean name="whiteBoxView" class="org.wearefrank.ladybug.filter.View" autowire="byName">
+	<bean name="whiteBoxView" class="org.wearefrank.ladybug.filter.View">
 		<property name="name" value="White box"/>
 	</bean>
 
-	<bean name="grayBoxView" parent="whiteBoxView" autowire="byName">
+	<bean name="grayBoxView" parent="whiteBoxView">
 		<property name="name" value="Gray box"/>
 		<property name="checkpointMatchers">
 			<list>
@@ -23,7 +23,7 @@
 		</property>
 	</bean>
 
-	<bean name="blackBoxView" parent="whiteBoxView" autowire="byName">
+	<bean name="blackBoxView" parent="whiteBoxView">
 		<property name="name" value="Black box"/>
 		<property name="checkpointMatchers">
 			<list>

--- a/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
+++ b/ladybug/debugger/src/main/java/org/frankframework/ladybug/LadybugDebugger.java
@@ -53,6 +53,7 @@ import org.frankframework.core.PipeLineSession;
 import org.frankframework.management.bus.BusMessageUtils;
 import org.frankframework.management.bus.DebuggerStatusChangedEvent;
 import org.frankframework.stream.Message;
+import org.frankframework.util.AppConstants;
 import org.frankframework.util.LogUtil;
 import org.frankframework.util.MessageUtils;
 import org.frankframework.util.RunState;
@@ -83,6 +84,8 @@ public class LadybugDebugger implements ApplicationContextAware, ApplicationList
 	public void afterPropertiesSet() {
 		if(applicationContext.containsBean(LADYBUG_TESTTOOL_NAME)) {
 			testtool = applicationContext.getBean(LADYBUG_TESTTOOL_NAME, TestTool.class);
+			String instanceName = AppConstants.getInstance().getProperty("instance.name");
+			testtool.setApplication(instanceName);
 			testtool.setDebugger(this);
 			log.info("configuring debugger on TestTool [{}]", testtool);
 		} else {

--- a/ladybug/debugger/src/main/resources/springIbisTestToolTibet2.xml
+++ b/ladybug/debugger/src/main/resources/springIbisTestToolTibet2.xml
@@ -72,7 +72,7 @@
 		</property>
 	</bean>
 
-	<bean name="oldSchoolView" parent="whiteBoxView" autowire="byName">
+	<bean name="oldSchoolView" parent="whiteBoxView">
 		<property name="name" value="Old school"/>
 		<property name="metadataNames">
 			<list>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>4.1-20260619.162848</ladybug.version>
+		<ladybug.version>4.1-20260723.104852</ladybug.version>
 	</properties>
 
 </project>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>10.3.0-20260825.042332</ladybug.version>
+		<ladybug.version>4.1-20260813.191427</ladybug.version>
 	</properties>
 
 </project>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>4.1-20260723.104852</ladybug.version>
+		<ladybug.version>10.3.0-20260825.042332</ladybug.version>
 	</properties>
 
 </project>


### PR DESCRIPTION
Cherry picks:

mhdirkse		11309	Fix circular bean creation with Ladybug	7904a5f90b842cda36dd96c1d50852a485246590
mhdirkse		11316	Bump ladybug and apply testTool.setApplication()	628b10b6921fc252b3ae522d4e99842c92f89ec9
Vivy		11323	Console ladybug view set application name parameter	501c830911af60e0281654571fcc676e548324b9

After these, Ladybug is bumped to 10.3.0-20260825.042332.

This is not yet done because a cherry-pick gave conflicts:

Vivy		11495	Update iframe & ladybug components to work with updated appconstants	883554ef65f76aaac7c5dd0d30d0a2c76002e8f0