### PR TITLE
Document metrics export options in AppConstants

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -368,22 +368,32 @@ statistics.cron=0 45 23 * * ?
 
 statistics.size=true
 
+#### Metrics export
+## Micrometer registries. Set management.metrics.export.<name>.enabled=true to turn one on.
+## Local is on by default (Frank!Console statistics). Prometheus scrapes GET /metrics/prometheus.
+## Also exported: JVM memory/threads/GC/CPU/classloader, Log4j2, disk of log.dir, and per-pipe duration/size.
+
+## Keep the in-process local registry (Frank!Console statistics).
 management.metrics.export.local.enabled=true
 management.metrics.export.local.configurator=org.frankframework.metrics.LocalRegistryConfigurator
 
+## Prometheus scrape endpoint at /metrics/prometheus when enabled.
 management.metrics.export.prometheus.enabled=false
 management.metrics.export.prometheus.configurator=org.frankframework.metrics.PrometheusRegistryConfigurator
 
+## Push metrics to Amazon CloudWatch.
 management.metrics.export.cloudwatch.enabled=false
 management.metrics.export.cloudwatch.configurator=org.frankframework.metrics.CloudWatchRegistryConfigurator
 management.metrics.export.cloudwatch.namespace=${instance.name.lc}
 management.metrics.export.cloudwatch.step=15m
 
+## Push metrics to StatsD.
 management.metrics.export.statsd.enabled=false
 management.metrics.export.statsd.configurator=org.frankframework.metrics.StatsDRegistryConfigurator
 management.metrics.export.statsd.flavor=etsy
 management.metrics.export.statsd.step=15m
 
+## Push metrics to InfluxDB.
 management.metrics.export.influx.enabled=false
 management.metrics.export.influx.configurator=org.frankframework.metrics.InfluxRegistryConfigurator
 management.metrics.export.influx.uri=http://localhost:8086
@@ -391,6 +401,7 @@ management.metrics.export.influx.org=waf
 management.metrics.export.influx.bucket=${instance.name.lc}
 management.metrics.export.influx.authAlias=influx
 
+## Push metrics to KairosDB.
 management.metrics.export.kairos.enabled=false
 management.metrics.export.kairos.configurator=org.frankframework.metrics.KairosDbRegistryConfigurator
 management.metrics.export.kairos.uri=http://localhost:8080/api/v1/datapoints

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -375,6 +375,7 @@ statistics.size=true
 
 ## Keep the in-process local registry (Frank!Console statistics).
 management.metrics.export.local.enabled=true
+## Registry factory class. Leave the default unless you replace the implementation.
 management.metrics.export.local.configurator=org.frankframework.metrics.LocalRegistryConfigurator
 
 ## Prometheus scrape endpoint at /metrics/prometheus when enabled.
@@ -384,27 +385,37 @@ management.metrics.export.prometheus.configurator=org.frankframework.metrics.Pro
 ## Push metrics to Amazon CloudWatch.
 management.metrics.export.cloudwatch.enabled=false
 management.metrics.export.cloudwatch.configurator=org.frankframework.metrics.CloudWatchRegistryConfigurator
+## CloudWatch metric namespace. Defaults to the instance name in lowercase.
 management.metrics.export.cloudwatch.namespace=${instance.name.lc}
+## How often meters are published to CloudWatch.
 management.metrics.export.cloudwatch.step=15m
 
 ## Push metrics to StatsD.
 management.metrics.export.statsd.enabled=false
 management.metrics.export.statsd.configurator=org.frankframework.metrics.StatsDRegistryConfigurator
+## StatsD flavor: etsy, datadog, telegraf or sysdig.
 management.metrics.export.statsd.flavor=etsy
+## How often meters are published to StatsD.
 management.metrics.export.statsd.step=15m
 
 ## Push metrics to InfluxDB.
 management.metrics.export.influx.enabled=false
 management.metrics.export.influx.configurator=org.frankframework.metrics.InfluxRegistryConfigurator
+## InfluxDB write endpoint.
 management.metrics.export.influx.uri=http://localhost:8086
+## InfluxDB organization.
 management.metrics.export.influx.org=waf
+## InfluxDB bucket. Defaults to the instance name in lowercase.
 management.metrics.export.influx.bucket=${instance.name.lc}
+## Auth alias for InfluxDB credentials (username/password or token).
 management.metrics.export.influx.authAlias=influx
 
 ## Push metrics to KairosDB.
 management.metrics.export.kairos.enabled=false
 management.metrics.export.kairos.configurator=org.frankframework.metrics.KairosDbRegistryConfigurator
+## KairosDB write endpoint.
 management.metrics.export.kairos.uri=http://localhost:8080/api/v1/datapoints
+## Auth alias for KairosDB credentials. Empty means no authentication.
 management.metrics.export.kairos.authAlias=
 
 ## Default management control endpoints


### PR DESCRIPTION
AppConstants already had the export flags, but nothing described how to turn a registry on, where Prometheus is scraped, or what meters go out.

I added that next to the properties. Local stays the default; Prometheus is GET /metrics/prometheus when enabled.

Fixes #6691