### PR TITLE
Add deprecation warning for action open and param filename

### DIFF
--- a/core/src/main/java/org/frankframework/collection/AbstractCollectorPipe.java
+++ b/core/src/main/java/org/frankframework/collection/AbstractCollectorPipe.java
@@ -118,7 +118,7 @@ public abstract class AbstractCollectorPipe<C extends ICollector<P>, P> extends 
 				}
 				case WRITE:
 				case LAST:
-					addPartToCollection(collection, input, session, getParameterValueList(input, session));
+					collection.add(input, session, getParameterValueList(input, session));
 					if (action == Action.LAST) {
 						return closeCollector(collection, session);
 					}
@@ -131,11 +131,6 @@ public abstract class AbstractCollectorPipe<C extends ICollector<P>, P> extends 
 
 			return Message.nullMessage();
 		}
-	}
-
-	// This purely exists because of the STREAM action in the ZipWriterPipe.
-	protected void addPartToCollection(Collection<C, P> collection, Message input, PipeLineSession session, ParameterValueList pvl) throws CollectionException {
-		collection.add(input, session, pvl);
 	}
 
 	protected abstract C createCollector(Message input, PipeLineSession session) throws CollectionException;

--- a/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
+++ b/core/src/main/java/org/frankframework/compression/ZipWriterPipe.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import org.frankframework.collection.AbstractCollectorPipe;
 import org.frankframework.collection.CollectionException;
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarnings;
 import org.frankframework.core.PipeLineSession;
 import org.frankframework.stream.Message;
 
@@ -27,7 +28,7 @@ import org.frankframework.stream.Message;
  * Pipe that creates a ZIP archive (on action close).
  * <p>
  * A chain of zipWriterPipes can be used to create a ZIP archive. You can use the pipe with different actions (see specified below).
- * Action <code>CLOSE</code> will generate the ZIP archive which is returned as the pipe ouput.
+ * Action <code>CLOSE</code> will generate the ZIP archive which is returned as the pipe output.
  * </p>
  *
  * @ff.parameter filename only for <code>action=WRITE</code>: the filename of the zip-entry
@@ -49,6 +50,10 @@ public class ZipWriterPipe extends AbstractCollectorPipe<ZipWriter, MessageZipEn
 	public void configure() throws ConfigurationException {
 		super.configure();
 		ZipWriter.validateParametersForAction(getAction(), getParameterList());
+
+		if (getAction() == Action.OPEN && getParameterList().hasParameter(ZipWriter.PARAMETER_FILENAME)) {
+			ConfigurationWarnings.add(this, "parameter '"+ZipWriter.PARAMETER_FILENAME+"' should be used for ZipEntries and not for the zip location.");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## Changes
<!--
Describe the changes that are made in this pull request.
-->

The open action slowly becomes obsolete and the desired flow, where the ZIP archive is created on CLOSE (or LAST).

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [ ] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [ ] Relevant issue(s) linked
- [ ] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [ ] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [ ] FF! Reference updated (user-facing behaviour/config)
- [ ] Javadoc updated/generated (developer-facing APIs)
- [ ] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [ ] Unit tests added/updated
- [ ] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [ ] Breaking change recorded in markdown file
- [ ] Migration notes included (if needed)
</details>
