### PR TITLE
Jexl expressions cancelled after configuration unloaded

### DIFF
--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -204,6 +204,9 @@ public class IbisContext extends IbisApplicationContext {
 		try {
 			classLoaderManager.reload(configurationName);
 			unload(configurationName);
+			if (Thread.interrupted()) { // clear the Thread-Interrupted status because it will, ahem, interrupt the loading process
+				APPLICATION_LOG.info("Thread interrupted while unloading configuration [{}], status cleared before reloading", configurationName);
+			}
 			load(configurationName);
 		} catch (ClassLoaderException e) {
 			log("failed to reload", MessageEventLevel.ERROR, e);

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -202,13 +202,13 @@ public class IbisContext extends IbisApplicationContext {
 	 */
 	public synchronized void reload(String configurationName) {
 		try {
-			classLoaderManager.reload(configurationName);
+//			classLoaderManager.reload(configurationName);
 			unload(configurationName);
 			if (Thread.interrupted()) { // clear the Thread-Interrupted status because it will, ahem, interrupt the loading process
 				APPLICATION_LOG.info("Thread interrupted while unloading configuration [{}], status cleared before reloading", configurationName);
 			}
 			load(configurationName);
-		} catch (ClassLoaderException e) {
+		} catch (Exception e) {
 			log("failed to reload", MessageEventLevel.ERROR, e);
 		}
 	}

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -199,6 +199,7 @@ public class IbisContext extends IbisApplicationContext {
 	 * It then replaces the old resources with the new resources. If all is successful
 	 * it will unload the old configuration from the IbisManager, and load the new
 	 * configuration.
+	 * This also destroys the ClassLoader and creates a new one.
 	 */
 	public synchronized void reload(String configurationName) {
 		try {

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -203,7 +203,6 @@ public class IbisContext extends IbisApplicationContext {
 	 */
 	public synchronized void reload(String configurationName) {
 		try {
-//			classLoaderManager.reload(configurationName);
 			unload(configurationName);
 			if (Thread.interrupted()) { // clear the Thread-Interrupted status because it will, ahem, interrupt the loading process
 				APPLICATION_LOG.info("Thread interrupted while unloading configuration [{}], status cleared before reloading", configurationName);

--- a/core/src/main/java/org/frankframework/configuration/classloaders/ScanningDirectoryClassLoader.java
+++ b/core/src/main/java/org/frankframework/configuration/classloaders/ScanningDirectoryClassLoader.java
@@ -38,8 +38,10 @@ import org.frankframework.management.Action;
 public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 
 	private ScheduledThreadPoolExecutor executor;
-	private int scanInterval = 10;
 	private ScheduledFuture<?> future;
+
+	private int scanInterval = 10;
+	private long lastScanTime;
 
 	public ScanningDirectoryClassLoader(ClassLoader parent) {
 		super(parent);
@@ -51,6 +53,7 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 
 		createTaskExecutor();
 
+		lastScanTime = System.currentTimeMillis();
 		if (scanInterval > 0) {
 			schedule();
 		}
@@ -61,21 +64,21 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 		ThreadFactory namedThreadFactory = runnable -> {
 			Thread thread = new Thread(runnable);
 			thread.setName(threadName);
-			thread.setDaemon(false);
+			thread.setDaemon(true);
 			return thread;
 		};
 		executor = new ScheduledThreadPoolExecutor(1, namedThreadFactory);
-		executor.setRemoveOnCancelPolicy(true);
+		executor.setRemoveOnCancelPolicy(false);
 		executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-		executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+		executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(true);
 	}
 
 	@Override
-	public void destroy() {
+	public synchronized void destroy() {
 		super.destroy();
 
 		if (future != null) {
-			future.cancel(true);
+			future.cancel(false);
 			future = null;
 		}
 
@@ -105,24 +108,28 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 	 * Create a new schedule to check if file in the given directory have been changed
 	 * @param delay cooldown/startup delay before the scheduler should start looking for file changes
 	 */
-	private void schedule(int delay) {
+	private synchronized void schedule(int delay) {
 		if (future != null) {
 			future.cancel(false);
 		}
 
+		if (executor == null) {
+			log.debug("Cannot reschedule tasks because executor is null");
+			return;
+		}
 		log.debug("starting new scheduler, interval [{}] delay [{}]", scanInterval, delay);
 		future = executor.scheduleAtFixedRate(ScanningDirectoryClassLoader.this::scan, delay, scanInterval, TimeUnit.SECONDS);
 	}
 
-	protected synchronized void scan() {
+	protected void scan() {
 		if (log.isTraceEnabled()) log.trace("running directory scanner on directory [{}]", getDirectory());
+		long scanTime = System.currentTimeMillis();
 		File[] files = getDirectory().listFiles();
 		if (hasBeenModified(files)) {
 			log.debug("detected file change, reloading configuration");
 			getIbisManager().handleAction(Action.RELOAD, getConfigurationName(), null, null, toString(), false);
-
-			schedule();
 		}
+		lastScanTime = scanTime;
 	}
 
 	/**
@@ -154,7 +161,7 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 	 */
 	private boolean hasBeenModified(File file) {
 		if (log.isTraceEnabled()) log.trace("scanning file [{}] lastModDate [{}]", file.getName(), file.lastModified());
-		boolean modified = file.lastModified() + scanInterval*1000L >= System.currentTimeMillis();
+		boolean modified = file.lastModified() >= lastScanTime;
 
 		if (log.isDebugEnabled() && modified) {
 			log.debug("file [{}] has been changed in the last [{}] seconds", file.getAbsolutePath(), scanInterval);

--- a/core/src/main/java/org/frankframework/parameters/ParameterValueList.java
+++ b/core/src/main/java/org/frankframework/parameters/ParameterValueList.java
@@ -128,6 +128,14 @@ public class ParameterValueList implements Iterable<ParameterValue> {
 		return defaultValue;
 	}
 
+	public boolean getValue(@NonNull String parameterName, boolean defaultValue) {
+		ParameterValue pv = get(parameterName);
+		if (pv != null) {
+			return pv.asBooleanValue(defaultValue);
+		}
+		return defaultValue;
+	}
+
 	@Nullable
 	public String getValue(@NonNull String parameterName) {
 		return getValue(parameterName, (String) null);

--- a/core/src/main/java/org/frankframework/senders/ReloadSender.java
+++ b/core/src/main/java/org/frankframework/senders/ReloadSender.java
@@ -52,11 +52,11 @@ public class ReloadSender extends AbstractSenderWithParameters {
 		boolean forceReload = getForceReload();
 
 		ParameterValueList pvl = getParameterValueList(message, session);
-		if(pvl != null) {
-			if(pvl.contains("name"))
-				configName = pvl.get("name").asStringValue();
-			if(pvl.contains("forceReload"))
-				forceReload = pvl.get("forceReload").asBooleanValue(false);
+		if (pvl != null) {
+			if (pvl.contains("name"))
+				configName = pvl.getValue("name");
+			if (pvl.contains("forceReload"))
+				forceReload = pvl.getValue("forceReload", false);
 		}
 
 		try {
@@ -78,7 +78,7 @@ public class ReloadSender extends AbstractSenderWithParameters {
 
 		if (configuration != null) {
 			String currentVersion = configuration.getVersion();
-			if (forceReload || (currentVersion != null && !newVersion.equals(currentVersion))) {
+			if (forceReload || (currentVersion != null && !currentVersion.equals(newVersion))) {
 				IbisContext ibisContext = ibisManager.getIbisContext();
 				ibisContext.reload(configName);
 				return new SenderResult("Reload " + configName + " succeeded");

--- a/core/src/test/java/org/frankframework/configuration/digester/ValidateAttributeRuleTest.java
+++ b/core/src/test/java/org/frankframework/configuration/digester/ValidateAttributeRuleTest.java
@@ -323,7 +323,7 @@ public class ValidateAttributeRuleTest {
 	@Test
 	public void testAttributeValueEqualToDefaultValueWarningsSuppressed() throws Exception {
 		// Arrange
-		configuration = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		configuration = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 		loadAppConstants(configuration);
 
 		// This test has a different value for this property than the other tests in this class

--- a/core/src/test/java/org/frankframework/lifecycle/WebContentServletTest.java
+++ b/core/src/test/java/org/frankframework/lifecycle/WebContentServletTest.java
@@ -39,7 +39,7 @@ public class WebContentServletTest {
 	 */
 	@Test
 	void testListDirectory() throws IOException, ClassLoaderException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		DirectoryClassLoader classLoader = new DirectoryClassLoader(new NullClassLoader());
 		classLoader.setDirectory(JunitTestClassLoaderWrapper.getTestClassesLocation() + "WebContentTestRoot");
@@ -58,7 +58,7 @@ public class WebContentServletTest {
 	 */
 	@Test
 	void testListDirectoryNotPresent() throws IOException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		// Act
 		MockHttpServletResponse response = getWebContentForConfiguration(config);
@@ -87,7 +87,7 @@ public class WebContentServletTest {
 
 	@Test
 	void noPath() throws IOException, ServletException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		// Act
 		MockHttpServletResponse response = doGet(config, null);
@@ -100,7 +100,7 @@ public class WebContentServletTest {
 
 	@Test
 	void rootPath() throws IOException, ServletException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		// Act
 		MockHttpServletResponse response = doGet(config, "/");
@@ -113,7 +113,7 @@ public class WebContentServletTest {
 
 	@Test
 	void testConfigurationWelcomeFile() throws IOException, ServletException, ClassLoaderException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		DirectoryClassLoader classLoader = new DirectoryClassLoader(new NullClassLoader());
 		classLoader.setDirectory(JunitTestClassLoaderWrapper.getTestClassesLocation() + "WebContentTestRoot");
@@ -131,7 +131,7 @@ public class WebContentServletTest {
 
 	@Test
 	void testConfigurationTestFile() throws IOException, ServletException, ClassLoaderException {
-		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+		TestConfiguration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 
 		DirectoryClassLoader classLoader = new DirectoryClassLoader(new NullClassLoader());
 		classLoader.setDirectory(JunitTestClassLoaderWrapper.getTestClassesLocation() + "WebContentTestRoot");

--- a/core/src/test/java/org/frankframework/management/bus/BusTestBase.java
+++ b/core/src/test/java/org/frankframework/management/bus/BusTestBase.java
@@ -50,7 +50,7 @@ public class BusTestBase {
 
 	protected final Configuration getConfiguration() {
 		if(configuration == null) {
-			Configuration config = new TestConfiguration(TestConfiguration.TEST_CONFIGURATION_FILE);
+			Configuration config = new TestConfiguration(TestConfiguration.TEST_SPRING_CONFIGURATION_FILE);
 			try {
 				getParentContext().getAutowireCapableBeanFactory().autowireBeanProperties(config, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, false);
 				configuration = (Configuration) getParentContext().getAutowireCapableBeanFactory().initializeBean(config, TestConfiguration.TEST_CONFIGURATION_NAME);

--- a/core/src/test/java/org/frankframework/testutil/TestConfiguration.java
+++ b/core/src/test/java/org/frankframework/testutil/TestConfiguration.java
@@ -25,8 +25,8 @@ import org.frankframework.util.SpringUtils;
  */
 public class TestConfiguration extends Configuration {
 	public static final String TEST_CONFIGURATION_NAME = "TestConfiguration";
-	public static final String TEST_CONFIGURATION_FILE = "testConfigurationContext.xml";
-	public static final String TEST_DATABASE_ENABLED_CONFIGURATION_FILE = "testDatabaseEnabledConfigurationContext.xml";
+	public static final String TEST_SPRING_CONFIGURATION_FILE = "testConfigurationContext.xml";
+	public static final String TEST_DATABASE_ENABLED_SPRING_CONFIGURATION_FILE = "testDatabaseEnabledConfigurationContext.xml";
 	private final QuerySenderPostProcessor qsPostProcessor = new QuerySenderPostProcessor();
 	private final boolean autoConfigure;
 
@@ -36,22 +36,22 @@ public class TestConfiguration extends Configuration {
 	}
 
 	public TestConfiguration(boolean autoConfigure) {
-		this(autoConfigure, TEST_CONFIGURATION_FILE);
+		this(autoConfigure, TEST_SPRING_CONFIGURATION_FILE);
 		refresh();
 	}
 
-	public TestConfiguration(String... configurationFiles) {
-		this(true, configurationFiles);
+	public TestConfiguration(String... springConfigurationFiles) {
+		this(true, springConfigurationFiles);
 	}
 
-	public TestConfiguration(boolean autoConfigure, String... configurationFiles) {
+	public TestConfiguration(boolean autoConfigure, String... springConfigurationFiles) {
 		super();
 		setAutoStart(false);
 		this.autoConfigure = autoConfigure;
 
 		ClassLoader classLoader = new JunitTestClassLoaderWrapper(); // Add ability to retrieve classes from src/test/resources
 		setClassLoader(classLoader); // Add the test classpath
-		setConfigLocations(configurationFiles);
+		setConfigLocations(springConfigurationFiles);
 		setName(TEST_CONFIGURATION_NAME);
 	}
 

--- a/core/src/test/java/org/frankframework/testutil/TransactionManagerType.java
+++ b/core/src/test/java/org/frankframework/testutil/TransactionManagerType.java
@@ -37,9 +37,9 @@ public enum TransactionManagerType {
 
 	TransactionManagerType(Class<? extends IDataSourceFactory> clazz, String springConfigurationFile) {
 		if(springConfigurationFile == null) {
-			springConfigurationFiles = new String[]{ TestConfiguration.TEST_CONFIGURATION_FILE };
+			springConfigurationFiles = new String[]{ TestConfiguration.TEST_SPRING_CONFIGURATION_FILE};
 		} else {
-			springConfigurationFiles = new String[]{ springConfigurationFile, TestConfiguration.TEST_DATABASE_ENABLED_CONFIGURATION_FILE };
+			springConfigurationFiles = new String[]{ springConfigurationFile, TestConfiguration.TEST_DATABASE_ENABLED_SPRING_CONFIGURATION_FILE };
 		}
 		factory = clazz;
 	}

--- a/filesystem/src/main/java/org/frankframework/filesystem/MsalClientAdapter.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/MsalClientAdapter.java
@@ -146,8 +146,10 @@ public class MsalClientAdapter extends AbstractHttpSender implements IHttpClient
 		try {
 			String token = future.get().accessToken();
 			return "Bearer " + token;
-		} catch (InterruptedException | ExecutionException e) {
+		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
+			throw new IOException("interrupted while generating access token", e);
+		} catch (ExecutionException e) {
 			throw new IOException("could not generate access token", e);
 		}
 	}

--- a/property-expression-evaluator/src/main/java/org/frankframework/extentions/script/EmbeddedScriptEvaluation.java
+++ b/property-expression-evaluator/src/main/java/org/frankframework/extentions/script/EmbeddedScriptEvaluation.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections4.map.CompositeMap;
 import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.JexlException;
 import org.apache.commons.jexl3.JexlFeatures;
 import org.apache.commons.jexl3.JexlScript;
 import org.apache.commons.jexl3.introspection.JexlPermissions;
@@ -177,6 +178,9 @@ public class EmbeddedScriptEvaluation implements AdditionalStringResolver {
 			} else {
 				return Optional.of(result.toString());
 			}
+		} catch (JexlException.Cancel c) {
+			log.warn("Script execution has been cancelled because thread was interrupted.", c);
+			return Optional.empty();
 		} catch (Exception e) {
 			// Script was probably valid but not in the context of variables given
 			log.error(() -> "Cannot evaluate JEXL expression [%s]".formatted(key), e);

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -137,6 +137,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>

--- a/test/src/main/resources/ServerSpecifics_TOMCATBTM.properties
+++ b/test/src/main/resources/ServerSpecifics_TOMCATBTM.properties
@@ -1,2 +1,0 @@
-active.tibco=false
-active.jms=true


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Clear Thread interrupted flag after unloading a configuration during config reload, because the Thread interrupted status can mess up things including JEXL expression evaluation in configurations.

Closes #11463



<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
