### PR TITLE
On 9.4 bump Ladybug to 4.1-20260831.155321

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -19,7 +19,7 @@
 	</modules>
 
 	<properties>
-		<ladybug.version>4.1-20260813.191427</ladybug.version>
+		<ladybug.version>4.1-20260831.155321</ladybug.version>
 	</properties>
 
 </project>


### PR DESCRIPTION
Get a more meaningful error in Ladybug when rerunning a report fails due to something detected by the Frank!Framework.