### PR TITLE
Add data-cy attribute for accessing cluster member dropdown in Cypress tests

### DIFF
--- a/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
+++ b/console/frontend/src/main/frontend/src/app/components/pages/pages-topnavbar/pages-topnavbar.component.html
@@ -59,6 +59,7 @@
       @if (clusterMembers.length > 0) {
         <li>
           <select
+            data-cy-cluster-member
             class="cluster-member-selector"
             name="selectedClusterMember"
             [(ngModel)]="selectedClusterMember"


### PR DESCRIPTION
Add a data-cy attribute at the drop-down menu of the cluster member. This is done to support testing Ladybug.