### PR TITLE
Fix new JDBC BLOB reading code for backwards compatibility with incorrect "compressedBlob" flag.

### DIFF
--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -454,7 +454,7 @@ public class Message implements Serializable {
 			case URL rL -> new UrlMessage(rL);
 			case File file -> new FileMessage(file);
 			case Path path -> new PathMessage(path);
-			case RawMessageWrapper<?> ignored -> throw new IllegalArgumentException("Raw message extraction / wrapping should be done via Listener.");
+			case RawMessageWrapper<?> ignored -> throw new IllegalArgumentException("Raw message extraction / unwrapping should be done via Listener.");
 			default -> // Constructor will reject unsupported types
 					new Message(new MessageContext(), object);
 		};

--- a/core/src/main/java/org/frankframework/util/JdbcUtil.java
+++ b/core/src/main/java/org/frankframework/util/JdbcUtil.java
@@ -270,9 +270,22 @@ public class JdbcUtil {
 					.setEncode(true)
 					.get());
 		}
-		Message intermediateMessage = new Message(blobInputStream, blobCharset);
-		if (!blobSmartGet) {
-			return intermediateMessage;
+		Message intermediateMessage;
+		try {
+			intermediateMessage = new Message(blobInputStream, blobCharset);
+			if (!blobSmartGet) {
+				return intermediateMessage;
+			}
+		} catch (ZipException | EOFException e) {
+			if (!blobSmartGet) {
+				throw e;
+			}
+			// Try again, but without compression. This of course means the flag `blobsCompressed` was set wrong, but this preserves backwards compatibility. Only when blobSmartGet=true
+			InputStream uncompressedStream = JdbcUtil.getBlobInputStream(dbmsSupport, rs, colNum, false);
+			if (uncompressedStream == null) {
+				return Message.nullMessage();
+			}
+			intermediateMessage = new Message(uncompressedStream, blobCharset);
 		}
 		Object result;
 		try (ObjectInputStream ois = new RenamingObjectInputStream(intermediateMessage.asInputStream())) {


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->
New code to read BLOB directly into a Message had a backwards compatibility issue when "isBlobsCompressed" and "smartBlobGet" are both set "true" but the blob was not compressed.
Weird edge case that was triggered only in some tests that are normally not executed.

After merging this, Sergi's Database Workflow PR #11550 should become green.


<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
