### PR TITLE
Fix for JEXL expression Cancelled exception during config reload

### DIFF
--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -199,13 +199,16 @@ public class IbisContext extends IbisApplicationContext {
 	 * It then replaces the old resources with the new resources. If all is successful
 	 * it will unload the old configuration from the IbisManager, and load the new
 	 * configuration.
+	 * This also destroys the ClassLoader and creates a new one.
 	 */
 	public synchronized void reload(String configurationName) {
 		try {
-			classLoaderManager.reload(configurationName);
 			unload(configurationName);
+			if (Thread.interrupted()) { // clear the Thread-Interrupted status because it will, ahem, interrupt the loading process
+				APPLICATION_LOG.info("Thread interrupted while unloading configuration [{}], status cleared before reloading", configurationName);
+			}
 			load(configurationName);
-		} catch (ClassLoaderException e) {
+		} catch (Exception e) {
 			log("failed to reload", MessageEventLevel.ERROR, e);
 		}
 	}

--- a/core/src/main/java/org/frankframework/configuration/classloaders/ScanningDirectoryClassLoader.java
+++ b/core/src/main/java/org/frankframework/configuration/classloaders/ScanningDirectoryClassLoader.java
@@ -38,8 +38,10 @@ import org.frankframework.management.Action;
 public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 
 	private ScheduledThreadPoolExecutor executor;
-	private int scanInterval = 10;
 	private ScheduledFuture<?> future;
+
+	private int scanInterval = 10;
+	private long lastScanTime;
 
 	public ScanningDirectoryClassLoader(ClassLoader parent) {
 		super(parent);
@@ -51,6 +53,7 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 
 		createTaskExecutor();
 
+		lastScanTime = System.currentTimeMillis();
 		if (scanInterval > 0) {
 			schedule();
 		}
@@ -61,21 +64,21 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 		ThreadFactory namedThreadFactory = runnable -> {
 			Thread thread = new Thread(runnable);
 			thread.setName(threadName);
-			thread.setDaemon(false);
+			thread.setDaemon(true);
 			return thread;
 		};
 		executor = new ScheduledThreadPoolExecutor(1, namedThreadFactory);
-		executor.setRemoveOnCancelPolicy(true);
+		executor.setRemoveOnCancelPolicy(false);
 		executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-		executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+		executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(true);
 	}
 
 	@Override
-	public void destroy() {
+	public synchronized void destroy() {
 		super.destroy();
 
 		if (future != null) {
-			future.cancel(true);
+			future.cancel(false);
 			future = null;
 		}
 
@@ -105,24 +108,28 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 	 * Create a new schedule to check if file in the given directory have been changed
 	 * @param delay cooldown/startup delay before the scheduler should start looking for file changes
 	 */
-	private void schedule(int delay) {
+	private synchronized void schedule(int delay) {
 		if (future != null) {
 			future.cancel(false);
 		}
 
+		if (executor == null) {
+			log.debug("Cannot reschedule tasks because executor is null");
+			return;
+		}
 		log.debug("starting new scheduler, interval [{}] delay [{}]", scanInterval, delay);
 		future = executor.scheduleAtFixedRate(ScanningDirectoryClassLoader.this::scan, delay, scanInterval, TimeUnit.SECONDS);
 	}
 
-	protected synchronized void scan() {
+	protected void scan() {
 		if (log.isTraceEnabled()) log.trace("running directory scanner on directory [{}]", getDirectory());
+		long scanTime = System.currentTimeMillis();
 		File[] files = getDirectory().listFiles();
 		if (hasBeenModified(files)) {
 			log.debug("detected file change, reloading configuration");
 			getIbisManager().handleAction(Action.RELOAD, getConfigurationName(), null, null, toString(), false);
-
-			schedule();
 		}
+		lastScanTime = scanTime;
 	}
 
 	/**
@@ -154,7 +161,7 @@ public class ScanningDirectoryClassLoader extends DirectoryClassLoader {
 	 */
 	private boolean hasBeenModified(File file) {
 		if (log.isTraceEnabled()) log.trace("scanning file [{}] lastModDate [{}]", file.getName(), file.lastModified());
-		boolean modified = file.lastModified() + scanInterval*1000L >= System.currentTimeMillis();
+		boolean modified = file.lastModified() >= lastScanTime;
 
 		if (log.isDebugEnabled() && modified) {
 			log.debug("file [{}] has been changed in the last [{}] seconds", file.getAbsolutePath(), scanInterval);

--- a/filesystem/src/main/java/org/frankframework/filesystem/MsalClientAdapter.java
+++ b/filesystem/src/main/java/org/frankframework/filesystem/MsalClientAdapter.java
@@ -146,8 +146,10 @@ public class MsalClientAdapter extends AbstractHttpSender implements IHttpClient
 		try {
 			String token = future.get().accessToken();
 			return "Bearer " + token;
-		} catch (InterruptedException | ExecutionException e) {
+		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
+			throw new IOException("interrupted while generating access token", e);
+		} catch (ExecutionException e) {
 			throw new IOException("could not generate access token", e);
 		}
 	}

--- a/property-expression-evaluator/src/main/java/org/frankframework/extentions/script/EmbeddedScriptEvaluation.java
+++ b/property-expression-evaluator/src/main/java/org/frankframework/extentions/script/EmbeddedScriptEvaluation.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections4.map.CompositeMap;
 import org.apache.commons.jexl3.JexlBuilder;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JexlEngine;
+import org.apache.commons.jexl3.JexlException;
 import org.apache.commons.jexl3.JexlFeatures;
 import org.apache.commons.jexl3.JexlScript;
 import org.apache.commons.jexl3.introspection.JexlPermissions;
@@ -174,6 +175,9 @@ public class EmbeddedScriptEvaluation implements AdditionalStringResolver {
 			} else {
 				return Optional.of(result.toString());
 			}
+		} catch (JexlException.Cancel c) {
+			log.warn("Script execution has been cancelled because thread was interrupted.", c);
+			return Optional.empty();
 		} catch (Exception e) {
 			// Script was probably valid but not in the context of variables given
 			log.error(() -> "Cannot evaluate JEXL expression [%s]".formatted(key), e);


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
Partial cherry-pick from the PR that fixed #11463, focussing on the actual fix.

- Improvements in ScanningDirectoryClassloader
- Reset Thread-Interrupted status caused by destroying/recreating ScanningDirectoryClassLoader in IbisContext

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
