### PR TITLE
Message can return empty values instead of NULL

### DIFF
--- a/cmis/src/main/java/org/frankframework/extensions/cmis/server/CmisEventDispatcher.java
+++ b/cmis/src/main/java/org/frankframework/extensions/cmis/server/CmisEventDispatcher.java
@@ -107,7 +107,7 @@ public class CmisEventDispatcher {
 		// Try and catch the original CMIS exception and throw that instead
 		catch (ListenerException e) {
 			if(e.getCause() instanceof PipeRunException pre) {
-				if(pre != null && pre.getCause() instanceof CmisBaseException cbe)
+				if(pre.getCause() instanceof CmisBaseException cbe)
 					throw cbe;
 			}
 			throw new CmisRuntimeException(e.getMessage(), e);

--- a/cmis/src/test/java/org/frankframework/extensions/cmis/TestGetAction.java
+++ b/cmis/src/test/java/org/frankframework/extensions/cmis/TestGetAction.java
@@ -79,11 +79,11 @@ public class TestGetAction extends CmisSenderTestBase {
 		sender.setFileSessionKey("fis");
 		configure(bindingType, getProperties, getDocumentContent);
 
-		String actualResult = sender.sendMessageOrThrow(INPUT_WITH_PROPERTIES, session).asString();
+		Message actualResult = sender.sendMessageOrThrow(INPUT_WITH_PROPERTIES, session);
 		if (!getProperties) {
-			assertNull(actualResult);
+			assertTrue(actualResult.isNull());
 		} else {
-			TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, actualResult);
+			TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, actualResult.asString());
 		}
 
 		Message stream = session.getMessage(sender.getFileSessionKey());
@@ -112,11 +112,11 @@ public class TestGetAction extends CmisSenderTestBase {
 
 		configure(bindingType, getProperties, getDocumentContent);
 
-		String actualResult = sender.sendMessageOrThrow(INPUT_WITH_PROPERTIES, session).asString();
+		Message actualResult = sender.sendMessageOrThrow(INPUT_WITH_PROPERTIES, session);
 		if (!getProperties) {
-			assertNull(actualResult);
+			assertTrue(actualResult.isNull());
 		} else {
-			TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, actualResult);
+			TestAssertions.assertEqualsIgnoreRNTSpace(expectedResult, actualResult.asString());
 		}
 
 		Message message = (Message) session.get(sender.getFileSessionKey());

--- a/core/src/main/java/org/frankframework/align/Json2Xml.java
+++ b/core/src/main/java/org/frankframework/align/Json2Xml.java
@@ -377,22 +377,20 @@ public class Json2Xml extends XmlAligner {
 
 	private String getOverride(JsonValue node) throws SAXException {
 		Object text = sp.getOverride(getContext());
-		// When we drop Java17 support, we can turn this into a concise switch-expression, see https://docs.oracle.com/en/java/javase/21/language/pattern-matching-switch.html#GUID-E69EEA63-E204-41B4-AA7F-D58B26A3B232
-		if (text instanceof List) {
+		return switch (text) {
 			// if the override is a List, then it has already been substituted via getSubstitutedChild.
 			// Therefore now get the node text, which is here an individual element already.
-			return getNodeText(node);
-		} else if (text instanceof Message message) {
-			try {
-				return message.asString();
-			} catch (IOException e) {
-				throw new SAXException(e);
+			case List<?> ignored -> getNodeText(node);
+			case Message message -> {
+				try {
+					yield message.asString();
+				} catch (IOException e) {
+					throw new SAXException(e);
+				}
 			}
-		} else if (text instanceof String string) {
-			return string;
-		} else {
-			return text.toString();
-		}
+			case String string -> string;
+			default -> text.toString();
+		};
 	}
 
 	private void processChildElement(JsonValue node, String parentName, XSElementDeclaration childElementDeclaration, boolean mandatory, Set<String> processedChildren, Set<String> declaredSiblingElements) throws SAXException {

--- a/core/src/main/java/org/frankframework/dataconversion/DataConverter.java
+++ b/core/src/main/java/org/frankframework/dataconversion/DataConverter.java
@@ -81,12 +81,12 @@ public interface DataConverter {
 	/**
 	 * Returns a {@link String} representing the data in this container, or {@code NULL} if {@link #isNull()}.
 	 */
-	@Nullable String asString() throws IOException;
+	String asString() throws IOException;
 
 	/**
 	 * Returns a {@code byte[]} representing the data in this container, or {@code NULL} if {@link #isNull()}.
 	 */
-	byte @Nullable [] asByteArray() throws IOException;
+	byte[] asByteArray() throws IOException;
 
 	/**
 	 * Return data as a {@link Reader}. The {@code Reader} is guaranteed to support {@link Reader#mark(int)} and

--- a/core/src/main/java/org/frankframework/dataconversion/NullDataConverter.java
+++ b/core/src/main/java/org/frankframework/dataconversion/NullDataConverter.java
@@ -55,8 +55,8 @@ final class NullDataConverter implements DataConverter {
 	}
 
 	@Override
-	public @Nullable String asString() {
-		return null;
+	public String asString() {
+		return "";
 	}
 
 	@Override
@@ -75,8 +75,8 @@ final class NullDataConverter implements DataConverter {
 	}
 
 	@Override
-	public byte @Nullable [] asByteArray() {
-		return null;
+	public byte[] asByteArray() {
+		return new byte[0];
 	}
 
 	@Override

--- a/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
+++ b/core/src/main/java/org/frankframework/errormessageformatters/ErrorMessageFormatter.java
@@ -237,14 +237,11 @@ public class ErrorMessageFormatter implements IErrorMessageFormatter, IScopeProv
 				for (Map.Entry<String, Object> entry : entries) {
 					String key = entry.getKey();
 					Object value = entry.getValue();
-					if (value instanceof Message message) {
-						paramsObject.add(key, message.asString());
-					} else if (value instanceof Number number) {
-						paramsObject.add(key, number);
-					} else if (value instanceof Boolean bool) {
-						paramsObject.add(key, bool);
-					} else {
-						paramsObject.add(key, entry.getValue().toString());
+					switch (value) {
+						case Message message -> paramsObject.add(key, message.asString());
+						case Number number -> paramsObject.add(key, number);
+						case Boolean bool -> paramsObject.add(key, bool);
+						case null, default -> paramsObject.add(key, entry.getValue().toString());
 					}
 				}
 				paramsObject.close();

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -347,15 +347,16 @@ public class Message implements Serializable {
 	/**
 	 * Return the request object as a byte array.
 	 */
-	public byte @Nullable[] asByteArray() throws IOException {
+	public byte[] asByteArray() throws IOException {
+		if (isEmpty()) return new byte[0];
 		return request.asByteArray();
 	}
 
 	/**
 	 * Return the request object as a byte array with the specified character encoding.
 	 */
-	public byte @Nullable[] asByteArray(@Nullable String defaultEncodingCharset) throws IOException {
-		if (isNull()) return null;
+	public byte[] asByteArray(@Nullable String defaultEncodingCharset) throws IOException {
+		if (isEmpty()) return new byte[0];
 		return StreamUtil.streamToBytes(asInputStream(defaultEncodingCharset));
 	}
 
@@ -364,7 +365,6 @@ public class Message implements Serializable {
 	 * modifying the state of the Message object.
 	 * This operation is not thread-safe.
 	 */
-	@Nullable
 	public String asString() throws IOException {
 		return request.asString();
 	}

--- a/core/src/main/java/org/frankframework/util/DB2DocumentWriter.java
+++ b/core/src/main/java/org/frankframework/util/DB2DocumentWriter.java
@@ -168,7 +168,9 @@ public class DB2DocumentWriter {
 				}
 				try {
 					Message value = JdbcUtil.getValueAsMessage(dbmsSupport, rs, i, rsmeta, blobCharset, decompressBlobs, trimSpaces, getBlobSmart, false);
-					if (value.isRequestOfType(Number.class)) {
+					if (value.isNull()) {
+						row.add(columnName, (String)null);
+					} else if (value.isRequestOfType(Number.class)) {
 						Number n = value.getValueAsType();
 						row.add(columnName, n);
 					} else if (value.isRequestOfType(Boolean.class)) {

--- a/core/src/test/java/org/frankframework/collection/CollectorPipeTest.java
+++ b/core/src/test/java/org/frankframework/collection/CollectorPipeTest.java
@@ -2,7 +2,6 @@ package org.frankframework.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -66,7 +65,7 @@ public class CollectorPipeTest extends PipeTestBase<AbstractCollectorPipe<TestCo
 
 		assertEquals("success", prr.getPipeForward().getName());
 		assertEquals("testWrite", collector.getInput());
-		assertNull(prr.getResult().asString());
+		assertTrue(prr.getResult().isNull());
 		assertTrue(collector.open);
 	}
 
@@ -81,7 +80,7 @@ public class CollectorPipeTest extends PipeTestBase<AbstractCollectorPipe<TestCo
 
 		assertEquals("success", prr.getPipeForward().getName());
 		assertEquals("testWrite", collector.getInput());
-		assertNull(prr.getResult().asString());
+		assertTrue(prr.getResult().isNull());
 		assertTrue(collector.open);
 	}
 }

--- a/core/src/test/java/org/frankframework/jdbc/StoredProcedureQuerySenderTest.java
+++ b/core/src/test/java/org/frankframework/jdbc/StoredProcedureQuerySenderTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -326,7 +325,7 @@ public class StoredProcedureQuerySenderTest {
 
 		// Assert
 		assertTrue(result.isSuccess());
-		assertNull(result.getResult().asString());
+		assertTrue(result.getResult().isNull());
 	}
 
 	@DatabaseTest

--- a/core/src/test/java/org/frankframework/pipes/CrlPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/CrlPipeTest.java
@@ -2,7 +2,7 @@ package org.frankframework.pipes;
 
 import static org.frankframework.testutil.MatchUtils.assertTestFileEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 
@@ -78,7 +78,7 @@ public class CrlPipeTest extends PipeTestBase<CrlPipe> {
 
 		// assert
 		assertEquals("success", prr.getPipeForward().getName()); 	// CrlPipe could return exception forward here
-		assertNull(prr.getResult().asString());						// CrlPipe could return error message here
+		assertTrue(prr.getResult().isNull());						// CrlPipe could return error message here
 	}
 
 

--- a/core/src/test/java/org/frankframework/pipes/GetPrincipalPipeTest.java
+++ b/core/src/test/java/org/frankframework/pipes/GetPrincipalPipeTest.java
@@ -17,8 +17,8 @@ package org.frankframework.pipes;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +33,7 @@ import org.frankframework.core.ISecurityHandler;
 import org.frankframework.core.PipeForward;
 import org.frankframework.core.PipeRunException;
 import org.frankframework.core.PipeRunResult;
+import org.frankframework.stream.Message;
 
 class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 	private final String PRINCIPAL_NAME = "TST9";
@@ -104,9 +105,9 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 		PipeRunResult prr = doPipe(pipe, "", session);
 
 		// Expect
-		String result = prr.getResult().asString();
+		Message result = prr.getResult();
 		assertEquals("success", prr.getPipeForward().getName());
-		assertNull(result);
+		assertTrue(result.isNull());
 	}
 
 	@Test
@@ -181,10 +182,10 @@ class GetPrincipalPipeTest extends PipeTestBase<GetPrincipalPipe> {
 		PipeRunResult prr = doPipe(pipe, "", session);
 
 		// Expect
-		String result = prr.getResult().asString();
+		Message result = prr.getResult();
 		assertEquals(NOT_FOUND_FORWARD_NAME, prr.getPipeForward().getName());
 		assertEquals(NOT_FOUND_FORWARD_PATH, prr.getPipeForward().getPath());
-		assertNull(result);
+		assertTrue(result.isNull());
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/pipes/JsonValidatorTest.java
+++ b/core/src/test/java/org/frankframework/pipes/JsonValidatorTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Arrays;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,7 +75,7 @@ public class JsonValidatorTest extends PipeTestBase<JsonValidator>{
 		PipeRunResult result = doPipe(input);
 
 		assertEquals("failure", result.getPipeForward().getName());
-		assertEquals(input, result.getResult().asString());
+		Assertions.assertThat(result.getResult().isNull()).describedAs("Expected result to be a NULL message").isTrue();
 
 		String reason = (String)session.get("failureReason");
 		assertThat(reason, containsString("required property 'members' not found"));

--- a/core/src/test/java/org/frankframework/processors/CorePipeLineProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/CorePipeLineProcessorTest.java
@@ -1,8 +1,8 @@
 package org.frankframework.processors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
@@ -295,8 +295,8 @@ class CorePipeLineProcessorTest {
 		PipeLineResult pipeLineResult = processor.processPipeLine(null, pipeLine, "id", new Message(input), session, "p1");
 
 		// Assert
-		assertFalse(pipeLineResult.isSuccessful(), "Expected failure pipeline result");
-		assertNull(pipeLineResult.getResult().asString(), "Expected pipeline result to be NULL");
+		assertThat(pipeLineResult.isSuccessful()).describedAs("Expected failure pipeline result").isFalse();
+		assertThat(pipeLineResult.getResult().isNull()).describedAs("Expected pipeline result to be NULL").isTrue();
 
 		// Verify that pipes 1 & 2 have not been executed
 		assertFalse(session.containsKey("s1"), "Did not expect pipe 1 to be executed");
@@ -327,8 +327,8 @@ class CorePipeLineProcessorTest {
 		PipeLineResult pipeLineResult = processor.processPipeLine(null, pipeLine, "id", new Message(input), session, "p1");
 
 		// Assert
-		assertTrue(pipeLineResult.isSuccessful(), "Expected successful pipeline result");
-		assertNull(pipeLineResult.getResult().asString(), "Expected pipeline result to be NULL");
+		assertThat(pipeLineResult.isSuccessful()).describedAs("Expected successful pipeline result").isTrue();
+		assertThat(pipeLineResult.getResult().isNull()).describedAs("Expected pipeline result to be a NULL message").isTrue();
 
 		// Verify that pipes 1 & 2 have both been executed
 		assertEquals("1", session.getString("s1"));

--- a/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
+++ b/core/src/test/java/org/frankframework/processors/InputOutputPipeProcessorTest.java
@@ -2,7 +2,6 @@ package org.frankframework.processors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -345,7 +344,7 @@ public class InputOutputPipeProcessorTest {
 		PipeRunResult prr = processor.processPipe(pipeLine, pipe, input, session);
 
 		// Assert
-		assertNull(prr.getResult().asString());
+		assertTrue(prr.getResult().isNull());
 		assertFalse(pipeExecuted.get(), "Pipe executed but should not have been");
 	}
 

--- a/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/org/frankframework/util/XmlUtilsTest.java
@@ -28,6 +28,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -186,24 +187,24 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 	void noHtmlToXhtml() throws Exception {
 		Message message = new Message("<xml>tralalal</xml>");
 
-		String actual = XmlUtils.toXhtml(message).asString();
-		assertNull(actual);
+		Message result = XmlUtils.toXhtml(message);
+		Assertions.assertThat(result.isNull()).isTrue();
 	}
 
 	@Test
 	void nullToXhtml() throws Exception {
 		Message message = Message.nullMessage();
 
-		String actual = XmlUtils.toXhtml(message).asString();
-		assertNull(actual);
+		Message result = XmlUtils.toXhtml(message);
+		Assertions.assertThat(result.isNull()).isTrue();
 	}
 
 	@Test
 	void emptyToXhtml() throws Exception {
 		Message message = new Message("");
 
-		String actual = XmlUtils.toXhtml(message).asString();
-		assertNull(actual);
+		Message result = XmlUtils.toXhtml(message);
+		Assertions.assertThat(result.isNull()).isTrue();
 	}
 
 	@Test

--- a/filesystem/src/test/java/org/frankframework/filesystem/exchange/ExchangeFileSystemTestHelper.java
+++ b/filesystem/src/test/java/org/frankframework/filesystem/exchange/ExchangeFileSystemTestHelper.java
@@ -148,6 +148,9 @@ public class ExchangeFileSystemTestHelper implements IFileSystemTestHelper {
 
 	/** Removes all files and folders in the base directory */
 	private void cleanBaseMailFolder() {
+		if (baseMailFolder == null) {
+			return;
+		}
 		List<MailFolder> folders = baseMailFolder.childFolders().get().getValue();
 		for (MailFolder mailFolder : folders) {
 			deleteFolderById(mailFolder.getId());

--- a/tibco/src/test/java/org/frankframework/extensions/tibco/pipes/ObfuscatePipeTest.java
+++ b/tibco/src/test/java/org/frankframework/extensions/tibco/pipes/ObfuscatePipeTest.java
@@ -2,7 +2,7 @@ package org.frankframework.extensions.tibco.pipes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -53,7 +53,7 @@ class ObfuscatePipeTest extends PipeTestBase<ObfuscatePipe> {
 		PipeRunResult emptyResult = doPipe(pipe, "", session);
 
 		// Assert
-		assertNull(nullMessageResult.getResult().asString());
+		assertTrue(nullMessageResult.getResult().isNull());
 		assertEquals("", emptyResult.getResult().asString());
 	}
 


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Message#asString & Message#asByteArray can return empty values instead of NULL


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
