### PR TITLE
Use CDN for fonts for better caching

### DIFF
--- a/console/backend/src/main/java/org/frankframework/console/filters/CspFilter.java
+++ b/console/backend/src/main/java/org/frankframework/console/filters/CspFilter.java
@@ -44,7 +44,7 @@ public class CspFilter implements Filter {
 
 		List<String> policyDirectives = new ArrayList<>();
 		policyDirectives.add("default-src 'self';");
-		policyDirectives.add("style-src 'self' https://fonts.googleapis.com/css 'unsafe-inline';");
+		policyDirectives.add("style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline';");
 		policyDirectives.add("font-src 'self' https://fonts.gstatic.com data:;");
 		// 'sha256-nTT9HlzZYsLZk5BbdhMKiMCvEgbfaqTeueMbRW8r6Ak=' belongs to larva
 		policyDirectives.add("script-src 'self' 'unsafe-eval' 'nonce-IE-warning' 'sha256-nTT9HlzZYsLZk5BbdhMKiMCvEgbfaqTeueMbRW8r6Ak=';");

--- a/console/frontend/src/main/frontend/src/assets/css/style.css
+++ b/console/frontend/src/main/frontend/src/assets/css/style.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700');
-@import url('https://fonts.googleapis.com/css?family=Roboto:400,300,500,700');
 
 h1,
 h2,

--- a/console/frontend/src/main/frontend/src/index.html
+++ b/console/frontend/src/main/frontend/src/index.html
@@ -18,6 +18,9 @@
     <meta name="msapplication-TileColor" content="#1e1e1e" />
     <meta name="msapplication-config" content="assets/favicon/browserconfig.xml?v=2" />
     <meta name="theme-color" content="#1e1e1e" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,300,500,700" />
   </head>
   <body id="page-top">
     <app-root>


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

Browsers save fonts in the cache, when a CDN is used, the fonts can be used over multiple FF! instances, making the bundle size smaller.

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
