### PR TITLE
Introduce Keycloak as an OAuth2 authenticator 

### DIFF
--- a/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
@@ -76,7 +76,7 @@ import org.frankframework.util.StringUtil;
  * }</pre>
  * </p>
  * <p>
- * Please note that we assume keycloak version 18 or higher is used, so we use the new endpoints and not the old ones. So `<host></host>/realms/test` is
+ * Please note that we assume keycloak version 18 or higher is used, so we use the new endpoints and not the old ones. So `HOST_NAME/realms/test` is
  * used and not `HOST_NAME/auth/realms/test`.
  * </p>
  *

--- a/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
+++ b/security/src/main/java/org/frankframework/lifecycle/servlets/OAuth2Authenticator.java
@@ -29,6 +29,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration.Builder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestCustomizers;
@@ -50,14 +51,12 @@ import org.frankframework.util.SpringUtils;
 import org.frankframework.util.StringUtil;
 
 /**
- * OAuth2 Authentication provider which contains 4 defaults (Google, GitHub,
- * Facebook and Okta), as well as a custom setting which allows users to
+ * OAuth2 Authentication provider which contains 5 defaults (Google, GitHub, Facebook, Okta and Keycloak), as well as a custom setting which allows users to
  * use their own IDP.
- *
  * <p>
  * Default redirect url is as follows:
  * <pre>{@code
- * {baseUrl}/-servlet-name-/oauth2/code/{registrationId}
+ *   {baseUrl}/-servlet-name-/oauth2/code/{registrationId}
  * }</pre>
  * </p>
  * <p>
@@ -70,11 +69,15 @@ import org.frankframework.util.StringUtil;
  * <p>
  * This authenticator should be configured by setting its type to 'OAUTH2', for example:
  * <pre>{@code
- * application.security.console.authentication.type=OAUTH2
- * application.security.console.authentication.provider=google
- * application.security.console.authentication.clientId=my-client-id
- * application.security.console.authentication.clientSecret=my-client-secret
+ *   application.security.console.authentication.type=OAUTH2
+ *   application.security.console.authentication.provider=google
+ *   application.security.console.authentication.clientId=my-client-id
+ *   application.security.console.authentication.clientSecret=my-client-secret
  * }</pre>
+ * </p>
+ * <p>
+ * Please note that we assume keycloak version 18 or higher is used, so we use the new endpoints and not the old ones. So `<host></host>/realms/test` is
+ * used and not `HOST_NAME/auth/realms/test`.
  * </p>
  *
  * @author Niels Meijer
@@ -183,7 +186,7 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 	private ICredentials clientCredentials;
 
 	/**
-	 * The tenant ID to use for the Azure provider.
+	 * The tenant ID to use for the Azure or Keycloak provider.
 	 */
 	private @Setter String tenantId = null;
 
@@ -197,6 +200,7 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 	 *   <li>facebook - Facebook OAuth2</li>
 	 *   <li>okta - Okta OAuth2</li>
 	 *   <li>azure - Microsoft Azure OAuth2</li>
+	 *   <li>keycloak - Keycloak</li>
 	 *   <li>custom - Custom OAuth2 provider (requires additional configuration)</li>
 	 * </ul>
 	 * </p>
@@ -326,6 +330,7 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 				yield commonProvider.getBuilder(provider);
 			}
 			case "azure" -> createAzureBuilder(credentials.getUsername());
+			case "keycloak" -> createKeycloakBuilder();
 			case "custom" -> createCustomBuilder(provider, provider.toLowerCase());
 			default -> throw new IllegalStateException("unknown OAuth provider");
 		};
@@ -338,7 +343,7 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 
 	/**
 	 * @param appId the Azure ClientID
-	 * See https://login.microsoftonline.com/%s/.well-known/openid-configuration
+	 *              See <a href="https://login.microsoftonline.com/%s/.well-known/openid-configuration">Microsoft well known information</a>
 	 */
 	private ClientRegistration.Builder createAzureBuilder(@NonNull String appId) {
 		if (StringUtils.isBlank(tenantId)) throw new IllegalStateException("when using Azure provider the tenantId property is required");
@@ -357,6 +362,34 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 		builder.userInfoUri("https://graph.microsoft.com/oidc/userinfo");
 		builder.userNameAttributeName("email");
 		builder.clientName("azure");
+
+		return builder;
+	}
+
+	/**
+	 * Uses Keycloak's OIDC discovery endpoint to autoconfigure all provider URLs. We use the issuerUri to base the discovery url off of.
+	 * The discovery document is fetched from: {@code {baseUrl}/realms/{tenantId}/.well-known/openid-configuration}
+	 */
+	private ClientRegistration.Builder createKeycloakBuilder() {
+		if (StringUtils.isBlank(tenantId)) {
+			throw new IllegalStateException("when using Keycloak provider the tenantId property is required");
+		}
+
+		if (StringUtils.isBlank(baseUrl)) {
+			throw new IllegalStateException("when using Keycloak provider the baseUrl property is required");
+		}
+
+		String issuerUri = "%s/realms/%s".formatted(baseUrl, tenantId);
+
+		// Fetches .well-known/openid-configuration to auto-configure authorizationUri, tokenUri, jwkSetUri, userInfoUri, etc.
+		ClientRegistration.Builder builder = ClientRegistrations.fromOidcIssuerLocation(issuerUri);
+		builder.registrationId("keycloak");
+
+		// Use the default scopes but allow users to overwrite them
+		builder.scope(StringUtil.split(StringUtils.isBlank(scopes) ? "openid,profile,email" : scopes));
+
+		builder.userNameAttributeName("preferred_username");
+		builder.clientName("keycloak");
 
 		return builder;
 	}
@@ -390,8 +423,8 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 		}
 
 		final String computed;
-		if(baseUrl.endsWith("/")) { // Ensure the url does not end with a slash
-			computed = baseUrl.substring(0, baseUrl.length()-1);
+		if (baseUrl.endsWith("/")) { // Ensure the url does not end with a slash
+			computed = baseUrl.substring(0, baseUrl.length() - 1);
 		} else {
 			computed = baseUrl;
 		}
@@ -433,12 +466,12 @@ public class OAuth2Authenticator extends AbstractServletAuthenticator {
 	private String computeRelativePathFromServlet() {
 		String servletPath = getPrivateEndpoints().stream().findFirst().orElse("");
 
-		if(servletPath.endsWith("*")) { // Strip the '*' if the url ends with it
-			servletPath = servletPath.substring(0, servletPath.length()-1);
+		if (servletPath.endsWith("*")) { // Strip the '*' if the url ends with it
+			servletPath = servletPath.substring(0, servletPath.length() - 1);
 		}
 
-		if(servletPath.endsWith("/")) { // Ensure the url does not end with a slash
-			servletPath = servletPath.substring(0, servletPath.length()-1);
+		if (servletPath.endsWith("/")) { // Ensure the url does not end with a slash
+			servletPath = servletPath.substring(0, servletPath.length() - 1);
 		}
 
 		log.debug("using oauth servlet-path [{}]", servletPath);

--- a/security/src/test/java/org/frankframework/lifecycle/servlets/OAuth2AuthenticatorTest.java
+++ b/security/src/test/java/org/frankframework/lifecycle/servlets/OAuth2AuthenticatorTest.java
@@ -2,12 +2,22 @@ package org.frankframework.lifecycle.servlets;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
 import org.frankframework.credentialprovider.ICredentials;
 
@@ -27,14 +37,14 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 		ServletConfiguration config = createServletConfiguration();
 		config.setUrlMapping("/iaf/gui/*");
-		config.setSecurityRoles(new String[] {"IbisTester"});
+		config.setSecurityRoles(new String[]{ "IbisTester" });
 		authenticator.registerServlet(config);
 
 		// Act
 		authenticator.configureHttpSecurity(httpSecurity);
 
 		// Assert
-		assertArrayEquals(new String[] {"/iaf/gui/*"}, authenticator.getPrivateEndpoints().toArray());
+		assertArrayEquals(new String[]{ "/iaf/gui/*" }, authenticator.getPrivateEndpoints().toArray());
 		assertEquals("{baseUrl}/iaf/gui/oauth2/code/{registrationId}", authenticator.getRedirectUri());
 	}
 
@@ -47,14 +57,14 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 		ServletConfiguration config = createServletConfiguration();
 		config.setUrlMapping("/test/*,/"); // Uses the first entry
-		config.setSecurityRoles(new String[] {"IbisTester"});
+		config.setSecurityRoles(new String[]{ "IbisTester" });
 		authenticator.registerServlet(config);
 
 		// Act
 		authenticator.configureHttpSecurity(httpSecurity);
 
 		// Assert
-		assertArrayEquals(new String[] {"/test/*", "/"}, authenticator.getPrivateEndpoints().toArray());
+		assertArrayEquals(new String[]{ "/test/*", "/" }, authenticator.getPrivateEndpoints().toArray());
 		assertEquals("{baseUrl}/test/oauth2/code/{registrationId}", authenticator.getRedirectUri());
 	}
 
@@ -68,14 +78,14 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 		ServletConfiguration config = createServletConfiguration();
 		config.setUrlMapping("/iaf/gui/*");
-		config.setSecurityRoles(new String[] {"IbisTester"});
+		config.setSecurityRoles(new String[]{ "IbisTester" });
 		authenticator.registerServlet(config);
 
 		// Act
 		authenticator.configureHttpSecurity(httpSecurity);
 
 		// Assert
-		assertArrayEquals(new String[] {"/iaf/gui/*"}, authenticator.getPrivateEndpoints().toArray());
+		assertArrayEquals(new String[]{ "/iaf/gui/*" }, authenticator.getPrivateEndpoints().toArray());
 		assertEquals("http://my-base.com/context/oauth2/code/{registrationId}", authenticator.getRedirectUri());
 	}
 
@@ -89,7 +99,7 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 		ServletConfiguration config = createServletConfiguration();
 		config.setUrlMapping("/iaf/gui/*");
-		config.setSecurityRoles(new String[] {"IbisTester"});
+		config.setSecurityRoles(new String[]{ "IbisTester" });
 		authenticator.registerServlet(config);
 		ArgumentCaptor<ICredentials> credentialCapture = ArgumentCaptor.captor();
 
@@ -99,7 +109,7 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 
 		// Assert
-		assertArrayEquals(new String[] {"/iaf/gui/*"}, authenticator.getPrivateEndpoints().toArray());
+		assertArrayEquals(new String[]{ "/iaf/gui/*" }, authenticator.getPrivateEndpoints().toArray());
 		assertEquals("http://my-base.com/context/oauth2/code/{registrationId}", authenticator.getRedirectUri());
 		ICredentials credentials = credentialCapture.getValue();
 		assertEquals("username1", credentials.getUsername());
@@ -119,7 +129,7 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 		ServletConfiguration config = createServletConfiguration();
 		config.setUrlMapping("/iaf/gui/*");
-		config.setSecurityRoles(new String[] {"IbisTester"});
+		config.setSecurityRoles(new String[]{ "IbisTester" });
 		authenticator.registerServlet(config);
 		ArgumentCaptor<ICredentials> credentialCapture = ArgumentCaptor.captor();
 
@@ -129,11 +139,58 @@ public class OAuth2AuthenticatorTest extends ServletAuthenticatorTest<OAuth2Auth
 
 
 		// Assert
-		assertArrayEquals(new String[] {"/iaf/gui/*"}, authenticator.getPrivateEndpoints().toArray());
+		assertArrayEquals(new String[]{ "/iaf/gui/*" }, authenticator.getPrivateEndpoints().toArray());
 		assertEquals("http://my-base.com/context/oauth2/code/{registrationId}", authenticator.getRedirectUri());
 		ICredentials credentials = credentialCapture.getValue();
 		assertEquals("clientID", credentials.getUsername());
 		assertEquals("clientSecret", credentials.getPassword());
 		assertEquals("doesnt-exist", credentials.getAlias());
+	}
+
+	@Test
+	void testKeycloakUsesOidcDiscovery() throws Exception {
+		// Arrange
+		authenticator.setBaseUrl("http://keycloak.example.com");
+		authenticator.setTenantId("my-realm");
+		authenticator.setClientId("clientID");
+		authenticator.setClientSecret("clientSecret");
+		authenticator.setProvider("keycloak");
+
+		ServletConfiguration config = createServletConfiguration();
+		config.setUrlMapping("/iaf/gui/*");
+		config.setSecurityRoles(new String[]{ "IbisTester" });
+		authenticator.registerServlet(config);
+
+		String expectedIssuerUri = "http://keycloak.example.com/realms/my-realm";
+
+		// Simulate what fromOidcIssuerLocation would return after fetching .well-known/openid-configuration
+		ClientRegistration.Builder discoveredBuilder = ClientRegistration.withRegistrationId("keycloak")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.authorizationUri(expectedIssuerUri + "/protocol/openid-connect/auth")
+				.tokenUri(expectedIssuerUri + "/protocol/openid-connect/token")
+				.jwkSetUri(expectedIssuerUri + "/protocol/openid-connect/certs")
+				.userInfoUri(expectedIssuerUri + "/protocol/openid-connect/userinfo")
+				.issuerUri(expectedIssuerUri);
+
+		try (MockedStatic<ClientRegistrations> clientRegistrationsMock = mockStatic(ClientRegistrations.class)) {
+			clientRegistrationsMock.when(() -> ClientRegistrations.fromOidcIssuerLocation(expectedIssuerUri))
+					.thenReturn(discoveredBuilder);
+
+			// Act
+			authenticator.configureHttpSecurity(httpSecurity);
+
+			// Assert: the discovery endpoint was called with the correct issuer URI
+			clientRegistrationsMock.verify(() -> ClientRegistrations.fromOidcIssuerLocation(expectedIssuerUri));
+
+			ClientRegistration registration = authenticator.getOrCreateClientRegistrationRepository()
+					.findByRegistrationId("keycloak");
+
+			assertNotNull(registration);
+			assertEquals("keycloak", registration.getRegistrationId());
+			assertEquals("keycloak", registration.getClientName());
+			assertEquals("preferred_username", registration.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName());
+			assertTrue(registration.getScopes().containsAll(Set.of("openid", "profile", "email")));
+		}
 	}
 }


### PR DESCRIPTION
## Changes
Introduce Keycloak as an OAuth2 authenticator option instead of using type=CUSTOM to configure it

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [n/a] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
