### PR TITLE
Update Docker HEALTHCHECK endpoint to handle authenticated api

### DIFF
--- a/docker/Tomcat/test/Dockerfile
+++ b/docker/Tomcat/test/Dockerfile
@@ -26,6 +26,6 @@ COPY --chown=tomcat target/dependencies/*.jar /opt/frank/drivers
 RUN mv /usr/local/tomcat/webapps/ROOT /usr/local/tomcat/webapps/iaf-test
 
 # Ensure the container is healty
-HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 CMD curl --fail --silent http://localhost:8080/iaf-test/iaf/api || exit 1
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 CMD curl --fail --silent http://localhost:8080/iaf-test/iaf/api/server/health || exit 1
 
 # Note: Credentials need to be mounted in /opt/frank/secrets at runtime

--- a/docker/Tomcat/webapp/Dockerfile
+++ b/docker/Tomcat/webapp/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i "s/<\/web-app>//g" /usr/local/tomcat/webapps/ROOT/WEB-INF/web.xml && 
     rm -f /scripts/web.xml
 
 # Ensure the container is healty
-HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 CMD curl --fail --silent http://localhost:8080/iaf/api || exit 1
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 CMD curl --fail --silent http://localhost:8080/iaf/api/server/health || exit 1
 
 ENTRYPOINT ["/scripts/entrypoint.sh"]
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
The default `/iaf/api` endpoint returns HTTP 401 when console authentication is enabled, causing Docker to mark the container as unhealthy. Update the healthcheck command to probe an accessible endpoint as documented in the [Frank!Framework Health & Readiness Documentation](https://docs.frankframework.org/docs/get-started/docker/health-and-readiness).

## Changes

- Updated Docker `HEALTHCHECK` command to prevent false-negative HTTP 401 failures when console authentication is enabled, aligning with the official endpoint provided in the [docs](https://docs.frankframework.org/docs/get-started/docker/health-and-readiness).

docker ps gives an unhealthy instance
<img width="187" height="45" alt="afbeelding" src="https://github.com/user-attachments/assets/0b8557bc-8e70-47e3-87c1-95890028582b" />

While the endpoint "/iaf/api/server/health" returns HTTP 200
<img width="110" height="30" alt="afbeelding" src="https://github.com/user-attachments/assets/d9025eaa-a0c3-4afd-a75a-7ecdacd49358" />


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>