### PR TITLE
Make sure to add the "unsafe-memory-access"

### DIFF
--- a/docker/Tomcat/webapp/src/scripts/entrypoint.sh
+++ b/docker/Tomcat/webapp/src/scripts/entrypoint.sh
@@ -12,6 +12,7 @@ export JAVA_OPTS="\
 	--add-opens java.base/sun.nio.ch=ALL-UNNAMED \
 	--add-opens java.management/sun.management=ALL-UNNAMED \
 	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+	--sun-misc-unsafe-memory-access=allow \
 	$JAVA_OPTS"
 
 # By default, GC debugging is disabled.

--- a/docker/embedded/console/Dockerfile
+++ b/docker/embedded/console/Dockerfile
@@ -11,4 +11,6 @@ CMD ["java", \
 	"--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", \
 	"--add-opens", "java.management/sun.management=ALL-UNNAMED", \
 	"--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED", \
-	"-jar", "/app/frankframework-console-webapp.war"]
+	"--sun-misc-unsafe-memory-access=allow", \
+	"-jar", "/app/frankframework-console-webapp.war"
+]


### PR DESCRIPTION
## Changes
In #11336 we added a setting to hide a jvm warning. This also had to be applied to the docker images we build.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [x] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [n/a] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
