### PR TITLE
Add AppConstantsValidator for property validation and deprecation checks

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,12 @@ Contains breaking changes per release.
 > [!NOTE]\
 > Previously, we put this information in RELEASES.md. Take a look there for older breaking changes and migration notes.
 
+10.3
+--------------
+[Commits](https://github.com/frankframework/frankframework/compare/release/10.2...HEAD)
+
+* In ticket [11345](https://github.com/frankframework/frankframework/issues/11345) validation for the instance name was added. If you are using a name that is not valid the application will not start up.
+
 10.2
 --------------
 [Commits](https://github.com/frankframework/frankframework/compare/release/10.1...HEAD)

--- a/core/src/main/java/org/frankframework/configuration/AppConstantsValidator.java
+++ b/core/src/main/java/org/frankframework/configuration/AppConstantsValidator.java
@@ -1,0 +1,94 @@
+/*
+  Copyright 2026 WeAreFrank!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.frankframework.configuration;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.log4j.Log4j2;
+
+import org.frankframework.credentialprovider.CredentialFactory;
+import org.frankframework.credentialprovider.util.CredentialConstants;
+import org.frankframework.util.AppConstants;
+
+/**
+ * Contains validation logic for AppConstants properties, including checks for deprecated properties and regex validation for specific properties.
+ */
+@Log4j2
+@UtilityClass
+public class AppConstantsValidator {
+
+	private static final String DEPRECATED_PROPERTY_MESSAGE = "DEPRECATED: [%s] is set to [%s]";
+
+	private static final Map<String, Function<String, Boolean>> deprecatedProperties = Map.of(
+			"jdbc.convertFieldnamesToUppercase", "false"::equalsIgnoreCase,
+			AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, StringUtils::isNotEmpty,
+			"configurations.autoDatabaseClassLoader", StringUtils::isNotEmpty
+	);
+
+	private static final Map<String, String> propertyRegexMatchers = Map.of(
+			// Validates that the instance name is between 1 and 253 characters, starts and ends with an alphanumeric character, and may contain dots and hyphens in between
+			"instance.name", "(?=.{1,253}\\.?$)[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\\.?"
+	);
+
+	public static void validate() {
+		AppConstants appConstants = AppConstants.getInstance();
+
+		validateAppConstants(appConstants);
+		checkForDeprecations(appConstants);
+	}
+
+	/**
+	 * Validates the properties in AppConstants against predefined regex patterns.
+	 */
+	private static void validateAppConstants(AppConstants appConstants) {
+		propertyRegexMatchers.forEach((key, regex) -> {
+			String propertyValue = appConstants.getProperty(key);
+
+			if (propertyValue != null && !propertyValue.matches(regex)) {
+				String error = String.format("Property [%s] with value [%s] does not match the expected pattern [%s]", key, propertyValue, regex);
+				log.error(error);
+
+				throw new IllegalStateException(error);
+			}
+		});
+	}
+
+	/**
+	 * Checks for deprecated properties and/or values in AppConstants and logs warnings if present
+	 */
+	private static void checkForDeprecations(AppConstants appConstants) {
+		deprecatedProperties.forEach((key, value) -> {
+			String deprecatedProperty = appConstants.getProperty(key);
+
+			if (Boolean.TRUE.equals(value.apply(deprecatedProperty))) {
+				ApplicationWarnings.add(log, String.format(DEPRECATED_PROPERTY_MESSAGE, key, deprecatedProperty));
+			}
+		});
+
+		String credentialFactoryClassNames = CredentialConstants.getInstance().getProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY);
+		// Legacy support for old package names; to be removed in Frank!Framework 8.1 or later
+		if (StringUtils.isNotEmpty(credentialFactoryClassNames) && credentialFactoryClassNames.contains(CredentialFactory.LEGACY_PACKAGE_NAME)) {
+			ApplicationWarnings.add(log, "DEPRECATED: legacy classnames from package [" +
+					CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders, please update to use new classnames starting with [" +
+					CredentialFactory.ORG_FRANKFRAMEWORK_PACKAGE_NAME + "]: [" + credentialFactoryClassNames + "]");
+		}
+	}
+
+}

--- a/core/src/main/java/org/frankframework/configuration/IbisContext.java
+++ b/core/src/main/java/org/frankframework/configuration/IbisContext.java
@@ -23,7 +23,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.BeanCreationException;
@@ -36,8 +35,6 @@ import lombok.Getter;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
 import org.frankframework.configuration.util.ConfigurationUtils;
 import org.frankframework.core.IScopeProvider;
-import org.frankframework.credentialprovider.CredentialFactory;
-import org.frankframework.credentialprovider.util.CredentialConstants;
 import org.frankframework.http.RestServiceDispatcher;
 import org.frankframework.jdbc.JdbcPropertySourceFactory;
 import org.frankframework.lifecycle.IbisApplicationContext;
@@ -69,29 +66,7 @@ public class IbisContext extends IbisApplicationContext {
 	private static final Logger APPLICATION_LOG = LogUtil.getLogger("APPLICATION");
 
 	static {
-		checkForDeprecations();
-	}
-
-	public static void checkForDeprecations() {
-		AppConstants appConstants = AppConstants.getInstance();
-		if (!appConstants.getBoolean("jdbc.convertFieldnamesToUppercase", true))
-			ApplicationWarnings.add(LOG, "DEPRECATED: jdbc.convertFieldnamesToUppercase is set to false, please set to true. XML field definitions of SQL senders will be uppercased!");
-
-		String loadFileSuffix = appConstants.getProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
-		if (StringUtils.isNotEmpty(loadFileSuffix))
-			ApplicationWarnings.add(LOG, "DEPRECATED: SUFFIX [_"+loadFileSuffix+"] files are deprecated, property files are now inherited from their parent!");
-
-		String autoDatabaseClassLoader = appConstants.getProperty("configurations.autoDatabaseClassLoader");
-		if (StringUtils.isNotEmpty(autoDatabaseClassLoader))
-			ApplicationWarnings.add(LOG, "DEPRECATED property [configurations.autoDatabaseClassLoader], please use [configurations.database.autoLoad] instead");
-
-		String credentialFactoryClassNames = CredentialConstants.getInstance().getProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY);
-		// Legacy support for old package names; to be removed in Frank!Framework 8.1 or later
-		if (StringUtils.isNotEmpty(credentialFactoryClassNames) && credentialFactoryClassNames.contains(CredentialFactory.LEGACY_PACKAGE_NAME)) {
-			ApplicationWarnings.add(LOG, "DEPRECATED legacy classnames from package [" +
-					CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders, please update to use new classnames starting with [" +
-					CredentialFactory.ORG_FRANKFRAMEWORK_PACKAGE_NAME + "]: [" + credentialFactoryClassNames + "]");
-		}
+		AppConstantsValidator.validate();
 	}
 
 	private @Getter IbisManager ibisManager;

--- a/core/src/main/java/org/frankframework/stream/Message.java
+++ b/core/src/main/java/org/frankframework/stream/Message.java
@@ -386,7 +386,7 @@ public class Message implements Serializable {
 	/**
 	 * Check if a message is empty. If message size cannot be determined, check if any data can be read from the message.
 	 *
-	 * @return {@code true} if the message is empty or no data can be read from it, {@code false} if the size if larger than 0 or data can be read from it.
+	 * @return {@code true} if the message is empty or no data can be read from it, {@code false} if the size is larger than 0 or data can be read from it.
 	 */
 	public boolean isEmpty() {
 		return request.isEmpty();

--- a/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
+++ b/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
@@ -37,7 +37,6 @@ public class AppConstantsValidatorTest {
 
 	@BeforeEach
 	public void setUp() {
-		ApplicationWarnings.removeInstance(); // Ensure a clean list of warnings for every test
 		appConstants = AppConstants.getInstance();
 	}
 
@@ -50,6 +49,7 @@ public class AppConstantsValidatorTest {
 
 		CredentialConstants.getInstance().remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
 		ApplicationWarnings.removeInstance();
+		AppConstants.removeInstance();
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
+++ b/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
@@ -1,0 +1,188 @@
+/*
+  Copyright 2026 WeAreFrank!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+package org.frankframework.configuration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.frankframework.credentialprovider.CredentialFactory;
+import org.frankframework.credentialprovider.util.CredentialConstants;
+import org.frankframework.testutil.TestAppender;
+import org.frankframework.util.AppConstants;
+
+public class AppConstantsValidatorTest {
+
+	private AppConstants appConstants;
+
+	@BeforeEach
+	public void setUp() {
+		ApplicationWarnings.removeInstance(); // Ensure a clean list of warnings for every test
+		appConstants = AppConstants.getInstance();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		appConstants.remove("jdbc.convertFieldnamesToUppercase");
+		appConstants.remove(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY);
+		appConstants.remove("configurations.autoDatabaseClassLoader");
+		appConstants.remove("instance.name");
+
+		CredentialConstants.getInstance().remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
+		ApplicationWarnings.removeInstance();
+	}
+
+	@Test
+	public void testDeprecatedJdbcConvertFieldnamesToUppercaseFalseTriggersWarning() {
+		// Arrange
+		appConstants.setProperty("jdbc.convertFieldnamesToUppercase", "false");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		List<String> warnings = ApplicationWarnings.getWarningsList();
+		assertEquals(1, warnings.size());
+		assertThat(warnings.getFirst(), containsString("jdbc.convertFieldnamesToUppercase"));
+		assertThat(warnings.getFirst(), containsString("false"));
+	}
+
+	@Test
+	public void testDeprecatedJdbcConvertFieldnamesToUppercaseTrueDoesNotTriggerWarning() {
+		// Arrange
+		appConstants.setProperty("jdbc.convertFieldnamesToUppercase", "true");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		assertEquals(0, ApplicationWarnings.getWarningsList().size());
+	}
+
+	@Test
+	public void testDeprecatedAdditionalPropertiesFileSuffixTriggersWarningWhenSet() {
+		// Arrange
+		appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".properties");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		List<String> warnings = ApplicationWarnings.getWarningsList();
+		assertEquals(1, warnings.size());
+		assertThat(warnings.getFirst(), containsString(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY));
+	}
+
+	@Test
+	public void testDeprecatedConfigurationsAutoDatabaseClassLoaderTriggersWarningWhenSet() {
+		// Arrange
+		appConstants.setProperty("configurations.autoDatabaseClassLoader", "someValue");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		List<String> warnings = ApplicationWarnings.getWarningsList();
+		assertEquals(1, warnings.size());
+		assertThat(warnings.getFirst(), containsString("configurations.autoDatabaseClassLoader"));
+	}
+
+	@Test
+	public void testInstanceNameNotMatchingRegexLogsWarning() {
+		// Arrange
+		appConstants.setProperty("instance.name", "invalid instance name");
+
+		// Act
+		try (TestAppender testAppender = TestAppender.newBuilder().build()) {
+			AppConstantsValidator.validate();
+
+			// Assert
+			assertThat(testAppender.getLogLines(), hasItem(containsString("does not match the expected pattern")));
+		}
+	}
+
+	@Test
+	public void testLegacyCredentialFactoryPackageNameTriggersWarning() {
+		// Arrange
+		CredentialConstants.getInstance().setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, "nl.nn.credentialprovider.SomeFactory");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		List<String> warnings = ApplicationWarnings.getWarningsList();
+		assertEquals(1, warnings.size());
+		assertThat(warnings.getFirst(), containsString("legacy classnames"));
+		assertThat(warnings.getFirst(), containsString("nl.nn.credentialprovider."));
+	}
+
+	@Test
+	public void testNonLegacyCredentialFactoryPackageNameDoesNotTriggerWarning() {
+		// Arrange
+		CredentialConstants.getInstance().setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, "org.frankframework.credentialprovider.SomeFactory");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		assertEquals(0, ApplicationWarnings.getWarningsList().size());
+	}
+
+	@Test
+	public void testDeprecationChecksAllDeps() {
+		// Arrange
+		appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
+		appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
+		appConstants.setProperty("configurations.autoDatabaseClassLoader", "not-empty");
+
+		CredentialConstants credentialConstants = CredentialConstants.getInstance();
+		Object credentialFactoryOriginalValue = credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, "nl.nn.credentialprovider.PropertyFileCredentialFactory");
+
+		// Act
+		AppConstantsValidator.validate();
+
+		// Assert
+		try {
+			List<String> warnings = ApplicationWarnings.getWarningsList();
+
+			assertEquals(4, warnings.size());
+			assertThat(warnings, containsInAnyOrder(
+					containsString("DEPRECATED: legacy classnames from package [" + CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders"),
+					containsString("DEPRECATED: [configurations.autoDatabaseClassLoader] is set to [not-empty]"),
+					containsString("DEPRECATED: [ADDITIONAL.PROPERTIES.FILE.SUFFIX] is set to [.propmap]"),
+					containsString("DEPRECATED: [jdbc.convertFieldnamesToUppercase] is set to [false]")
+					));
+		} finally {
+			// Clean up properties set for this test to make sure we do not mess up any other tests
+			AppConstants.removeInstance();
+			ApplicationWarnings.removeInstance();
+
+			if (credentialFactoryOriginalValue == null) {
+				credentialConstants.remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
+			} else {
+				credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, credentialFactoryOriginalValue.toString());
+			}
+		}
+	}
+}

--- a/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
+++ b/core/src/test/java/org/frankframework/configuration/AppConstantsValidatorTest.java
@@ -18,8 +18,8 @@ package org.frankframework.configuration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 
 import org.frankframework.credentialprovider.CredentialFactory;
 import org.frankframework.credentialprovider.util.CredentialConstants;
-import org.frankframework.testutil.TestAppender;
 import org.frankframework.util.AppConstants;
 
 public class AppConstantsValidatorTest {
@@ -109,17 +108,13 @@ public class AppConstantsValidatorTest {
 	}
 
 	@Test
-	public void testInstanceNameNotMatchingRegexLogsWarning() {
+	public void testInstanceNameNotMatchingRegex() {
 		// Arrange
 		appConstants.setProperty("instance.name", "invalid instance name");
 
 		// Act
-		try (TestAppender testAppender = TestAppender.newBuilder().build()) {
-			AppConstantsValidator.validate();
-
-			// Assert
-			assertThat(testAppender.getLogLines(), hasItem(containsString("does not match the expected pattern")));
-		}
+		// Assert
+		assertThrows(IllegalStateException.class, AppConstantsValidator::validate);
 	}
 
 	@Test

--- a/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
+++ b/core/src/test/java/org/frankframework/configuration/IbisContextTest.java
@@ -1,8 +1,6 @@
 package org.frankframework.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -17,11 +15,8 @@ import org.springframework.context.support.AbstractApplicationContext;
 
 import org.frankframework.configuration.classloaders.DummyClassLoader;
 import org.frankframework.configuration.classloaders.IConfigurationClassLoader;
-import org.frankframework.credentialprovider.CredentialFactory;
-import org.frankframework.credentialprovider.util.CredentialConstants;
 import org.frankframework.lifecycle.events.MessageEventListener;
 import org.frankframework.testutil.NullClassLoader;
-import org.frankframework.util.AppConstants;
 import org.frankframework.util.MessageKeeperMessage;
 
 public class IbisContextTest {
@@ -134,59 +129,6 @@ public class IbisContextTest {
 			assertThat(ex.getMessage(), Matchers.startsWith("error instantiating configuration"));
 			Throwable[] suppressed = ex.getCause().getSuppressed();
 			assertEquals(0, suppressed.length, "no further information");
-		}
-	}
-
-	@Test
-	public void testDeprecationChecksNoDeps() {
-		// Arrange
-		ApplicationWarnings.removeInstance();
-
-		// Act
-		IbisContext.checkForDeprecations();
-
-		// Assert
-		List<String> warnings = ApplicationWarnings.getWarningsList();
-
-		assertEquals(0, warnings.size());
-	}
-
-	@Test
-	public void testDeprecationChecksAllDeps() {
-		// Arrange
-		ApplicationWarnings.removeInstance();
-		AppConstants.removeInstance();
-		AppConstants appConstants = AppConstants.getInstance();
-		appConstants.setProperty("jdbc.convertFieldnamesToUppercase", false);
-		appConstants.setProperty(AppConstants.ADDITIONAL_PROPERTIES_FILE_SUFFIX_KEY, ".propmap");
-		appConstants.setProperty("configurations.autoDatabaseClassLoader", "not-empty");
-
-		CredentialConstants credentialConstants = CredentialConstants.getInstance();
-		Object credentialFactoryOriginalValue = credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, "nl.nn.credentialprovider.PropertyFileCredentialFactory");
-
-		// Act
-		IbisContext.checkForDeprecations();
-
-		// Assert
-		try {
-			List<String> warnings = ApplicationWarnings.getWarningsList();
-
-			assertEquals(4, warnings.size());
-			assertThat(warnings, containsInAnyOrder(
-					containsString("DEPRECATED legacy classnames from package [" + CredentialFactory.LEGACY_PACKAGE_NAME + "] used for creating CredentialProviders"),
-					containsString("DEPRECATED property [configurations.autoDatabaseClassLoader]"),
-					containsString("DEPRECATED: SUFFIX [_"),
-					containsString("DEPRECATED: jdbc.convertFieldnamesToUppercase is set to false, please set to true")
-					));
-		} finally {
-			// Clean up properties set for this test to make sure we do not mess up any other tests
-			AppConstants.removeInstance();
-			ApplicationWarnings.removeInstance();
-			if (credentialFactoryOriginalValue == null) {
-				credentialConstants.remove(CredentialFactory.CREDENTIAL_FACTORY_KEY);
-			} else {
-				credentialConstants.setProperty(CredentialFactory.CREDENTIAL_FACTORY_KEY, credentialFactoryOriginalValue.toString());
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Changes
Added a generic way to validate app constants using regular expressions and add warnings to notify users of deprecated properties and/or values.

```
Validates that the instance name is between 1 and 253 characters, starts and ends with an 
alphanumeric character, and may contain dots and hyphens in between
```

<!--
Checklist for completeness and clarity of the PR
-->
<details>
<summary>
<strong>Pull Request Checklist</strong>
</summary>

### Title

<!--
Goal: Make the value obvious to readers at a glance. Prefer the benefit over the implementation.
Example good: "Reduce adapter startup time ~30% by caching configuration"
Example bad: "Refactor AdapterManager"
-->

- [x] Title expresses the business value (who benefits + what outcome)

### Issues

<!--
Link all relevant issues so they auto-close on merge and remain traceable.
Select issues in sidebar or use: Closes/Fixes/Resolves #123
-->

- [x] Relevant issue(s) linked
- [x] Confirmed with the issue creator(s) that the solution is satisfactory

### Backports

<!--
If this needs to land in supported release branches, open separate PRs and link them here.
Example: release/9.x, release/10.x
-->

- [n/a] Backport PRs created (if needed) and linked

### Documentation

<!--
Keep user and developer docs in sync with the change.
Update where applicable: FF! Reference, Javadoc and if applicable the docs on [docs.frankframework.org](https://docs.frankframework.org/)
-->

- [n/a] FF! Reference updated (user-facing behaviour/config)
- [n/a] Javadoc updated/generated (developer-facing APIs)
- [n/a] FF! Docs updated (if applicable)

### Tests

<!--
Changes should be covered so behaviour is verified and regressions are prevented.
Add or update both unit and end-to-end/integration tests as needed.
-->

- [x] Unit tests added/updated
- [n/a] E2E/Integration tests added/updated (if applicable)

### Breaking changes

<!--
If behaviour or public APIs change in a non-backward-compatible way:
- Document in the repository’s breaking-changes BREAKING.md 
- Provide brief migration notes
-->

- [x] Breaking change recorded in markdown file
- [n/a] Migration notes included (if needed)

</details>
