### PR TITLE
Add deprecation warnings for conditional IPipe parameters

### DIFF
--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -23,7 +23,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.Lifecycle;
 
 import org.frankframework.configuration.ConfigurationException;
-import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.doc.FrankDocGroup;
 import org.frankframework.doc.FrankDocGroupValue;
 import org.frankframework.doc.Mandatory;
@@ -227,24 +226,16 @@ public interface IPipe extends IConfigurable, IForwardTarget, FrankElement, Name
 
 	void setSkipOnEmptyInput(boolean b);
 
-	@Deprecated(forRemoval = true)
-	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfParam to control application flow")
 	void setIfParam(String string);
 
-	@Deprecated(forRemoval = true)
-	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfValue to control application flow")
 	void setIfValue(String string);
 
 	void setOnlyIfSessionKey(String onlyIfSessionKey);
 
-	@Deprecated(forRemoval = true)
-	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of OnlyIfValue to control application flow")
 	void setOnlyIfValue(String onlyIfValue);
 
 	void setUnlessSessionKey(String unlessSessionKey);
 
-	@Deprecated(forRemoval = true)
-	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of unlessValue to control application flow")
 	void setUnlessValue(String unlessValue);
 
 	boolean isSkipOnEmptyInput();

--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.Lifecycle;
 
 import org.frankframework.configuration.ConfigurationException;
+import org.frankframework.configuration.ConfigurationWarning;
 import org.frankframework.doc.FrankDocGroup;
 import org.frankframework.doc.FrankDocGroupValue;
 import org.frankframework.doc.Mandatory;
@@ -219,23 +220,31 @@ public interface IPipe extends IConfigurable, IForwardTarget, FrankElement, Name
 	void setLogIntermediaryResults(String string);
 	String getLogIntermediaryResults();
 
-	/**
+	/**j
 	 * Called by {@link InputOutputPipeProcessor} to check if the pipe needs to be skipped.
 	 */
 	boolean skipPipe(Message input, PipeLineSession session) throws PipeRunException;
 
 	void setSkipOnEmptyInput(boolean b);
 
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfParam to control application flow")
 	void setIfParam(String string);
 
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfValue to control application flow")
 	void setIfValue(String string);
 
 	void setOnlyIfSessionKey(String onlyIfSessionKey);
 
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of OnlyIfValue to control application flow")
 	void setOnlyIfValue(String onlyIfValue);
 
 	void setUnlessSessionKey(String unlessSessionKey);
 
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of unlessValue to control application flow")
 	void setUnlessValue(String unlessValue);
 
 	boolean isSkipOnEmptyInput();

--- a/core/src/main/java/org/frankframework/core/IPipe.java
+++ b/core/src/main/java/org/frankframework/core/IPipe.java
@@ -219,7 +219,7 @@ public interface IPipe extends IConfigurable, IForwardTarget, FrankElement, Name
 	void setLogIntermediaryResults(String string);
 	String getLogIntermediaryResults();
 
-	/**j
+	/**
 	 * Called by {@link InputOutputPipeProcessor} to check if the pipe needs to be skipped.
 	 */
 	boolean skipPipe(Message input, PipeLineSession session) throws PipeRunException;

--- a/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
+++ b/core/src/main/java/org/frankframework/pipes/AbstractPipe.java
@@ -514,6 +514,8 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 	}
 
 	/** If set, this pipe is only executed when the value of the parameter with the name <code>ifParam</code> equals <code>ifValue</code>. Otherwise, this pipe is skipped. */
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfParam to control application flow")
 	@Override
 	public void setIfParam(String ifParam) {
 		this.ifParam = ifParam;
@@ -521,6 +523,8 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 
 	/** See {@code ifParam} */
 	@Override
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of IfValue to control application flow")
 	public void setIfValue(String ifValue) {
 		this.ifValue = ifValue;
 	}
@@ -533,6 +537,8 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 
 	/** Value of session variable 'onlyIfSessionKey' to check if the action must be executed. The pipe is only executed if the session variable has the specified value. */
 	@Override
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of OnlyIfValue to control application flow")
 	public void setOnlyIfValue(String onlyIfValue) {
 		this.onlyIfValue = onlyIfValue;
 	}
@@ -545,6 +551,8 @@ public abstract class AbstractPipe extends TransactionAttributes implements IPip
 
 	/** Value of session variable 'unlessSessionKey' to check if the action must be executed. The pipe is not executed if the session variable has the specified value. */
 	@Override
+	@Deprecated(forRemoval = true)
+	@ConfigurationWarning("Use the IfPipe and/or SwitchPipe instead of unlessValue to control application flow")
 	public void setUnlessValue(String unlessValue) {
 		this.unlessValue = unlessValue;
 	}


### PR DESCRIPTION
## Changes
Add annotations and deprecation warnings for IfParam, IfValue, OnlyIfValue, and unlessValue

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>
  
### Title
<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->
- [x] Title expresses the business value (who benefits + what outcome)

### Issues
<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->
- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports
<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->
- [x] Backport PRs created (if needed) and linked

### Documentation
<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->
- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests
<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->
- [n/a] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes
<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->
- [n/a] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)
</details>
